### PR TITLE
P14: add mind-model context assembler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,9 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 
 ### 当前 Spec（草稿，未实现）
 
-暂无。
+| Spec | 范围 |
+|------|------|
+| `specs/p14-context-assembler.spec.md` | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
 
 ### 实现计划
 
@@ -82,6 +84,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-21-p12-implementation.md` — P12 mind-model bootstrap（已完成）
 - `docs/plans/2026-04-23-p13a-implementation.md` — P13A wake-up statement（已完成）
 - `docs/plans/2026-04-23-p13b-implementation.md` — P13B bootstrap ingest identity parity（已完成）
+- `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（草稿）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P13B）
+### 已完成的 Spec（P0-P14）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -60,12 +60,11 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p12-mind-model-bootstrap.spec.md` | 完成 | Stage-1 mind-model bootstrap：typed drawers + `dao/shu/qi` 最小治理字段 + `global/repo/worktree` anchor metadata |
 | `specs/p13-wake-up-statement.spec.md` | 完成 | wake-up 最小闭环：knowledge drawer 优先按 `statement` 唤醒，evidence 继续按 `content` 唤醒 |
 | `specs/p13-ingest-identity.spec.md` | 完成 | typed/bootstrap ingest `drawer_id` identity parity：MCP / REST / 文件入口统一使用 bootstrap identity components |
+| `specs/p14-context-assembler.spec.md` | 完成 | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
 
 ### 当前 Spec（草稿，未实现）
 
-| Spec | 范围 |
-|------|------|
-| `specs/p14-context-assembler.spec.md` | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
+暂无。
 
 ### 实现计划
 
@@ -84,7 +83,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-21-p12-implementation.md` — P12 mind-model bootstrap（已完成）
 - `docs/plans/2026-04-23-p13a-implementation.md` — P13A wake-up statement（已完成）
 - `docs/plans/2026-04-23-p13b-implementation.md` — P13B bootstrap ingest identity parity（已完成）
-- `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（草稿）
+- `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P13B）
+### 已完成的 Spec（P0-P14）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -58,12 +58,11 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p12-mind-model-bootstrap.spec.md` | 完成 | Stage-1 mind-model bootstrap：typed drawers + `dao/shu/qi` 最小治理字段 + `global/repo/worktree` anchor metadata |
 | `specs/p13-wake-up-statement.spec.md` | 完成 | wake-up 最小闭环：knowledge drawer 优先按 `statement` 唤醒，evidence 继续按 `content` 唤醒 |
 | `specs/p13-ingest-identity.spec.md` | 完成 | typed/bootstrap ingest `drawer_id` identity parity：MCP / REST / 文件入口统一使用 bootstrap identity components |
+| `specs/p14-context-assembler.spec.md` | 完成 | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
 
 ### 当前 Spec（草稿，未实现）
 
-| Spec | 范围 |
-|------|------|
-| `specs/p14-context-assembler.spec.md` | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
+暂无。
 
 ### 实现计划
 
@@ -82,7 +81,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-21-p12-implementation.md` — P12 mind-model bootstrap（已完成）
 - `docs/plans/2026-04-23-p13a-implementation.md` — P13A wake-up statement（已完成）
 - `docs/plans/2026-04-23-p13b-implementation.md` — P13B bootstrap ingest identity parity（已完成）
-- `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（草稿）
+- `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,9 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 
 ### 当前 Spec（草稿，未实现）
 
-暂无。
+| Spec | 范围 |
+|------|------|
+| `specs/p14-context-assembler.spec.md` | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
 
 ### 实现计划
 
@@ -80,6 +82,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-21-p12-implementation.md` — P12 mind-model bootstrap（已完成）
 - `docs/plans/2026-04-23-p13a-implementation.md` — P13A wake-up statement（已完成）
 - `docs/plans/2026-04-23-p13b-implementation.md` — P13B bootstrap ingest identity parity（已完成）
+- `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（草稿）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -808,6 +808,15 @@ Limits:
 - knowledge drawers will eventually become overloaded with lifecycle and governance metadata
 - this is a bootstrap architecture, not the final form
 
+Implemented Phase-1 runtime surface:
+
+- `mempal context <query>` assembles a runtime context pack from typed drawers
+- knowledge sections are ordered as `dao_tian -> dao_ren -> shu -> qi`
+- evidence remains opt-in via `--include-evidence`
+- same-tier items prefer `worktree`, then current `repo`, then `repo://legacy`, then `global`
+- `global` anchor candidates use `domain=global`, preserving the invariant that global anchors do not hold project-local domain memory
+- `trigger_hints` are exposed as metadata only; they do not directly execute skills
+
 ### Phase 2: Knowledge Card Extraction
 
 Once the model proves useful, separate knowledge memory from evidence memory structurally.

--- a/docs/plans/2026-04-24-p14-context-assembler-implementation.md
+++ b/docs/plans/2026-04-24-p14-context-assembler-implementation.md
@@ -172,10 +172,11 @@ Use `anchor::derive_anchor_from_cwd(Some(&request.cwd))`. The resulting active a
 ```text
 worktree://...
 repo://...
+repo://legacy
 global://...
 ```
 
-Only include repo if `parent_anchor_id` exists. Global should be represented as `anchor_kind=Global`; use `global://default` or the existing canonical global id if already present.
+Use the derived repo anchor when `parent_anchor_id` exists, and keep `repo://legacy` as a compatibility fallback for drawers backfilled by P12 migrations. Global should be represented as `anchor_kind=Global`; use `global://default` or the existing canonical global id if already present. Global anchor candidates must query `domain=global`, not the request domain.
 
 - [ ] **Step 3: Apply domain/field/tier/status filters**
 

