### PR TITLE
P15: expose mind-model context over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P14）
+### 已完成的 Spec（P0-P15）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -61,6 +61,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p13-wake-up-statement.spec.md` | 完成 | wake-up 最小闭环：knowledge drawer 优先按 `statement` 唤醒，evidence 继续按 `content` 唤醒 |
 | `specs/p13-ingest-identity.spec.md` | 完成 | typed/bootstrap ingest `drawer_id` identity parity：MCP / REST / 文件入口统一使用 bootstrap identity components |
 | `specs/p14-context-assembler.spec.md` | 完成 | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
+| `specs/p15-mcp-context.spec.md` | 完成 | `mempal_context` MCP 工具：向 agent runtime 暴露 P14 mind-model context pack |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -84,6 +85,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-23-p13a-implementation.md` — P13A wake-up statement（已完成）
 - `docs/plans/2026-04-23-p13b-implementation.md` — P13B bootstrap ingest identity parity（已完成）
 - `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（已完成）
+- `docs/plans/2026-04-24-p15-mcp-context-implementation.md` — P15 mempal_context MCP tool（已完成）
 
 ### Spec 使用方式
 
@@ -104,12 +106,13 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，11 条规则
 
-## MCP 工具（10 个）
+## MCP 工具（11 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
+| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack（P15） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P14）
+### 已完成的 Spec（P0-P15）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -59,6 +59,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p13-wake-up-statement.spec.md` | 完成 | wake-up 最小闭环：knowledge drawer 优先按 `statement` 唤醒，evidence 继续按 `content` 唤醒 |
 | `specs/p13-ingest-identity.spec.md` | 完成 | typed/bootstrap ingest `drawer_id` identity parity：MCP / REST / 文件入口统一使用 bootstrap identity components |
 | `specs/p14-context-assembler.spec.md` | 完成 | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
+| `specs/p15-mcp-context.spec.md` | 完成 | `mempal_context` MCP 工具：向 agent runtime 暴露 P14 mind-model context pack |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -82,6 +83,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-23-p13a-implementation.md` — P13A wake-up statement（已完成）
 - `docs/plans/2026-04-23-p13b-implementation.md` — P13B bootstrap ingest identity parity（已完成）
 - `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（已完成）
+- `docs/plans/2026-04-24-p15-mcp-context-implementation.md` — P15 mempal_context MCP tool（已完成）
 
 ### Spec 使用方式
 
@@ -102,12 +104,13 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，11 条规则
 
-## MCP 工具（10 个）
+## MCP 工具（11 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
+| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack（P15） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -811,6 +811,7 @@ Limits:
 Implemented Phase-1 runtime surface:
 
 - `mempal context <query>` assembles a runtime context pack from typed drawers
+- `mempal_context` exposes the same pack to MCP-connected agents
 - knowledge sections are ordered as `dao_tian -> dao_ren -> shu -> qi`
 - evidence remains opt-in via `--include-evidence`
 - same-tier items prefer `worktree`, then current `repo`, then `repo://legacy`, then `global`

