### PR TITLE
fix(search): cap KNN k at sqlite-vec's 4096 hard limit

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -227,6 +227,12 @@ pub fn search_by_vector(
         )
         .map_err(SearchError::CountTotalDrawers)?;
 
+    // sqlite-vec vec0 MATCH ... k = ? has a hard upper bound of 4096.
+    // Clamp to stay under the limit; BM25 side of the hybrid rerank still
+    // covers candidates that fall outside the KNN top-4096 by vector distance.
+    const SQLITE_VEC_KNN_MAX: i64 = 4096;
+    let knn_k: i64 = total_count.min(SQLITE_VEC_KNN_MAX);
+
     let query_json =
         serde_json::to_string(query_vector).map_err(SearchError::SerializeQueryVector)?;
     let top_k = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
@@ -257,7 +263,7 @@ pub fn search_by_vector(
         .query_map(
             (
                 query_json.as_str(),
-                total_count,
+                knn_k,
                 applied_wing,
                 applied_room,
                 top_k,


### PR DESCRIPTION
## Summary

`mempal search` currently errors out with `k value in knn query too large, provided N and the limit is 4096` on any palace with more than ~4096 active drawers, which a realistically-sized codebase ingest hits very quickly. This PR clamps the KNN `k` to sqlite-vec's hard limit so the command works end-to-end on large palaces.

## Root cause

`src/search/mod.rs::search_by_vector` (around L221–L260) runs

```sql
WITH matches AS (
    SELECT id, distance
    FROM drawer_vectors
    WHERE embedding MATCH vec_f32(?1)
      AND k = ?2          -- bound to `total_count`
)
...
```

`total_count = SELECT COUNT(*) FROM drawers WHERE deleted_at IS NULL`, so once the palace grows past 4096 the `vec0` virtual table rejects the query — its candidate buffer is compile-time-capped at 4096.

Why `total_count` was chosen: `vec0 MATCH` can't push down `wing=?` / `room=?` filters, so the query needs "all vector matches" before the JOIN-based post-filter can narrow them. That's fine below 4096 and broken above.

## Fix

Clamp `k` at the extension ceiling:

```rust
const SQLITE_VEC_KNN_MAX: i64 = 4096;
let knn_k: i64 = total_count.min(SQLITE_VEC_KNN_MAX);
```

…and bind `knn_k` instead of `total_count` in the parameter tuple.

## Trade-offs

- **Gives up:** on palaces with >4096 drawers, candidates that rank beyond the top-4096 by raw cosine distance but would pass the `wing`/`room` post-filter are no longer seen by the vector channel.
- **Mitigated by:** the BM25/FTS channel in `search_with_vector` → `rrf_merge` still pulls those rows in when the query has literal term overlap, so recall loss is partial, not total.
- **Preserves:** full recall when `drawer_count ≤ 4096`, hybrid RRF merge semantics, all existing API signatures.

## Verification

Reproduced on `main @ 71426011` (v0.2.0):

```
mempal ingest <project> --wing demo      # drawer_count: 5221
mempal search --wing demo --top-k 5 "x"
# error: failed to collect search rows
#   caused by: k value in knn query too large, provided 5221 and the limit is 4096
```

After this patch, the same command returns ranked results in ~16 ms on the same palace.

## Follow-ups (out of scope here)

A more thorough fix would be one of:

1. **Filter push-down:** register `wing`/`room` as `vec0` partition keys so `MATCH` scans a smaller candidate set.
2. **Iterative KNN:** loop `k=4096` pages, filter, accumulate until enough post-filter matches are found or the distance exceeds a threshold.

Happy to prototype either if it's the direction you'd prefer — wanted to land the no-recall-regression-below-4096 fix first.


---
Closes #6