--- a/docs/plans/2026-04-24-p14-context-assembler-implementation.md
+++ b/docs/plans/2026-04-24-p14-context-assembler-implementation.md
@@ -1,0 +1,371 @@
+# P14 Context Assembler Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `mempal context` as the first runtime assembler for the mind-model stack.
+
+**Architecture:** Add a focused `src/context.rs` module that builds a `ContextPack` from existing typed drawers. The CLI should remain thin: parse flags, call the assembler, render plain or JSON. No schema bump, no MCP/REST surface, no skill execution.
+
+**Tech Stack:** Rust 2024, clap, serde, rusqlite-backed `Database`, existing `search` and `anchor` modules, integration tests under `tests/context_assembler.rs`.
+
+---
+
+## Source Spec
+
+- `specs/p14-context-assembler.spec.md`
+
+## File Map
+
+- Create `src/context.rs`: owns `ContextRequest`, `ContextPack`, `ContextSection`, `ContextItem`, assembly order, status eligibility, anchor precedence, and text selection.
+- Modify `src/lib.rs`: export `context`.
+- Modify `src/main.rs`: add `Commands::Context`, parse CLI flags, initialize embedder, call assembler, render `plain` / `json`.
+- Modify `src/core/db.rs`: add read-only helper if search filters cannot express anchor-id precedence cleanly.
+- Modify `src/search/**`: only if needed to avoid duplicating filter behavior; do not change ranking.
+- Create `tests/context_assembler.rs`: integration tests for all P14 scenarios.
+- Modify `docs/MIND-MODEL-DESIGN.md`: mark P14 as Phase-1 runtime assembler work if implementation decisions diverge from the design doc.
+- Modify `AGENTS.md` / `CLAUDE.md`: move P14 from current draft to completed only after all checks pass.
+
+## Task 1: Test Harness And First Failing Scenario
+
+**Files:**
+- Create: `tests/context_assembler.rs`
+
+- [ ] **Step 1: Add integration test helpers**
+
+Create helper functions that open a temporary database, insert typed drawers, and run the CLI binary using `assert_cmd`-style patterns already used in existing tests. If no command-runner helper exists, use the existing project pattern from `tests/mind_model_bootstrap.rs`.
+
+Minimum fixture shape:
+
+```rust
+fn knowledge_drawer(
+    id: &str,
+    tier: KnowledgeTier,
+    status: KnowledgeStatus,
+    statement: &str,
+    content: &str,
+) -> Drawer {
+    // Build a Drawer with memory_kind=Knowledge and repo anchor.
+}
+```
+
+- [ ] **Step 2: Write tier-order failing test**
+
+Add:
+
+```rust
+#[test]
+fn test_context_groups_knowledge_by_tier_order() {
+    // Insert dao_tian, dao_ren, shu, qi matching the same query/domain/field.
+    // Run `mempal context "debug failing build" --field software-engineering`.
+    // Assert section order and citation metadata.
+}
+```
+
+- [ ] **Step 3: Run targeted test and verify failure**
+
+Run:
+
+```bash
+cargo test --test context_assembler test_context_groups_knowledge_by_tier_order -- --exact
+```
+
+Expected: FAIL because `mempal context` does not exist.
+
+## Task 2: Core Context Types And Assembly Skeleton
+
+**Files:**
+- Create: `src/context.rs`
+- Modify: `src/lib.rs`
+- Test: `tests/context_assembler.rs`
+
+- [ ] **Step 1: Define public internal types**
+
+Implement:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextRequest {
+    pub query: String,
+    pub domain: MemoryDomain,
+    pub field: String,
+    pub cwd: PathBuf,
+    pub include_evidence: bool,
+    pub max_items: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextPack {
+    pub query: String,
+    pub domain: MemoryDomain,
+    pub field: String,
+    pub anchors: Vec<ContextAnchor>,
+    pub sections: Vec<ContextSection>,
+}
+```
+
+Include `ContextSection`, `ContextItem`, and `ContextAnchor`. Keep these data-only and serializable.
+
+- [ ] **Step 2: Add deterministic tier/status helpers**
+
+Implement helpers:
+
+```rust
+fn tier_order() -> [KnowledgeTier; 4]
+fn is_active_status(status: &KnowledgeStatus) -> bool
+fn context_text(drawer: &Drawer) -> &str
+```
+
+Rules:
+- active status is `Canonical` or `Promoted`
+- knowledge text prefers non-empty `statement`
+- evidence text uses `content`
+
+- [ ] **Step 3: Add a minimal assembler function**
+
+Implement a function shaped like:
+
+```rust
+pub async fn assemble_context<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    request: ContextRequest,
+) -> Result<ContextPack, ContextError>
+```
+
+The first version can return tier sections using existing search filters and no anchor precedence yet.
+
+- [ ] **Step 4: Export module**
+
+Modify `src/lib.rs`:
+
+```rust
+pub mod context;
+```
+
+- [ ] **Step 5: Run unit/API test**
+
+Run:
+
+```bash
+cargo test --test context_assembler test_context_assembler_returns_typed_pack -- --exact
+```
+
+Expected: PASS after adding the dedicated test and implementation.
+
+## Task 3: Anchor Precedence, Domain/Field Filters, And Evidence Gate
+
+**Files:**
+- Modify: `src/context.rs`
+- Modify: `src/core/db.rs` only if needed
+- Test: `tests/context_assembler.rs`
+
+- [ ] **Step 1: Write anchor precedence test**
+
+Add `test_context_prefers_worktree_anchor_before_repo_and_global`.
+
+Expected failure before implementation: same-tier output does not sort by anchor precedence.
+
+- [ ] **Step 2: Implement anchor derivation**
+
+Use `anchor::derive_anchor_from_cwd(Some(&request.cwd))`. The resulting active anchor list should be:
+
+```text
+worktree://...
+repo://...
+global://...
+```
+
+Only include repo if `parent_anchor_id` exists. Global should be represented as `anchor_kind=Global`; use `global://default` or the existing canonical global id if already present.
+
+- [ ] **Step 3: Apply domain/field/tier/status filters**
+
+For each tier:
+- `memory_kind=knowledge`
+- `domain=request.domain`
+- `field=request.field`
+- `tier=<current tier>`
+- `status in canonical/promoted`
+
+If existing `SearchFilters` cannot express multiple allowed statuses, run one search per allowed status and merge/dedup before sorting.
+
+- [ ] **Step 4: Apply anchor precedence after retrieval**
+
+Sort same-tier items by:
+
+```text
+anchor_rank(worktree)=0
+anchor_rank(repo)=1
+anchor_rank(global)=2
+search_score ascending/descending according to existing score semantics
+drawer_id stable tiebreak
+```
+
+Do not modify search ranking internals.
+
+- [ ] **Step 5: Implement evidence gate**
+
+Only add evidence section when `request.include_evidence == true`. Evidence filters:
+- `memory_kind=evidence`
+- `domain=request.domain`
+- `field=request.field`
+- matching active anchors
+
+- [ ] **Step 6: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --test context_assembler test_context_prefers_worktree_anchor_before_repo_and_global -- --exact
+cargo test --test context_assembler test_context_domain_and_field_filters_exclude_unrelated_knowledge -- --exact
+cargo test --test context_assembler test_context_omits_evidence_by_default -- --exact
+cargo test --test context_assembler test_context_include_evidence_adds_evidence_section_after_qi -- --exact
+```
+
+Expected: PASS.
+
+## Task 4: CLI Surface And Renderers
+
+**Files:**
+- Modify: `src/main.rs`
+- Test: `tests/context_assembler.rs`
+
+- [ ] **Step 1: Add `Commands::Context`**
+
+Add clap args:
+
+```rust
+Context {
+    query: String,
+    #[arg(long, default_value = "general")]
+    field: String,
+    #[arg(long, default_value = "project")]
+    domain: String,
+    #[arg(long)]
+    cwd: Option<PathBuf>,
+    #[arg(long, default_value = "plain")]
+    format: String,
+    #[arg(long)]
+    include_evidence: bool,
+    #[arg(long, default_value_t = 12)]
+    max_items: usize,
+}
+```
+
+- [ ] **Step 2: Add validation**
+
+Reject:
+- `max_items == 0`
+- unsupported `format`
+- unsupported `domain`
+
+Use `bail!` with clear messages.
+
+- [ ] **Step 3: Implement plain renderer**
+
+Plain output should group sections:
+
+```text
+## dao_tian
+- <text>
+  source: <source_file>
+  drawer: <drawer_id>
+```
+
+Include `trigger_hints` only as metadata text for items that have it. Do not execute skills.
+
+- [ ] **Step 4: Implement JSON renderer**
+
+Use `serde_json::to_string_pretty(&pack)` and print to stdout.
+
+- [ ] **Step 5: Run CLI tests**
+
+Run:
+
+```bash
+cargo test --test context_assembler test_context_json_output_exposes_stable_pack_shape -- --exact
+cargo test --test context_assembler test_context_empty_result_exits_successfully -- --exact
+cargo test --test context_assembler test_context_rejects_invalid_max_items -- --exact
+```
+
+Expected: PASS.
+
+## Task 5: Statement Selection, Inactive Statuses, And Schema Guard
+
+**Files:**
+- Modify: `src/context.rs`
+- Test: `tests/context_assembler.rs`
+
+- [ ] **Step 1: Add statement/content regression tests**
+
+Add or complete:
+- `test_context_knowledge_item_uses_statement_before_content`
+- `test_context_excludes_inactive_knowledge_statuses`
+- `test_context_assembler_does_not_bump_schema`
+
+- [ ] **Step 2: Implement missing behavior**
+
+Ensure:
+- blank `statement` falls back to `content`
+- `candidate`, `demoted`, and `retired` are excluded
+- schema version remains v7
+- no tables are created by context assembly
+
+- [ ] **Step 3: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --test context_assembler test_context_knowledge_item_uses_statement_before_content -- --exact
+cargo test --test context_assembler test_context_excludes_inactive_knowledge_statuses -- --exact
+cargo test --test context_assembler test_context_assembler_does_not_bump_schema -- --exact
+```
+
+Expected: PASS.
+
+## Task 6: Documentation, Verification, And Commit
+
+**Files:**
+- Modify: `docs/MIND-MODEL-DESIGN.md` if implementation clarifies Phase-1 runtime behavior
+- Modify: `AGENTS.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update docs status**
+
+After implementation passes, move `specs/p14-context-assembler.spec.md` from current draft to completed in `AGENTS.md` and `CLAUDE.md`. Add this plan to the implementation plan list as completed.
+
+- [ ] **Step 2: Run contract validation**
+
+Run:
+
+```bash
+agent-spec parse specs/p14-context-assembler.spec.md
+agent-spec lint specs/p14-context-assembler.spec.md --min-score 0.7
+```
+
+Expected: parse succeeds, lint score >= 70%.
+
+- [ ] **Step 3: Run Rust verification**
+
+Run:
+
+```bash
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add specs/p14-context-assembler.spec.md docs/plans/2026-04-24-p14-context-assembler-implementation.md src/context.rs src/lib.rs src/main.rs src/core/db.rs tests/context_assembler.rs AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+git commit -m "feat: add mind-model context assembler"
+```
+
+- [ ] **Step 5: Save decision memory**
+
+Use `mempal_ingest` or the current source-built CLI if the installed binary lags schema v7. Record what shipped, why `mempal context` is CLI-first, and which items remain out of scope.

--- a/specs/p14-context-assembler.spec.md
+++ b/specs/p14-context-assembler.spec.md
@@ -36,7 +36,8 @@ agent 上下文。本任务不做 MCP/REST parity，也不做 promotion/demotion
 - Anchor 选择和排序固定为：
   - 若请求显式提供 `--cwd`，按该 cwd 推导当前 `worktree` 和 parent `repo`
   - 否则按当前进程 cwd 推导
-  - 同 tier 内优先 `worktree`，再 `repo`，最后 `global`
+  - 同 tier 内优先 `worktree`，再当前 `repo`，再 `repo://legacy` fallback，最后 `global`
+  - `global` anchor 只匹配 `domain='global'` 的通用知识，以保持 P12 的 `global anchor requires domain=global` invariant
 - Knowledge eligibility：
   - 默认只使用 `status in ('canonical', 'promoted')`
   - `candidate`、`demoted`、`retired` 不进入默认 context pack