--- a/docs/plans/2026-04-24-p15-mcp-context-implementation.md
+++ b/docs/plans/2026-04-24-p15-mcp-context-implementation.md
@@ -1,0 +1,36 @@
+# P15 MCP Context Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the P14 mind-model context assembler to MCP clients as `mempal_context`.
+
+**Architecture:** Keep `src/context.rs` as the single assembly source of truth. Add MCP DTOs in `src/mcp/tools.rs`, a thin handler in `src/mcp/server.rs`, and protocol/docs updates so agents discover the new tool.
+
+**Tech Stack:** Rust 2024, rmcp tool macros, serde/schemars DTOs, existing embedder/search/database stack.
+
+---
+
+## Source Spec
+
+- `specs/p15-mcp-context.spec.md`
+
+## Tasks
+
+- [x] Add `ContextRequest` / `ContextResponse` DTOs in `src/mcp/tools.rs`.
+- [x] Add `mempal_context` handler in `src/mcp/server.rs`.
+- [x] Avoid holding `Database` across `.await` by using `assemble_context_with_vector`.
+- [x] Add MCP handler tests for tier ordering, defaults, evidence opt-in, invalid params, no DB side effects, and tool registry.
+- [x] Update `MEMORY_PROTOCOL`, usage docs, AGENTS.md, CLAUDE.md, and mind-model design notes.
+- [x] Run final verification and commit.
+
+## Verification
+
+```bash
+agent-spec parse specs/p15-mcp-context.spec.md
+agent-spec lint specs/p15-mcp-context.spec.md --min-score 0.7
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+cargo check --features rest
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,6 +95,7 @@ Use this when you already know the concepts and just need the right command quic
 | `mempal init <DIR> [--dry-run]` | infer a `wing` and seed initial taxonomy rooms from a project tree |
 | `mempal ingest --wing <WING> <DIR> [--dry-run]` | chunk, embed, and store a project tree |
 | `mempal search <QUERY> [--wing W] [--room R] [--json]` | hybrid search (BM25 + vector + RRF) with tunnel hints |
+| `mempal context <QUERY> [--format json] [--include-evidence]` | assemble mind-model runtime context (`dao_tian -> dao_ren -> shu -> qi`) |
 | `mempal wake-up [--format aaak]` | context refresh sorted by importance (not just recency) |
 | `mempal compress <TEXT>` | format arbitrary text as AAAK |
 | `mempal kg add <S> <P> <O> [--source-drawer ID]` | add a knowledge graph triple |
@@ -434,10 +435,11 @@ mempal serve --mcp
 
 If `mempal` was built without the `rest` feature, plain `mempal serve` behaves the same way.
 
-The MCP server exposes nine tools:
+The MCP server exposes eleven tools:
 
 - `mempal_status` — state + protocol + AAAK spec
 - `mempal_search` — hybrid search (BM25 + vector + RRF) with tunnel hints and AAAK-derived structured signals (`entities` / `topics` / `flags` / `emotions` / `importance_stars`)
+- `mempal_context` — mind-model runtime context pack (`dao_tian -> dao_ren -> shu -> qi`, evidence opt-in)
 - `mempal_ingest` — store memories with optional importance (0-5) and dry_run
 - `mempal_delete` — soft-delete with audit
 - `mempal_taxonomy` — list or edit routing keywords
@@ -445,8 +447,9 @@ The MCP server exposes nine tools:
 - `mempal_tunnels` — cross-wing room discovery
 - `mempal_peek_partner` — read the partner coding agent's live session (Claude ↔ Codex); pure read, never writes to mempal
 - `mempal_cowork_push` — send a short handoff message (≤ 8 KB) to the partner agent's inbox; delivered at the partner's next UserPromptSubmit via a drain hook
+- `mempal_fact_check` — offline contradiction detection against KG triples and known entities
 
-The server also embeds MEMORY_PROTOCOL (10 behavioral rules) in the MCP `initialize.instructions` field so any MCP client learns the workflow on connect — zero configuration.
+The server also embeds MEMORY_PROTOCOL (behavioral rules) in the MCP `initialize.instructions` field so any MCP client learns the workflow on connect — zero configuration.
 
 Example request shapes:
 

--- a/specs/p15-mcp-context.spec.md
+++ b/specs/p15-mcp-context.spec.md
@@ -1,0 +1,149 @@
+spec: task
+name: "P15: mempal_context MCP tool"
+inherits: project
+tags: [memory, context, mind-model, mcp]
+estimate: 0.5d
+---
+
+## Intent
+
+P14 已经实现 CLI-first `mempal context` 和核心 `assemble_context`。但 agent runtime 主要通过 MCP 使用 mempal；如果没有 MCP surface，agent 仍然只能调用 `mempal_search`，无法直接获得按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 组装的 mind-model context pack。
+
+本任务新增 `mempal_context` MCP 工具，复用 P14 assembler，不改变 CLI、search、schema 或 context 排序规则。
+
+## Decisions
+
+- 新增 MCP tool：`mempal_context`
+- Request 字段与 P14 CLI 对齐：
+  - `query: String`
+  - `field: Option<String>`，默认 `general`
+  - `domain: Option<String>`，默认 `project`
+  - `cwd: Option<String>`，默认当前进程 cwd
+  - `include_evidence: Option<bool>`，默认 `false`
+  - `max_items: Option<usize>`，默认 `12`
+- Response 是 machine-readable context pack：
+  - `query`
+  - `domain`
+  - `field`
+  - `anchors`
+  - `sections`
+  - 每个 item 包含 `drawer_id`, `source_file`, `text`, `tier`, `status`, `anchor_kind`, `anchor_id`, optional `parent_anchor_id`, optional `trigger_hints`
+- `mempal_context` 必须复用 `src/context.rs::assemble_context`
+- `max_items == 0` 返回 MCP invalid params
+- unsupported `domain` 返回 MCP invalid params
+- invalid `cwd` / anchor derivation failure 返回 MCP invalid params
+- embedder/search/db failures 返回 MCP internal error
+- `mempal_context` 是纯 read；不得写 drawer、vector、triple、tunnel、inbox 或 audit log
+- 不改变 `mempal_search` request/response contract
+- 不新增 CLI flags
+- 不 bump schema
+
+## Boundaries
+
+### Allowed Changes
+- `src/mcp/tools.rs`
+- `src/mcp/server.rs`
+- `src/core/protocol.rs`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `tests/**`
+
+### Forbidden
+- 不要修改 `src/context.rs` 的 assembly rules，除非只是为了 MCP 复用暴露必要 helper
+- 不要修改 `drawers` / `drawer_vectors` / `triples` / `tunnels` schema
+- 不要新增 REST endpoint
+- 不要改变 `mempal search` 或 MCP `mempal_search`
+- 不要实现 skill trigger execution
+- 不要实现 promote / demote / publish_anchor lifecycle
+- 不要集成 `research-rs`
+- 不要引入新依赖
+
+## Out of Scope
+
+- REST `context` API
+- automatic skill trigger orchestration
+- runtime injection hooks
+- token-budget optimizer beyond `max_items`
+- evidence-to-knowledge distillation
+- Phase-2 `knowledge_cards`
+- research-rs pipeline
+
+## Completion Criteria
+
+Scenario: MCP context returns tier-ordered knowledge sections
+  Test:
+    Filter: test_mcp_context_returns_tier_ordered_sections
+    Level: integration
+  Given 数据库中存在 active knowledge drawers，tier 分别为 `dao_tian`, `dao_ren`, `shu`, `qi`
+  And 每条 drawer 都匹配 query `"debug failing build"`
+  When MCP 客户端调用 `mempal_context(query="debug failing build")`
+  Then response.sections 按 `dao_tian`, `dao_ren`, `shu`, `qi` 顺序出现
+  And 每条 item 都包含 `drawer_id`
+  And 每条 item 都包含 `source_file`
+
+Scenario: MCP context defaults match CLI context defaults
+  Test:
+    Filter: test_mcp_context_defaults_match_cli_context_defaults
+    Level: integration
+  Given query 为 `"debug"`
+  Given 数据库中存在一个 matching promoted `shu` knowledge drawer
+  When MCP 客户端调用 `mempal_context` 只传 `query`
+  Then response.domain == `"project"`
+  And response.field == `"general"`
+  And response.sections 不包含 `evidence`
+  And response.anchors 非空
+  And response.sections 包含该 `shu` item
+
+Scenario: MCP context include_evidence appends evidence section
+  Test:
+    Filter: test_mcp_context_include_evidence_appends_evidence_section
+    Level: integration
+  Given query 为 `"observed failure"`
+  Given 数据库中存在 matching `qi` knowledge drawer
+  And 数据库中存在 matching evidence drawer
+  When MCP 客户端调用 `mempal_context(query="observed failure", include_evidence=true)`
+  Then response.sections 包含 `qi`
+  And response.sections 包含 `evidence`
+  And `evidence` section 排在 `qi` section 后
+
+Scenario: MCP context rejects max_items zero
+  Test:
+    Filter: test_mcp_context_rejects_max_items_zero
+    Level: integration
+  Given query 为 `"debug"`
+  Given 任意数据库状态
+  When MCP 客户端调用 `mempal_context(query="debug", max_items=0)`
+  Then 返回 MCP invalid params error
+  And 不执行 context assembly
+
+Scenario: MCP context rejects unsupported domain
+  Test:
+    Filter: test_mcp_context_rejects_unsupported_domain
+    Level: integration
+  Given query 为 `"debug"`
+  And domain 为 `"invalid"`
+  Given 任意数据库状态
+  When MCP 客户端调用 `mempal_context(query="debug", domain="invalid")`
+  Then 返回 MCP invalid params error
+
+Scenario: MCP context has no database side effects
+  Test:
+    Filter: test_mcp_context_has_no_db_side_effects
+    Level: integration
+  Given query 为 `"debug"`
+  Given 数据库中存在 matching knowledge drawer
+  And 记录调用前 schema_version, drawer_count, triple_count, taxonomy_count, scope_counts
+  When MCP 客户端连续调用 `mempal_context` 三次
+  Then 调用后的 schema_version, drawer_count, triple_count, taxonomy_count, scope_counts 与调用前完全一致
+  And MCP `mempal_search` request/response contract 不变
+
+Scenario: MCP tool registry includes mempal_context
+  Test:
+    Filter: test_mcp_tool_registry_includes_mempal_context
+    Level: unit
+  Given MCP server tool registry 已生成
+  When 枚举工具名称
+  Then 包含 `mempal_context`
+  And `mempal_context` description 提到 `dao_tian -> dao_ren -> shu -> qi`

--- a/src/context.rs
+++ b/src/context.rs
@@ -106,7 +106,6 @@ pub async fn assemble_context<E: Embedder + ?Sized>(
     embedder: &E,
     request: ContextRequest,
 ) -> Result<ContextPack> {
-    let anchors = context_anchors(&request)?;
     let query_vector = embedder
         .embed(&[request.query.as_str()])
         .await
@@ -115,6 +114,15 @@ pub async fn assemble_context<E: Embedder + ?Sized>(
         .next()
         .ok_or(ContextError::MissingQueryVector)?;
 
+    assemble_context_with_vector(db, request, &query_vector)
+}
+
+pub fn assemble_context_with_vector(
+    db: &Database,
+    request: ContextRequest,
+    query_vector: &[f32],
+) -> Result<ContextPack> {
+    let anchors = context_anchors(&request)?;
     let route = RouteDecision {
         wing: None,
         room: None,
@@ -143,7 +151,7 @@ pub async fn assemble_context<E: Embedder + ?Sized>(
                     db,
                     CandidateQuery {
                         request: &request,
-                        query_vector: &query_vector,
+                        query_vector,
                         route: &route,
                         anchor,
                         memory_kind: MemoryKind::Knowledge,
@@ -183,7 +191,7 @@ pub async fn assemble_context<E: Embedder + ?Sized>(
                 db,
                 CandidateQuery {
                     request: &request,
-                    query_vector: &query_vector,
+                    query_vector,
                     route: &route,
                     anchor,
                     memory_kind: MemoryKind::Evidence,

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -40,6 +40,15 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    call mempal_tunnels with action="list" to discover related rooms across
    wings when context may live in another project.
 
+3b. USE MIND-MODEL CONTEXT FOR GUIDANCE
+   When you need ordered operating guidance rather than raw evidence search,
+   call mempal_context. It assembles typed knowledge in the intended runtime
+   order: dao_tian -> dao_ren -> shu -> qi, with evidence opt-in. Use this
+   before choosing a workflow or skill when the user asks "how should we
+   approach this?" or when a task benefits from high-level principles plus
+   concrete tool bindings. Treat trigger_hints as metadata only — they bias
+   skill choice but do not execute skills for you.
+
 3a. TRANSLATE QUERIES TO ENGLISH
    The default embedding model is a multilingual distillation (model2vec) but
    still performs best with English queries. Non-English queries may miss
@@ -136,6 +145,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
+  mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi)
   mempal_ingest        — save a new drawer (wing required, room optional, importance 0-5)
   mempal_delete        — soft-delete a drawer by ID
   mempal_taxonomy      — list or edit routing keywords
@@ -192,6 +202,14 @@ mod tests {
         assert!(
             MEMORY_PROTOCOL.contains("mempal_cowork_push"),
             "MEMORY_PROTOCOL must mention mempal_cowork_push in TOOLS list"
+        );
+    }
+
+    #[test]
+    fn contains_context_tool_name() {
+        assert!(
+            MEMORY_PROTOCOL.contains("mempal_context"),
+            "MEMORY_PROTOCOL must mention mempal_context in TOOLS list"
         );
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use crate::context::assemble_context_with_vector;
 use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
@@ -34,12 +35,12 @@ use rmcp::{
 use serde_json::Value;
 
 use super::tools::{
-    CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DuplicateWarning,
-    FactCheckRequest, FactCheckResponse, IngestRequest, IngestResponse, KgRequest, KgResponse,
-    KgStatsDto, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest,
-    SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest,
-    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
-    TunnelsResponse,
+    ContextRequest, ContextResponse, CoworkPushRequest, CoworkPushResponse, DeleteRequest,
+    DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, IngestRequest,
+    IngestResponse, KgRequest, KgResponse, KgStatsDto, PeekMessageDto, PeekPartnerRequest,
+    PeekPartnerResponse, ScopeCount, SearchRequest, SearchResponse, SearchResultDto,
+    StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto,
+    TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -101,6 +102,17 @@ impl MempalMcpServer {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         self.mempal_search(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn context_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<ContextResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_context(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -584,6 +596,70 @@ impl MempalMcpServer {
                 .map(SearchResultDto::with_signals_from_result)
                 .collect(),
         }))
+    }
+
+    #[tool(
+        name = "mempal_context",
+        description = "Assemble a mind-model runtime context pack from typed memory. Use this when you need ordered guidance rather than raw search results: dao_tian -> dao_ren -> shu -> qi, with evidence opt-in. Returns source-backed items with drawer_id/source_file citations and trigger_hints metadata, but never executes skills."
+    )]
+    async fn mempal_context(
+        &self,
+        Parameters(request): Parameters<ContextRequest>,
+    ) -> std::result::Result<Json<ContextResponse>, ErrorData> {
+        let max_items = request.max_items.unwrap_or(12);
+        if max_items == 0 {
+            return Err(ErrorData::invalid_params(
+                "max_items must be greater than 0",
+                None,
+            ));
+        }
+
+        let domain = parse_domain(request.domain.as_deref())?.unwrap_or(MemoryDomain::Project);
+        let cwd = match request.cwd.as_deref() {
+            Some(value) if !value.trim().is_empty() => PathBuf::from(value),
+            Some(_) => {
+                return Err(ErrorData::invalid_params(
+                    "cwd must not be empty when provided",
+                    None,
+                ));
+            }
+            None => std::env::current_dir().map_err(|error| {
+                ErrorData::internal_error(
+                    format!("failed to read current directory: {error}"),
+                    None,
+                )
+            })?,
+        };
+
+        let embedder = self.embedder_factory.build().await.map_err(|error| {
+            ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
+        })?;
+        let query_vector = embedder
+            .embed(&[request.query.as_str()])
+            .await
+            .map_err(|error| ErrorData::internal_error(format!("embedding failed: {error}"), None))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| ErrorData::internal_error("embedder returned no query vector", None))?;
+
+        let db = self.open_db()?;
+        let pack = assemble_context_with_vector(
+            &db,
+            crate::context::ContextRequest {
+                query: request.query,
+                domain,
+                field: request
+                    .field
+                    .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
+                cwd,
+                include_evidence: request.include_evidence.unwrap_or(false),
+                max_items,
+            },
+            &query_vector,
+        )
+        .map_err(context_error)?;
+
+        Ok(Json(ContextResponse::from(pack)))
     }
 
     #[tool(
@@ -1284,6 +1360,20 @@ fn fact_check_error(error: crate::factcheck::FactCheckError) -> ErrorData {
     }
 }
 
+fn context_error(error: crate::context::ContextError) -> ErrorData {
+    match error {
+        crate::context::ContextError::DeriveAnchor(_) => {
+            ErrorData::invalid_params(error.to_string(), None)
+        }
+        crate::context::ContextError::EmbedQuery(_)
+        | crate::context::ContextError::MissingQueryVector
+        | crate::context::ContextError::Search(_)
+        | crate::context::ContextError::LoadDrawer(_) => {
+            ErrorData::internal_error(format!("context assembly failed: {error}"), None)
+        }
+    }
+}
+
 const DEDUP_THRESHOLD: f32 = 0.85;
 
 fn check_semantic_duplicate(
@@ -1513,6 +1603,48 @@ mod tests {
             .expect("insert vector");
     }
 
+    fn insert_knowledge_drawer(
+        db_path: &Path,
+        id: &str,
+        tier: KnowledgeTier,
+        status: KnowledgeStatus,
+        statement: &str,
+        content: &str,
+    ) {
+        let db = Database::open(db_path).expect("open db");
+        let drawer = Drawer {
+            id: id.to_string(),
+            content: content.to_string(),
+            wing: "mempal".to_string(),
+            room: Some("context".to_string()),
+            source_file: Some(format!("knowledge://project/context/{id}")),
+            source_type: SourceType::Manual,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            normalize_version: 1,
+            importance: 3,
+            memory_kind: MemoryKind::Knowledge,
+            domain: MemoryDomain::Project,
+            field: anchor::DEFAULT_FIELD.to_string(),
+            anchor_kind: AnchorKind::Repo,
+            anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+            parent_anchor_id: None,
+            provenance: None,
+            statement: Some(statement.to_string()),
+            tier: Some(tier),
+            status: Some(status),
+            supporting_refs: vec!["drawer_supporting_ev".to_string()],
+            counterexample_refs: Vec::new(),
+            teaching_refs: Vec::new(),
+            verification_refs: Vec::new(),
+            scope_constraints: None,
+            trigger_hints: None,
+        };
+        db.insert_drawer(&drawer).expect("insert knowledge drawer");
+        db.insert_vector(id, &[0.1, 0.2, 0.3])
+            .expect("insert vector");
+    }
+
     fn insert_triple(
         db_path: &Path,
         subject: &str,
@@ -1657,6 +1789,209 @@ mod tests {
         assert_eq!(
             db.schema_version().expect("schema version"),
             baseline_schema
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_returns_tier_ordered_sections() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_qi",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Promoted,
+            "Use cargo test.",
+            "debug failing build qi",
+        );
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_shu",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Reproduce before patching.",
+            "debug failing build shu",
+        );
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_dao_ren",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Promoted,
+            "Software changes need executable feedback.",
+            "debug failing build dao ren",
+        );
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_dao_tian",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Evidence precedes assertion.",
+            "debug failing build dao tian",
+        );
+
+        let response = server
+            .context_json_for_test(serde_json::json!({
+                "query": "debug failing build"
+            }))
+            .await
+            .expect("context should succeed");
+        let names = response
+            .sections
+            .iter()
+            .map(|section| section.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["dao_tian", "dao_ren", "shu", "qi"]);
+        for section in response.sections {
+            assert_eq!(section.items.len(), 1);
+            assert!(!section.items[0].drawer_id.is_empty());
+            assert!(!section.items[0].source_file.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_defaults_match_cli_context_defaults() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_shu",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Debug by reproducing.",
+            "debug default body",
+        );
+
+        let response = server
+            .context_json_for_test(serde_json::json!({ "query": "debug" }))
+            .await
+            .expect("context should succeed");
+        assert_eq!(response.domain, "project");
+        assert_eq!(response.field, "general");
+        assert!(!response.anchors.is_empty());
+        assert!(
+            response
+                .sections
+                .iter()
+                .all(|section| section.name != "evidence")
+        );
+        assert_eq!(response.sections[0].name, "shu");
+        assert_eq!(response.sections[0].items[0].drawer_id, "drawer_shu");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_include_evidence_appends_evidence_section() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_qi",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Promoted,
+            "Use cargo test.",
+            "observed failure qi",
+        );
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "observed failure",
+            "mempal",
+            Some("context"),
+            "/tmp/evidence.md",
+            2,
+        );
+
+        let response = server
+            .context_json_for_test(serde_json::json!({
+                "query": "observed failure",
+                "include_evidence": true
+            }))
+            .await
+            .expect("context should succeed");
+        let names = response
+            .sections
+            .iter()
+            .map(|section| section.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["qi", "evidence"]);
+        assert_eq!(response.sections[1].items[0].drawer_id, "drawer_evidence");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_rejects_max_items_zero() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let error = server
+            .context_json_for_test(serde_json::json!({
+                "query": "debug",
+                "max_items": 0
+            }))
+            .await
+            .expect_err("max_items=0 should reject");
+        assert!(error.to_string().contains("max_items"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_rejects_unsupported_domain() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let error = server
+            .context_json_for_test(serde_json::json!({
+                "query": "debug",
+                "domain": "invalid"
+            }))
+            .await
+            .expect_err("invalid domain should reject");
+        assert!(error.to_string().contains("domain"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_has_no_db_side_effects() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_shu",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Debug by reproducing.",
+            "debug side-effect body",
+        );
+
+        let db = Database::open(&db_path).expect("open db");
+        let baseline_schema = db.schema_version().expect("schema");
+        let baseline_drawers = db.drawer_count().expect("drawers");
+        let baseline_triples = db.triple_count().expect("triples");
+        let baseline_taxonomy = db.taxonomy_count().expect("taxonomy");
+        let baseline_scopes = db.scope_counts().expect("scopes");
+
+        for _ in 0..3 {
+            let response = server
+                .context_json_for_test(serde_json::json!({ "query": "debug" }))
+                .await
+                .expect("context should succeed");
+            assert!(!response.sections.is_empty());
+        }
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.schema_version().expect("schema"), baseline_schema);
+        assert_eq!(db.drawer_count().expect("drawers"), baseline_drawers);
+        assert_eq!(db.triple_count().expect("triples"), baseline_triples);
+        assert_eq!(db.taxonomy_count().expect("taxonomy"), baseline_taxonomy);
+        assert_eq!(db.scope_counts().expect("scopes"), baseline_scopes);
+
+        let search = run_search(&server, "debug", None, None, 1).await;
+        assert_eq!(search.results[0].drawer_id, "drawer_shu");
+        assert!(!search.results[0].content.is_empty());
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_includes_mempal_context() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let context_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_context")
+            .expect("mempal_context tool exists");
+        assert!(
+            context_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("dao_tian -> dao_ren -> shu -> qi")
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,3 +1,4 @@
+use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
     NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry, TunnelEndpoint,
@@ -52,6 +53,54 @@ pub struct SearchRequest {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct SearchResponse {
     pub results: Vec<SearchResultDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct ContextRequest {
+    pub query: String,
+    pub field: Option<String>,
+    pub domain: Option<String>,
+    pub cwd: Option<String>,
+    pub include_evidence: Option<bool>,
+    pub max_items: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ContextResponse {
+    pub query: String,
+    pub domain: String,
+    pub field: String,
+    pub anchors: Vec<ContextAnchorDto>,
+    pub sections: Vec<ContextSectionDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ContextAnchorDto {
+    pub anchor_kind: String,
+    pub anchor_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ContextSectionDto {
+    pub name: String,
+    pub items: Vec<ContextItemDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ContextItemDto {
+    pub drawer_id: String,
+    pub source_file: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    pub anchor_kind: String,
+    pub anchor_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_anchor_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_hints: Option<TriggerHintsDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -154,7 +203,7 @@ pub struct IngestRequest {
     pub cwd: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct TriggerHintsDto {
     pub intent_tags: Vec<String>,
     pub workflow_bias: Vec<String>,
@@ -484,6 +533,72 @@ impl SearchResultDto {
             anchor_kind: anchor_kind_slug(&value.anchor_kind).to_string(),
             anchor_id: value.anchor_id,
             parent_anchor_id: value.parent_anchor_id,
+        }
+    }
+}
+
+impl From<ContextPack> for ContextResponse {
+    fn from(value: ContextPack) -> Self {
+        Self {
+            query: value.query,
+            domain: domain_slug(&value.domain).to_string(),
+            field: value.field,
+            anchors: value
+                .anchors
+                .into_iter()
+                .map(|anchor| ContextAnchorDto {
+                    anchor_kind: anchor_kind_slug(&anchor.anchor_kind).to_string(),
+                    anchor_id: anchor.anchor_id,
+                })
+                .collect(),
+            sections: value
+                .sections
+                .into_iter()
+                .map(ContextSectionDto::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<ContextSection> for ContextSectionDto {
+    fn from(value: ContextSection) -> Self {
+        Self {
+            name: value.name,
+            items: value.items.into_iter().map(ContextItemDto::from).collect(),
+        }
+    }
+}
+
+impl From<ContextItem> for ContextItemDto {
+    fn from(value: ContextItem) -> Self {
+        Self {
+            drawer_id: value.drawer_id,
+            source_file: value.source_file,
+            text: value.text,
+            tier: value
+                .tier
+                .as_ref()
+                .map(knowledge_tier_slug)
+                .map(str::to_string),
+            status: value
+                .status
+                .as_ref()
+                .map(knowledge_status_slug)
+                .map(str::to_string),
+            anchor_kind: anchor_kind_slug(&value.anchor_kind).to_string(),
+            anchor_id: value.anchor_id,
+            parent_anchor_id: value.parent_anchor_id,
+            trigger_hints: value.trigger_hints.map(TriggerHintsDto::from),
+        }
+    }
+}
+
+impl From<crate::core::types::TriggerHints> for TriggerHintsDto {
+    fn from(value: crate::core::types::TriggerHints) -> Self {
+        Self {
+            intent_tags: value.intent_tags,
+            workflow_bias: value.workflow_bias,
+            tool_needs: value.tool_needs,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `mempal_context` MCP tool for P14 mind-model context packs.
- Reuse `src/context.rs` as the assembly source of truth via `assemble_context_with_vector`.
- Return ordered `dao_tian -> dao_ren -> shu -> qi` sections with evidence opt-in and citation-backed items.
- Update MEMORY_PROTOCOL, usage docs, AGENTS/CLAUDE, mind-model design notes, spec, and implementation plan.

## Verification

- `agent-spec parse specs/p15-mcp-context.spec.md`
- `agent-spec lint specs/p15-mcp-context.spec.md --min-score 0.7`
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `cargo check --features rest`
