### PR TITLE
fix(ingest): support current Codex rollout JSONL

### DIFF
--- a/crates/mempal-runtime/src/ingest/detect.rs
+++ b/crates/mempal-runtime/src/ingest/detect.rs
@@ -31,7 +31,7 @@ pub fn detect_format(content: &str) -> Format {
 
 fn is_codex_jsonl(content: &str) -> bool {
     let mut has_session_meta = false;
-    let mut event_msg_count = 0;
+    let mut has_activity = false;
 
     for line in content.lines().map(str::trim).filter(|l| !l.is_empty()) {
         let Ok(value) = serde_json::from_str::<Value>(line) else {
@@ -39,13 +39,15 @@ fn is_codex_jsonl(content: &str) -> bool {
         };
         match value.get("type").and_then(Value::as_str) {
             Some("session_meta") => has_session_meta = true,
-            Some("event_msg") => event_msg_count += 1,
-            Some("response_item") => {} // skip but don't reject
-            _ => return false,
+            Some("event_msg" | "response_item" | "turn_context" | "compacted") => {
+                has_activity = true
+            }
+            Some(_) => {} // tolerate newer rollout record types
+            None => return false,
         }
     }
 
-    has_session_meta && event_msg_count >= 2
+    has_session_meta && has_activity
 }
 
 fn is_slack_json(content: &str) -> bool {
@@ -112,7 +114,13 @@ pub(crate) fn extract_content_text(value: &Value) -> Option<String> {
         Value::Array(items) => Some(
             items
                 .iter()
-                .filter_map(Value::as_str)
+                .filter_map(|item| {
+                    item.as_str().map(ToOwned::to_owned).or_else(|| {
+                        item.get("text")
+                            .and_then(Value::as_str)
+                            .map(ToOwned::to_owned)
+                    })
+                })
                 .collect::<Vec<_>>()
                 .join("\n"),
         ),
@@ -128,5 +136,21 @@ pub(crate) fn extract_content_text(value: &Value) -> Option<String> {
             })
             .filter(|text| !text.is_empty()),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Format, detect_format};
+
+    #[test]
+    fn detects_current_codex_rollout_with_turn_context_and_compacted() {
+        let content = r#"{"timestamp":"2026-04-19T10:37:36.000Z","type":"session_meta","payload":{"cwd":"/tmp/project"}}
+{"timestamp":"2026-04-19T10:37:36.100Z","type":"turn_context","payload":{"cwd":"/tmp/project"}}
+{"timestamp":"2026-04-19T10:37:36.200Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"instructions"}]}}
+{"timestamp":"2026-04-19T10:37:36.300Z","type":"compacted","payload":{"summary":"trimmed"}}
+{"timestamp":"2026-04-19T10:37:36.400Z","type":"event_msg","payload":{"type":"token_count"}}"#;
+
+        assert_eq!(detect_format(content), Format::CodexJsonl);
     }
 }

--- a/crates/mempal-runtime/src/ingest/normalize.rs
+++ b/crates/mempal-runtime/src/ingest/normalize.rs
@@ -174,37 +174,70 @@ fn collect_messages_dfs(
 }
 
 fn normalize_codex_jsonl(content: &str, strip_noise: bool) -> Result<NormalizeOutput> {
-    let mut pairs: Vec<(String, String)> = Vec::new();
-    let mut noise_bytes_stripped = 0_u64;
+    let mut response_items: Vec<(String, String)> = Vec::new();
+    let mut legacy_events: Vec<(String, String)> = Vec::new();
 
     for line in content.lines().map(str::trim).filter(|l| !l.is_empty()) {
         let value: Value = serde_json::from_str(line)?;
-        if value.get("type").and_then(Value::as_str) != Some("event_msg") {
-            continue;
-        }
+        let record_type = value.get("type").and_then(Value::as_str).unwrap_or("");
         let Some(payload) = value.get("payload") else {
             continue;
         };
-        let msg_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
-        let message = payload
-            .get("message")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .trim();
-        let message = if strip_noise {
+        match record_type {
+            "response_item" => {
+                if payload.get("type").and_then(Value::as_str) != Some("message") {
+                    continue;
+                }
+
+                let role = payload.get("role").and_then(Value::as_str).unwrap_or("");
+                if role != "user" && role != "assistant" {
+                    continue;
+                }
+
+                let Some(message) = payload.get("content").and_then(extract_content_text) else {
+                    continue;
+                };
+                let message = message.trim();
+                if message.is_empty() {
+                    continue;
+                }
+
+                response_items.push((role.to_string(), message.to_string()));
+            }
+            "event_msg" => {
+                let msg_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
+                let message = payload
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .trim();
+                if message.is_empty() {
+                    continue;
+                }
+
+                match msg_type {
+                    "user_message" => legacy_events.push(("user".to_string(), message.to_string())),
+                    "agent_message" => {
+                        legacy_events.push(("assistant".to_string(), message.to_string()))
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut pairs = if response_items.is_empty() {
+        legacy_events
+    } else {
+        response_items
+    };
+    let mut noise_bytes_stripped = 0_u64;
+    if strip_noise {
+        for (_, message) in &mut pairs {
             let stripped = strip_codex_rollout_noise(message);
             noise_bytes_stripped += message.len().saturating_sub(stripped.len()) as u64;
-            stripped
-        } else {
-            message.to_string()
-        };
-        if message.is_empty() {
-            continue;
-        }
-        match msg_type {
-            "user_message" => pairs.push(("user".to_string(), message)),
-            "agent_message" => pairs.push(("assistant".to_string(), message)),
-            _ => {}
+            *message = stripped;
         }
     }
 
@@ -269,4 +302,33 @@ fn render_transcript(items: impl IntoIterator<Item = (String, String)>) -> Strin
     }
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_codex_jsonl;
+
+    #[test]
+    fn codex_normalize_prefers_response_item_messages() {
+        let content = r#"{"timestamp":"2026-04-19T10:37:36.000Z","type":"session_meta","payload":{"cwd":"/tmp/project"}}
+{"timestamp":"2026-04-19T10:37:36.050Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"developer instructions"}]}}
+{"timestamp":"2026-04-19T10:37:36.100Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"first line"},{"type":"input_text","text":"second line"}]}}
+{"timestamp":"2026-04-19T10:37:36.150Z","type":"event_msg","payload":{"type":"user_message","message":"duplicate legacy user"}}
+{"timestamp":"2026-04-19T10:37:36.200Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]}}
+{"timestamp":"2026-04-19T10:37:36.250Z","type":"event_msg","payload":{"type":"agent_message","message":"duplicate legacy assistant"}}
+{"timestamp":"2026-04-19T10:37:36.300Z","type":"compacted","payload":{"summary":"trimmed"}}"#;
+
+        let normalized = normalize_codex_jsonl(content, true).expect("normalize codex");
+        assert_eq!(normalized.content, "> first line\nsecond line\nanswer");
+    }
+
+    #[test]
+    fn codex_normalize_falls_back_to_legacy_event_messages() {
+        let content = r#"{"timestamp":"2026-04-13T12:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/project"}}
+{"timestamp":"2026-04-13T12:00:10Z","type":"event_msg","payload":{"type":"user_message","message":"legacy hello"}}
+{"timestamp":"2026-04-13T12:00:20Z","type":"event_msg","payload":{"type":"agent_message","message":"legacy hi"}}"#;
+
+        let normalized = normalize_codex_jsonl(content, true).expect("normalize codex");
+        assert_eq!(normalized.content, "> legacy hello\nlegacy hi");
+    }
 }


### PR DESCRIPTION
## Summary
- detect current Codex rollout JSONL files even when they include newer top-level records like `turn_context` and `compacted`
- normalize Codex transcripts from `response_item` message payloads and keep legacy `event_msg` parsing as a fallback
- extend shared content extraction so `content[].text` blocks are ingested correctly, with regression tests for both detection and normalization

## Why
Recent real `~/.codex/sessions/**/rollout-*.jsonl` files no longer match the older ingest assumptions:
- format detection rejected valid rollout files because of newer top-level record types
- normalization only consumed legacy `event_msg` messages
- `content` arrays store text in block objects like `{ "type": "input_text", "text": ... }`, which the shared extractor previously skipped

Together these caused current Codex rollout files to fall back to plain-text ingest or lose the actual user/assistant transcript.

## Verification
- `cargo test ingest:: --lib`
- `cargo test codex --tests`