--- a/specs/p14-context-assembler.spec.md
+++ b/specs/p14-context-assembler.spec.md
@@ -1,0 +1,246 @@
+spec: task
+name: "P14: mind-model runtime context assembler"
+inherits: project
+tags: [memory, context, mind-model, cli, runtime]
+estimate: 1d
+---
+
+## Intent
+
+P12/P13 已经让 mempal 能存储 typed evidence / knowledge drawers，并让
+knowledge drawer 在 wake-up 中优先使用 `statement`。但当前 runtime 仍没有
+一个按 mind-model 组装上下文的入口：agent 只能做普通 search 或 importance
+wake-up，无法稳定获得 `dao_tian -> dao_ren -> shu -> qi -> evidence` 的分层
+context pack。
+
+本任务实现最小 runtime assembler：新增 `mempal context` CLI 和核心组装逻辑，
+让已存的 knowledge/evidence 能按 anchor、tier、status、field/domain 约束进入
+agent 上下文。本任务不做 MCP/REST parity，也不做 promotion/demotion lifecycle。
+
+## Decisions
+
+- 新增 CLI：`mempal context <query>`
+- `mempal context` 支持最小 flags：
+  - `--field <field>`：默认 `general`
+  - `--domain <domain>`：默认 `project`
+  - `--cwd <path>`：用于推导当前 worktree/repo anchor，默认当前进程 cwd
+  - `--format plain|json`：默认 `plain`
+  - `--include-evidence`：默认不注入 evidence section
+  - `--max-items <n>`：总 item 上限，默认 `12`
+- 新增核心模块 `src/context.rs`，暴露内部 request/response 类型：
+  - `ContextRequest`
+  - `ContextPack`
+  - `ContextSection`
+  - `ContextItem`
+- Tier section order is fixed and observable as `dao_tian -> dao_ren -> shu -> qi -> evidence`
+- Anchor 选择和排序固定为：
+  - 若请求显式提供 `--cwd`，按该 cwd 推导当前 `worktree` 和 parent `repo`
+  - 否则按当前进程 cwd 推导
+  - 同 tier 内优先 `worktree`，再 `repo`，最后 `global`
+- Knowledge eligibility：
+  - 默认只使用 `status in ('canonical', 'promoted')`
+  - `candidate`、`demoted`、`retired` 不进入默认 context pack
+  - `dao_tian` 仍遵守 P12 规则，只应出现 `canonical` 或 `demoted`
+- Text selection：
+  - knowledge item 优先使用非空 `statement`
+  - knowledge item 缺失 `statement` 时回退 `content`
+  - evidence item 使用 `content`
+- Evidence section：
+  - 默认不输出 evidence
+  - 只有传入 `--include-evidence` 时才按 query 补充 evidence section
+  - evidence section 只使用 `memory_kind='evidence'` 且匹配 `domain/field/anchor`
+- `trigger_hints` 是输出 metadata，不是执行器：
+  - context assembler 可以返回 `trigger_hints`
+  - 不得直接调用 skill
+  - 不得把 `trigger_hints` 当作 hard-coded `skill_id`
+- Plain 输出按 section 分组，每条必须带 `drawer_id` 和 `source_file`
+- JSON 输出必须包含：
+  - `query`
+  - `domain`
+  - `field`
+  - `anchors`
+  - `sections`
+  - 每个 item 的 `drawer_id`、`source_file`、`text`、`tier/status`、`anchor_kind/anchor_id`
+- 本任务复用现有 search / DB 能力；不得改变 BM25 + vector + RRF ranking 语义
+- 本任务不 bump schema；schema v7 已具备 P12/P13 所需字段
+
+## Boundaries
+
+### Allowed Changes
+- `src/context.rs`
+- `src/lib.rs`
+- `src/main.rs`
+- `src/core/db.rs`
+- `src/search/**`
+- `tests/context_assembler.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- 不要修改 `drawers` / `drawer_vectors` / `triples` / `tunnels` schema
+- 不要新增 MCP tool，例如 `mempal_context`
+- 不要新增 REST endpoint
+- 不要实现 promote / demote / publish_anchor lifecycle
+- 不要集成 `research-rs`
+- 不要引入 Phase-2 `knowledge_cards`
+- 不要改变 `mempal search` 或 MCP `mempal_search` 的 response contract
+- 不要改变现有 BM25 + vector + RRF ranking 算法
+- 不要让 context assembler 直接调用任何 skill
+- 不要引入新依赖
+
+## Out of Scope
+
+- MCP `mempal_context` 工具
+- REST context API
+- automatic skill trigger orchestration
+- automatic evidence-to-knowledge distillation
+- promotion / demotion evaluator gates
+- `worktree -> repo -> global` publication API
+- Phase-2 `knowledge_cards` / `knowledge_events`
+- research-rs ingestion pipeline
+- token-budget optimizer beyond `--max-items`
+
+## Completion Criteria
+
+Scenario: context CLI groups knowledge by mind-model tier order
+  Test:
+    Filter: test_context_groups_knowledge_by_tier_order
+    Level: integration
+  Given query 为 `"debug failing build"`
+  Given 数据库中存在 active knowledge drawers，tier 分别为 `dao_tian`, `dao_ren`, `shu`, `qi`
+  And 每条 drawer 都匹配相同 `query/domain/field`
+  When 执行 `mempal context "debug failing build" --field software-engineering`
+  Then plain 输出按 `dao_tian`, `dao_ren`, `shu`, `qi` 的 section 顺序出现
+  And 每条 item 都包含 `drawer_id`
+  And 每条 item 都包含 `source_file`
+
+Scenario: context prefers worktree anchor before repo and global inside same tier
+  Test:
+    Filter: test_context_prefers_worktree_anchor_before_repo_and_global
+    Level: integration
+  Given query 为 `"local experiment"`
+  Given 当前 cwd 可推导出 `worktree` anchor 和 parent `repo` anchor
+  And 数据库中同一 tier 下存在 `worktree`, `repo`, `global` 三条匹配 knowledge
+  When 执行 `mempal context "local experiment" --cwd <current_worktree>`
+  Then 同一 section 内 `worktree` item 排在 `repo` item 前
+  And `repo` item 排在 `global` item 前
+
+Scenario: knowledge item uses statement before rationale content
+  Test:
+    Filter: test_context_knowledge_item_uses_statement_before_content
+    Level: integration
+  Given query 为 `"debug"`
+  Given 数据库中存在一个 knowledge drawer
+  And `statement == "Reproduce before patching."`
+  And `content == "Long rationale explaining why reproduction prevents false fixes."`
+  When 执行 `mempal context "debug"`
+  Then 输出 item text 包含 `"Reproduce before patching."`
+  And 输出 item text 不包含完整 rationale body
+
+Scenario: inactive knowledge statuses are excluded from default context
+  Test:
+    Filter: test_context_excludes_inactive_knowledge_statuses
+    Level: integration
+  Given query 为 `"debug"`
+  Given 数据库中存在 `candidate`, `demoted`, `retired`, `promoted`, `canonical` 五种 status 的匹配 knowledge
+  When 执行 `mempal context "debug"`
+  Then 输出包含 `promoted` knowledge
+  And 输出包含 `canonical` knowledge
+  And 输出不包含 `candidate` knowledge
+  And 输出不包含 `demoted` knowledge
+  And 输出不包含 `retired` knowledge
+
+Scenario: evidence section is omitted by default
+  Test:
+    Filter: test_context_omits_evidence_by_default
+    Level: integration
+  Given query 为 `"observed failure"`
+  Given 数据库中存在匹配 query 的 evidence drawer
+  When 执行 `mempal context "observed failure"`
+  Then 输出不包含 evidence section
+  And 输出不包含该 evidence drawer 的 `drawer_id`
+
+Scenario: include-evidence adds evidence section after qi
+  Test:
+    Filter: test_context_include_evidence_adds_evidence_section_after_qi
+    Level: integration
+  Given query 为 `"observed failure"`
+  Given 数据库中存在匹配 query 的 `qi` knowledge drawer
+  And 数据库中存在匹配 query 的 evidence drawer
+  When 执行 `mempal context "observed failure" --include-evidence`
+  Then 输出包含 `qi` section
+  And 输出包含 `evidence` section
+  And `evidence` section 排在 `qi` section 之后
+  And evidence item 使用 `content` 作为 text
+
+Scenario: json output exposes stable context pack shape
+  Test:
+    Filter: test_context_json_output_exposes_stable_pack_shape
+    Level: integration
+  Given query 为 `"debug"`
+  Given 数据库中存在一个带 `trigger_hints` 的 `shu` knowledge drawer
+  When 执行 `mempal context "debug" --format json`
+  Then stdout 是合法 JSON
+  And JSON 顶层包含 `query`, `domain`, `field`, `anchors`, `sections`
+  And item 包含 `drawer_id`, `source_file`, `text`, `tier`, `status`, `anchor_kind`, `anchor_id`
+  And item 暴露 `trigger_hints`
+  And context assembler 没有调用任何 skill
+
+Scenario: domain and field filters exclude unrelated knowledge
+  Test:
+    Filter: test_context_domain_and_field_filters_exclude_unrelated_knowledge
+    Level: integration
+  Given query 为 `"debug"`
+  Given 数据库中存在 `domain="skill", field="debugging"` 的 matching knowledge
+  And 数据库中存在 `domain="project", field="debugging"` 的 matching knowledge
+  And 数据库中存在 `domain="skill", field="writing"` 的 matching knowledge
+  When 执行 `mempal context "debug" --domain skill --field debugging`
+  Then 输出包含 `domain="skill", field="debugging"` 的 item
+  And 输出不包含 `domain="project", field="debugging"` 的 item
+  And 输出不包含 `domain="skill", field="writing"` 的 item
+
+Scenario: empty context result exits successfully with explicit empty sections
+  Test:
+    Filter: test_context_empty_result_exits_successfully
+    Level: integration
+  Given query 为 `"no such topic"`
+  Given 数据库中没有匹配 query/domain/field 的 active knowledge
+  When 执行 `mempal context "no such topic" --format json`
+  Then exit code 为 0
+  And JSON `sections` 是空数组
+  And stderr 不包含 error
+
+Scenario: invalid max-items is rejected before search
+  Test:
+    Filter: test_context_rejects_invalid_max_items
+    Level: integration
+  Given query 为 `"debug"`
+  Given 任意数据库状态
+  When 执行 `mempal context "debug" --max-items 0`
+  Then exit code 非 0
+  And stderr 说明 `--max-items` 必须大于 0
+  And 不执行 context assembly
+
+Scenario: core assembler API returns typed context pack
+  Test:
+    Filter: test_context_assembler_returns_typed_pack
+    Level: unit
+  Given 一个 `ContextRequest` 包含 `query`, `domain`, `field`, `cwd`, `include_evidence`, `max_items`
+  And 数据库中存在至少一个 matching knowledge drawer
+  When 调用 `src/context.rs` 的核心组装函数
+  Then 返回值类型为 `ContextPack`
+  And `ContextPack.sections` 中的元素类型为 `ContextSection`
+  And `ContextSection.items` 中的元素类型为 `ContextItem`
+  And 该 API 不直接写 stdout 或 stderr
+
+Scenario: context assembler does not bump schema
+  Test:
+    Filter: test_context_assembler_does_not_bump_schema
+    Level: integration
+  Given query 为 `"debug"`
+  Given 一个 schema v7 数据库
+  When 执行 `mempal context "debug"`
+  Then schema_version 仍然是 7
+  And 不创建新表
+  And 不修改 `drawers` 表结构

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,387 @@
+#![warn(clippy::all)]
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::core::{
+    anchor,
+    db::Database,
+    db::DbError,
+    types::{
+        AnchorKind, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, RouteDecision,
+        SearchResult, TriggerHints,
+    },
+};
+use crate::embed::{EmbedError, Embedder};
+use crate::search::{SearchError, SearchFilters, SearchOptions, search_with_vector_options};
+
+pub type Result<T> = std::result::Result<T, ContextError>;
+
+#[derive(Debug, Error)]
+pub enum ContextError {
+    #[error("failed to derive context anchors")]
+    DeriveAnchor(#[from] anchor::AnchorError),
+    #[error("failed to embed context query")]
+    EmbedQuery(#[source] EmbedError),
+    #[error("embedder returned no context query vector")]
+    MissingQueryVector,
+    #[error("failed to search context candidates")]
+    Search(#[source] SearchError),
+    #[error("failed to load context drawer metadata")]
+    LoadDrawer(#[source] DbError),
+}
+
+#[derive(Debug, Clone)]
+pub struct ContextRequest {
+    pub query: String,
+    pub domain: MemoryDomain,
+    pub field: String,
+    pub cwd: PathBuf,
+    pub include_evidence: bool,
+    pub max_items: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ContextAnchor {
+    pub anchor_kind: AnchorKind,
+    pub anchor_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextPack {
+    pub query: String,
+    pub domain: MemoryDomain,
+    pub field: String,
+    pub anchors: Vec<ContextAnchor>,
+    pub sections: Vec<ContextSection>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextSection {
+    pub name: String,
+    pub items: Vec<ContextItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextItem {
+    pub drawer_id: String,
+    pub source_file: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<KnowledgeTier>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<KnowledgeStatus>,
+    pub anchor_kind: AnchorKind,
+    pub anchor_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_anchor_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_hints: Option<TriggerHints>,
+}
+
+#[derive(Debug, Clone)]
+struct AnchorCandidate {
+    anchor_kind: AnchorKind,
+    anchor_id: String,
+    domain: MemoryDomain,
+}
+
+#[derive(Debug, Clone)]
+struct CandidateQuery<'a> {
+    request: &'a ContextRequest,
+    query_vector: &'a [f32],
+    route: &'a RouteDecision,
+    anchor: &'a AnchorCandidate,
+    memory_kind: MemoryKind,
+    tier: Option<KnowledgeTier>,
+    status: Option<KnowledgeStatus>,
+    top_k: usize,
+}
+
+pub async fn assemble_context<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    request: ContextRequest,
+) -> Result<ContextPack> {
+    let anchors = context_anchors(&request)?;
+    let query_vector = embedder
+        .embed(&[request.query.as_str()])
+        .await
+        .map_err(ContextError::EmbedQuery)?
+        .into_iter()
+        .next()
+        .ok_or(ContextError::MissingQueryVector)?;
+
+    let route = RouteDecision {
+        wing: None,
+        room: None,
+        confidence: 0.0,
+        reason: "mind-model context assembly".to_string(),
+    };
+
+    let mut sections = Vec::new();
+    let mut remaining = request.max_items;
+    let mut seen = BTreeSet::new();
+
+    for tier in tier_order() {
+        if remaining == 0 {
+            break;
+        }
+        let mut items = Vec::new();
+        for anchor in &anchors {
+            if remaining == 0 {
+                break;
+            }
+            for status in active_statuses() {
+                if remaining == 0 {
+                    break;
+                }
+                let mut results = search_context_candidates(
+                    db,
+                    CandidateQuery {
+                        request: &request,
+                        query_vector: &query_vector,
+                        route: &route,
+                        anchor,
+                        memory_kind: MemoryKind::Knowledge,
+                        tier: Some(tier.clone()),
+                        status: Some(status.clone()),
+                        top_k: remaining,
+                    },
+                )?;
+                results.retain(|result| result.anchor_id == anchor.anchor_id);
+                for result in results {
+                    if remaining == 0 {
+                        break;
+                    }
+                    if !seen.insert(result.drawer_id.clone()) {
+                        continue;
+                    }
+                    items.push(context_item_from_result(db, result)?);
+                    remaining -= 1;
+                }
+            }
+        }
+        if !items.is_empty() {
+            sections.push(ContextSection {
+                name: tier_slug(tier).to_string(),
+                items,
+            });
+        }
+    }
+
+    if request.include_evidence && remaining > 0 {
+        let mut items = Vec::new();
+        for anchor in &anchors {
+            if remaining == 0 {
+                break;
+            }
+            let mut results = search_context_candidates(
+                db,
+                CandidateQuery {
+                    request: &request,
+                    query_vector: &query_vector,
+                    route: &route,
+                    anchor,
+                    memory_kind: MemoryKind::Evidence,
+                    tier: None,
+                    status: None,
+                    top_k: remaining,
+                },
+            )?;
+            results.retain(|result| result.anchor_id == anchor.anchor_id);
+            for result in results {
+                if remaining == 0 {
+                    break;
+                }
+                if !seen.insert(result.drawer_id.clone()) {
+                    continue;
+                }
+                items.push(context_item_from_result(db, result)?);
+                remaining -= 1;
+            }
+        }
+        if !items.is_empty() {
+            sections.push(ContextSection {
+                name: "evidence".to_string(),
+                items,
+            });
+        }
+    }
+
+    Ok(ContextPack {
+        query: request.query,
+        domain: request.domain,
+        field: request.field,
+        anchors: anchors
+            .into_iter()
+            .map(|anchor| ContextAnchor {
+                anchor_kind: anchor.anchor_kind,
+                anchor_id: anchor.anchor_id,
+            })
+            .collect(),
+        sections,
+    })
+}
+
+fn context_anchors(request: &ContextRequest) -> Result<Vec<AnchorCandidate>> {
+    let derived = anchor::derive_anchor_from_cwd(Some(&request.cwd))?;
+    let mut anchors = Vec::new();
+    anchors.push(AnchorCandidate {
+        anchor_kind: AnchorKind::Worktree,
+        anchor_id: derived.anchor_id,
+        domain: request.domain.clone(),
+    });
+
+    let repo_anchor_id = derived
+        .parent_anchor_id
+        .unwrap_or_else(|| anchor::LEGACY_REPO_ANCHOR_ID.to_string());
+    anchors.push(AnchorCandidate {
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: repo_anchor_id,
+        domain: request.domain.clone(),
+    });
+
+    // P12 backfilled existing drawers to repo://legacy. Keep it as a fallback
+    // so the first runtime assembler remains useful on pre-anchor databases.
+    anchors.push(AnchorCandidate {
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        domain: request.domain.clone(),
+    });
+
+    anchors.push(AnchorCandidate {
+        anchor_kind: AnchorKind::Global,
+        anchor_id: "global://default".to_string(),
+        domain: MemoryDomain::Global,
+    });
+
+    Ok(dedup_anchors(anchors))
+}
+
+fn dedup_anchors(anchors: Vec<AnchorCandidate>) -> Vec<AnchorCandidate> {
+    let mut seen = BTreeSet::new();
+    anchors
+        .into_iter()
+        .filter(|anchor| {
+            seen.insert((
+                anchor_kind_slug(&anchor.anchor_kind).to_string(),
+                anchor.anchor_id.clone(),
+            ))
+        })
+        .collect()
+}
+
+fn search_context_candidates(
+    db: &Database,
+    query: CandidateQuery<'_>,
+) -> Result<Vec<SearchResult>> {
+    let filters = SearchFilters {
+        memory_kind: Some(memory_kind_slug(&query.memory_kind).to_string()),
+        domain: Some(domain_slug(&query.anchor.domain).to_string()),
+        field: Some(query.request.field.clone()),
+        tier: query.tier.as_ref().map(tier_slug).map(str::to_string),
+        status: query.status.as_ref().map(status_slug).map(str::to_string),
+        anchor_kind: Some(anchor_kind_slug(&query.anchor.anchor_kind).to_string()),
+    };
+
+    search_with_vector_options(
+        db,
+        &query.request.query,
+        query.query_vector,
+        query.route.clone(),
+        SearchOptions {
+            filters,
+            with_neighbors: false,
+        },
+        query.top_k,
+    )
+    .map_err(ContextError::Search)
+}
+
+fn context_item_from_result(db: &Database, result: SearchResult) -> Result<ContextItem> {
+    let trigger_hints = db
+        .get_drawer(&result.drawer_id)
+        .map_err(ContextError::LoadDrawer)?
+        .and_then(|drawer| drawer.trigger_hints);
+    let text = match result.memory_kind {
+        MemoryKind::Knowledge => result
+            .statement
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(result.content.as_str())
+            .to_string(),
+        MemoryKind::Evidence => result.content,
+    };
+    Ok(ContextItem {
+        drawer_id: result.drawer_id,
+        source_file: result.source_file,
+        text,
+        tier: result.tier,
+        status: result.status,
+        anchor_kind: result.anchor_kind,
+        anchor_id: result.anchor_id,
+        parent_anchor_id: result.parent_anchor_id,
+        trigger_hints,
+    })
+}
+
+fn tier_order() -> &'static [KnowledgeTier] {
+    &[
+        KnowledgeTier::DaoTian,
+        KnowledgeTier::DaoRen,
+        KnowledgeTier::Shu,
+        KnowledgeTier::Qi,
+    ]
+}
+
+fn active_statuses() -> &'static [KnowledgeStatus] {
+    &[KnowledgeStatus::Canonical, KnowledgeStatus::Promoted]
+}
+
+fn memory_kind_slug(value: &MemoryKind) -> &'static str {
+    match value {
+        MemoryKind::Evidence => "evidence",
+        MemoryKind::Knowledge => "knowledge",
+    }
+}
+
+fn domain_slug(value: &MemoryDomain) -> &'static str {
+    match value {
+        MemoryDomain::Project => "project",
+        MemoryDomain::Agent => "agent",
+        MemoryDomain::Skill => "skill",
+        MemoryDomain::Global => "global",
+    }
+}
+
+fn tier_slug(value: &KnowledgeTier) -> &'static str {
+    match value {
+        KnowledgeTier::Qi => "qi",
+        KnowledgeTier::Shu => "shu",
+        KnowledgeTier::DaoRen => "dao_ren",
+        KnowledgeTier::DaoTian => "dao_tian",
+    }
+}
+
+fn status_slug(value: &KnowledgeStatus) -> &'static str {
+    match value {
+        KnowledgeStatus::Candidate => "candidate",
+        KnowledgeStatus::Promoted => "promoted",
+        KnowledgeStatus::Canonical => "canonical",
+        KnowledgeStatus::Demoted => "demoted",
+        KnowledgeStatus::Retired => "retired",
+    }
+}
+
+fn anchor_kind_slug(value: &AnchorKind) -> &'static str {
+    match value {
+        AnchorKind::Global => "global",
+        AnchorKind::Repo => "repo",
+        AnchorKind::Worktree => "worktree",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod aaak;
 #[cfg(feature = "rest")]
 pub mod api;
+pub mod context;
 pub mod core;
 pub mod cowork;
 pub mod embed;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand};
 use mempal::aaak::{AaakCodec, AaakMeta};
 #[cfg(feature = "rest")]
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
+use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
     config::Config,
     db::Database,
@@ -87,6 +88,21 @@ enum Commands {
         json: bool,
         #[arg(long)]
         with_neighbors: bool,
+    },
+    Context {
+        query: String,
+        #[arg(long, default_value = "general")]
+        field: String,
+        #[arg(long, default_value = "project")]
+        domain: String,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+        #[arg(long)]
+        include_evidence: bool,
+        #[arg(long, default_value_t = 12)]
+        max_items: usize,
     },
     WakeUp {
         #[arg(long)]
@@ -372,6 +388,30 @@ async fn run() -> Result<()> {
             )
             .await
         }
+        Commands::Context {
+            query,
+            field,
+            domain,
+            cwd,
+            format,
+            include_evidence,
+            max_items,
+        } => {
+            context_command(
+                &db,
+                &config,
+                ContextCommandArgs {
+                    query,
+                    field,
+                    domain,
+                    cwd,
+                    format,
+                    include_evidence,
+                    max_items,
+                },
+            )
+            .await
+        }
         Commands::Delete { drawer_id } => delete_command(&db, &drawer_id),
         Commands::Purge { before } => purge_command(&db, before.as_deref()),
         Commands::WakeUp { format } => wake_up_command(&db, format.as_deref()),
@@ -408,6 +448,16 @@ struct SearchCommandArgs<'a> {
     top_k: usize,
     json: bool,
     with_neighbors: bool,
+}
+
+struct ContextCommandArgs {
+    query: String,
+    field: String,
+    domain: String,
+    cwd: Option<PathBuf>,
+    format: String,
+    include_evidence: bool,
+    max_items: usize,
 }
 
 async fn bench_command(config: &Config, command: BenchCommands) -> Result<()> {
@@ -602,6 +652,92 @@ fn append_ingest_audit_log(
     writeln!(file, "{entry}")
         .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
     Ok(())
+}
+
+async fn context_command(db: &Database, config: &Config, args: ContextCommandArgs) -> Result<()> {
+    if args.max_items == 0 {
+        bail!("--max-items must be greater than 0");
+    }
+    let domain = parse_domain(&args.domain)?;
+    let cwd = match args.cwd {
+        Some(cwd) => cwd,
+        None => env::current_dir().context("failed to read current directory")?,
+    };
+
+    let embedder = build_embedder(config).await?;
+    let pack = assemble_context(
+        db,
+        &*embedder,
+        ContextRequest {
+            query: args.query,
+            domain,
+            field: args.field,
+            cwd,
+            include_evidence: args.include_evidence,
+            max_items: args.max_items,
+        },
+    )
+    .await?;
+
+    match args.format.as_str() {
+        "plain" => print_context_plain(&pack),
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&pack).context("failed to serialize context pack")?
+            );
+        }
+        other => bail!("unsupported context format: {other}"),
+    }
+
+    Ok(())
+}
+
+fn parse_domain(value: &str) -> Result<MemoryDomain> {
+    match value {
+        "project" => Ok(MemoryDomain::Project),
+        "agent" => Ok(MemoryDomain::Agent),
+        "skill" => Ok(MemoryDomain::Skill),
+        "global" => Ok(MemoryDomain::Global),
+        other => bail!("unsupported domain: {other}"),
+    }
+}
+
+fn print_context_plain(pack: &ContextPack) {
+    if pack.sections.is_empty() {
+        println!("no context");
+        return;
+    }
+
+    for section in &pack.sections {
+        println!("## {}", section.name);
+        for item in &section.items {
+            println!("- {}", item.text);
+            println!("  source: {}", item.source_file);
+            println!("  drawer: {}", item.drawer_id);
+            println!(
+                "  anchor: {} {}",
+                anchor_kind_slug(&item.anchor_kind),
+                item.anchor_id
+            );
+            if let (Some(tier), Some(status)) = (&item.tier, &item.status) {
+                println!(
+                    "  knowledge: tier={} status={}",
+                    knowledge_tier_slug(tier),
+                    knowledge_status_slug(status)
+                );
+            }
+            if let Some(trigger_hints) = item.trigger_hints.as_ref() {
+                println!(
+                    "  trigger_hints: intent_tags={} workflow_bias={} tool_needs={}",
+                    trigger_hints.intent_tags.join(","),
+                    trigger_hints.workflow_bias.join(","),
+                    trigger_hints.tool_needs.join(",")
+                );
+            }
+        }
+        println!();
+    }
 }
 
 async fn search_command(db: &Database, config: &Config, args: SearchCommandArgs<'_>) -> Result<()> {

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -1,0 +1,634 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::Command;
+use std::thread;
+
+use async_trait::async_trait;
+use mempal::context::{ContextRequest, assemble_context};
+use mempal::core::anchor;
+use mempal::core::db::Database;
+use mempal::core::types::{
+    AnchorKind, Drawer, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance,
+    SourceType, TriggerHints,
+};
+use mempal::embed::Embedder;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+struct StubEmbedder {
+    vector: Vec<f32>,
+}
+
+#[async_trait]
+impl Embedder for StubEmbedder {
+    async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| self.vector.clone()).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "stub"
+    }
+}
+
+fn new_db() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    (tmp, db)
+}
+
+fn setup_cli_home() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_dir = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_dir).expect("create .mempal");
+    let db = Database::open(&mempal_dir.join("palace.db")).expect("open cli db");
+    (tmp, db)
+}
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn vector() -> Vec<f32> {
+    vec![0.25; 384]
+}
+
+fn embedder() -> StubEmbedder {
+    StubEmbedder { vector: vector() }
+}
+
+fn default_request(query: &str, cwd: &Path) -> ContextRequest {
+    ContextRequest {
+        query: query.to_string(),
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        cwd: cwd.to_path_buf(),
+        include_evidence: false,
+        max_items: 12,
+    }
+}
+
+fn knowledge_drawer(
+    id: &str,
+    tier: KnowledgeTier,
+    status: KnowledgeStatus,
+    statement: &str,
+    content: &str,
+) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("context".to_string()),
+        source_file: Some(format!("knowledge://project/context/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 3,
+        memory_kind: MemoryKind::Knowledge,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        provenance: None,
+        statement: Some(statement.to_string()),
+        tier: Some(tier),
+        status: Some(status),
+        supporting_refs: vec!["drawer_supporting_ev".to_string()],
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn evidence_drawer(id: &str, content: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("context".to_string()),
+        source_file: Some(format!("tests://context/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 2,
+        memory_kind: MemoryKind::Evidence,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        provenance: Some(Provenance::Human),
+        statement: None,
+        tier: None,
+        status: None,
+        supporting_refs: Vec::new(),
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn insert_fixture(db: &Database, drawer: &Drawer) {
+    db.insert_drawer(drawer).expect("insert drawer");
+    db.insert_vector(&drawer.id, &vector())
+        .expect("insert vector");
+}
+
+fn start_openai_embedding_stub(
+    expected_query: &str,
+    vector: Vec<f32>,
+) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding stub");
+    listener
+        .set_nonblocking(true)
+        .expect("set embedding stub nonblocking");
+    let address = listener.local_addr().expect("local addr");
+    let expected_query = expected_query.to_string();
+
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = (0..50)
+            .find_map(|_| match listener.accept() {
+                Ok(connection) => Some(connection),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(std::time::Duration::from_millis(100));
+                    None
+                }
+                Err(error) => panic!("accept request: {error}"),
+            })
+            .expect("embedding stub timed out waiting for request");
+        let mut request = [0_u8; 4096];
+        let bytes_read = stream.read(&mut request).expect("read embedding request");
+        assert!(bytes_read > 0, "expected non-empty HTTP request");
+        let request = String::from_utf8_lossy(&request[..bytes_read]);
+        let (headers, body) = request
+            .split_once("\r\n\r\n")
+            .expect("request should contain HTTP headers and JSON body");
+        let request_line = headers.lines().next().expect("request line");
+        assert_eq!(request_line, "POST /v1/embeddings HTTP/1.1");
+
+        let payload: Value = serde_json::from_str(body).expect("parse embedding request body");
+        assert_eq!(payload["model"], "test-model");
+        let input = payload["input"]
+            .as_array()
+            .expect("input should be an array");
+        assert_eq!(input.len(), 1, "expected a single embedding query");
+        assert_eq!(input[0], expected_query);
+
+        let body = serde_json::to_string(&json!({
+            "data": [{ "embedding": vector }]
+        }))
+        .expect("serialize response body");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write embedding response");
+    });
+
+    (format!("http://{address}/v1/embeddings"), handle)
+}
+
+fn write_cli_api_config(home: &Path, endpoint: &str) {
+    let config_path = home.join(".mempal").join("config.toml");
+    fs::write(
+        config_path,
+        format!(
+            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+        ),
+    )
+    .expect("write cli config");
+}
+
+fn run_context_json(home: &Path, query: &str, extra_args: &[&str]) -> Value {
+    let (endpoint, handle) = start_openai_embedding_stub(query, vector());
+    write_cli_api_config(home, &endpoint);
+
+    let mut args = vec!["context".to_string(), query.to_string()];
+    args.extend(extra_args.iter().map(|arg| (*arg).to_string()));
+    args.extend(["--format".to_string(), "json".to_string()]);
+
+    let output = Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .output()
+        .expect("run mempal context");
+    assert!(
+        output.status.success(),
+        "context command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    handle.join().expect("join embedding stub");
+    serde_json::from_slice(&output.stdout).expect("parse context json")
+}
+
+fn run_context_plain(home: &Path, query: &str, extra_args: &[&str]) -> String {
+    let (endpoint, handle) = start_openai_embedding_stub(query, vector());
+    write_cli_api_config(home, &endpoint);
+
+    let mut args = vec!["context".to_string(), query.to_string()];
+    args.extend(extra_args.iter().map(|arg| (*arg).to_string()));
+
+    let output = Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .output()
+        .expect("run mempal context");
+    assert!(
+        output.status.success(),
+        "context command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    handle.join().expect("join embedding stub");
+    String::from_utf8(output.stdout).expect("context stdout utf8")
+}
+
+#[tokio::test]
+async fn test_context_groups_knowledge_by_tier_order() {
+    let (tmp, db) = new_db();
+    let items = [
+        knowledge_drawer(
+            "drawer_qi",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Promoted,
+            "Use cargo test for verification.",
+            "qi body debug failing build",
+        ),
+        knowledge_drawer(
+            "drawer_shu",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Reproduce before patching.",
+            "shu body debug failing build",
+        ),
+        knowledge_drawer(
+            "drawer_dao_ren",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Promoted,
+            "Software changes need executable feedback.",
+            "dao ren body debug failing build",
+        ),
+        knowledge_drawer(
+            "drawer_dao_tian",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Evidence precedes assertion.",
+            "dao tian body debug failing build",
+        ),
+    ];
+    for item in &items {
+        insert_fixture(&db, item);
+    }
+
+    let mut request = default_request("debug failing build", tmp.path());
+    request.field = "general".to_string();
+    let pack = assemble_context(&db, &embedder(), request)
+        .await
+        .expect("assemble context");
+    let names: Vec<_> = pack
+        .sections
+        .iter()
+        .map(|section| section.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["dao_tian", "dao_ren", "shu", "qi"]);
+    for section in pack.sections {
+        assert_eq!(section.items.len(), 1);
+        assert!(!section.items[0].drawer_id.is_empty());
+        assert!(!section.items[0].source_file.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn test_context_prefers_worktree_anchor_before_repo_and_global() {
+    let (tmp, db) = new_db();
+    let repo_path = tmp.path().join("repo");
+    fs::create_dir_all(&repo_path).expect("create repo");
+    Command::new("git")
+        .arg("init")
+        .current_dir(&repo_path)
+        .output()
+        .expect("git init");
+    let derived = anchor::derive_anchor_from_cwd(Some(&repo_path)).expect("derive anchor");
+
+    let mut worktree = knowledge_drawer(
+        "drawer_worktree",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Worktree-local rule.",
+        "local experiment worktree",
+    );
+    worktree.anchor_kind = AnchorKind::Worktree;
+    worktree.anchor_id = derived.anchor_id.clone();
+    worktree.parent_anchor_id = derived.parent_anchor_id.clone();
+
+    let mut repo = knowledge_drawer(
+        "drawer_repo",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Repo rule.",
+        "local experiment repo",
+    );
+    repo.anchor_kind = AnchorKind::Repo;
+    repo.anchor_id = derived.parent_anchor_id.clone().expect("repo anchor");
+
+    let mut global = knowledge_drawer(
+        "drawer_global",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Global rule.",
+        "local experiment global",
+    );
+    global.domain = MemoryDomain::Global;
+    global.anchor_kind = AnchorKind::Global;
+    global.anchor_id = "global://default".to_string();
+
+    for item in [&worktree, &repo, &global] {
+        insert_fixture(&db, item);
+    }
+
+    let mut request = default_request("local experiment", &repo_path);
+    request.max_items = 3;
+    let pack = assemble_context(&db, &embedder(), request)
+        .await
+        .expect("assemble context");
+    let shu = pack
+        .sections
+        .iter()
+        .find(|section| section.name == "shu")
+        .expect("shu section");
+    let ids: Vec<_> = shu
+        .items
+        .iter()
+        .map(|item| item.drawer_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["drawer_worktree", "drawer_repo", "drawer_global"]);
+}
+
+#[tokio::test]
+async fn test_context_knowledge_item_uses_statement_before_content() {
+    let (tmp, db) = new_db();
+    insert_fixture(
+        &db,
+        &knowledge_drawer(
+            "drawer_statement",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Reproduce before patching.",
+            "Long rationale explaining why reproduction prevents false fixes.",
+        ),
+    );
+    let pack = assemble_context(&db, &embedder(), default_request("debug", tmp.path()))
+        .await
+        .expect("assemble context");
+    let text = &pack.sections[0].items[0].text;
+    assert!(text.contains("Reproduce before patching."));
+    assert!(!text.contains("Long rationale explaining"));
+}
+
+#[tokio::test]
+async fn test_context_excludes_inactive_knowledge_statuses() {
+    let (tmp, db) = new_db();
+    for (id, status) in [
+        ("drawer_candidate", KnowledgeStatus::Candidate),
+        ("drawer_demoted", KnowledgeStatus::Demoted),
+        ("drawer_retired", KnowledgeStatus::Retired),
+        ("drawer_promoted", KnowledgeStatus::Promoted),
+        ("drawer_canonical", KnowledgeStatus::Canonical),
+    ] {
+        insert_fixture(
+            &db,
+            &knowledge_drawer(id, KnowledgeTier::Shu, status, id, "debug status body"),
+        );
+    }
+    let pack = assemble_context(&db, &embedder(), default_request("debug", tmp.path()))
+        .await
+        .expect("assemble context");
+    let ids: Vec<_> = pack.sections[0]
+        .items
+        .iter()
+        .map(|item| item.drawer_id.as_str())
+        .collect();
+    assert!(ids.contains(&"drawer_promoted"));
+    assert!(ids.contains(&"drawer_canonical"));
+    assert!(!ids.contains(&"drawer_candidate"));
+    assert!(!ids.contains(&"drawer_demoted"));
+    assert!(!ids.contains(&"drawer_retired"));
+}
+
+#[tokio::test]
+async fn test_context_omits_evidence_by_default() {
+    let (tmp, db) = new_db();
+    insert_fixture(&db, &evidence_drawer("drawer_evidence", "observed failure"));
+    let pack = assemble_context(
+        &db,
+        &embedder(),
+        default_request("observed failure", tmp.path()),
+    )
+    .await
+    .expect("assemble context");
+    assert!(
+        pack.sections
+            .iter()
+            .all(|section| section.name != "evidence")
+    );
+}
+
+#[tokio::test]
+async fn test_context_include_evidence_adds_evidence_section_after_qi() {
+    let (tmp, db) = new_db();
+    insert_fixture(
+        &db,
+        &knowledge_drawer(
+            "drawer_qi",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Promoted,
+            "Use cargo test.",
+            "observed failure qi",
+        ),
+    );
+    insert_fixture(&db, &evidence_drawer("drawer_evidence", "observed failure"));
+    let mut request = default_request("observed failure", tmp.path());
+    request.include_evidence = true;
+    let pack = assemble_context(&db, &embedder(), request)
+        .await
+        .expect("assemble context");
+    let names: Vec<_> = pack
+        .sections
+        .iter()
+        .map(|section| section.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["qi", "evidence"]);
+    let evidence = pack
+        .sections
+        .iter()
+        .find(|section| section.name == "evidence")
+        .expect("evidence section");
+    assert_eq!(evidence.items[0].text, "observed failure");
+}
+
+#[test]
+fn test_context_json_output_exposes_stable_pack_shape() {
+    let (tmp, db) = setup_cli_home();
+    let mut drawer = knowledge_drawer(
+        "drawer_trigger",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Debug by reproducing.",
+        "debug trigger body",
+    );
+    drawer.trigger_hints = Some(TriggerHints {
+        intent_tags: vec!["debugging".to_string()],
+        workflow_bias: vec!["tdd".to_string()],
+        tool_needs: vec!["cargo-test".to_string()],
+    });
+    insert_fixture(&db, &drawer);
+    let value = run_context_json(tmp.path(), "debug", &[]);
+    assert_eq!(value["query"], "debug");
+    assert_eq!(value["domain"], "project");
+    assert_eq!(value["field"], "general");
+    assert!(value["anchors"].is_array());
+    assert!(value["sections"].is_array());
+    let item = &value["sections"][0]["items"][0];
+    assert_eq!(item["drawer_id"], "drawer_trigger");
+    assert_eq!(
+        item["source_file"],
+        "knowledge://project/context/drawer_trigger"
+    );
+    assert_eq!(item["text"], "Debug by reproducing.");
+    assert_eq!(item["tier"], "shu");
+    assert_eq!(item["status"], "promoted");
+    assert_eq!(item["anchor_kind"], "repo");
+    assert!(item["anchor_id"].is_string());
+    assert_eq!(item["trigger_hints"]["intent_tags"][0], "debugging");
+}
+
+#[tokio::test]
+async fn test_context_domain_and_field_filters_exclude_unrelated_knowledge() {
+    let (tmp, db) = new_db();
+    let mut target = knowledge_drawer(
+        "drawer_skill_debugging",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Skill debugging rule.",
+        "debug",
+    );
+    target.domain = MemoryDomain::Skill;
+    target.field = "debugging".to_string();
+
+    let mut wrong_domain = knowledge_drawer(
+        "drawer_project_debugging",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Project debugging rule.",
+        "debug",
+    );
+    wrong_domain.field = "debugging".to_string();
+
+    let mut wrong_field = knowledge_drawer(
+        "drawer_skill_writing",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Skill writing rule.",
+        "debug",
+    );
+    wrong_field.domain = MemoryDomain::Skill;
+    wrong_field.field = "writing".to_string();
+
+    for drawer in [&target, &wrong_domain, &wrong_field] {
+        insert_fixture(&db, drawer);
+    }
+
+    let mut request = default_request("debug", tmp.path());
+    request.domain = MemoryDomain::Skill;
+    request.field = "debugging".to_string();
+    let pack = assemble_context(&db, &embedder(), request)
+        .await
+        .expect("assemble context");
+    let ids: Vec<_> = pack.sections[0]
+        .items
+        .iter()
+        .map(|item| item.drawer_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["drawer_skill_debugging"]);
+}
+
+#[test]
+fn test_context_empty_result_exits_successfully() {
+    let (tmp, _db) = setup_cli_home();
+    let value = run_context_json(tmp.path(), "no such topic", &[]);
+    assert_eq!(value["sections"].as_array().expect("sections").len(), 0);
+}
+
+#[test]
+fn test_context_rejects_invalid_max_items() {
+    let (tmp, _db) = setup_cli_home();
+    let output = Command::new(mempal_bin())
+        .args(["context", "debug", "--max-items", "0"])
+        .env("HOME", tmp.path())
+        .output()
+        .expect("run mempal context");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--max-items"));
+    assert!(stderr.contains("greater than 0"));
+}
+
+#[tokio::test]
+async fn test_context_assembler_returns_typed_pack() {
+    let (tmp, db) = new_db();
+    insert_fixture(
+        &db,
+        &knowledge_drawer(
+            "drawer_typed",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Typed context pack.",
+            "debug typed body",
+        ),
+    );
+    let pack = assemble_context(&db, &embedder(), default_request("debug", tmp.path()))
+        .await
+        .expect("assemble context");
+    assert_eq!(pack.query, "debug");
+    assert_eq!(pack.sections[0].name, "shu");
+    assert_eq!(pack.sections[0].items[0].drawer_id, "drawer_typed");
+}
+
+#[test]
+fn test_context_assembler_does_not_bump_schema() {
+    let (tmp, db) = setup_cli_home();
+    assert_eq!(db.schema_version().expect("schema"), 7);
+    let before_tables = table_names(&db);
+    let _ = run_context_plain(tmp.path(), "debug", &[]);
+    assert_eq!(db.schema_version().expect("schema"), 7);
+    assert_eq!(table_names(&db), before_tables);
+}
+
+fn table_names(db: &Database) -> Vec<String> {
+    let mut statement = db
+        .conn()
+        .prepare(
+            "SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual table') ORDER BY name",
+        )
+        .expect("prepare table names");
+    statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query table names")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect table names")
+}


### PR DESCRIPTION
## Summary

- Add `mempal context <query>` as the first mind-model runtime context assembler.
- Assemble typed drawers by tier order: `dao_tian -> dao_ren -> shu -> qi`, with evidence opt-in via `--include-evidence`.
- Prefer anchor scope in runtime context as `worktree -> repo -> repo://legacy -> global`, while preserving `global` as `domain=global` only.

## Notes

This is a stacked PR on top of `p13-ingest-identity`, so the intended review scope is P14 only.

`trigger_hints` are exposed as metadata in JSON/plain output, but P14 deliberately does not execute skills or add MCP/REST context surfaces.

## Test Plan

- `agent-spec parse specs/p14-context-assembler.spec.md`
- `agent-spec lint specs/p14-context-assembler.spec.md --min-score 0.7`
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `cargo check --features rest`
