### PR TITLE
P17: add bootstrap knowledge lifecycle CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P16）
+### 已完成的 Spec（P0-P17）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -63,6 +63,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p14-context-assembler.spec.md` | 完成 | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
 | `specs/p15-mcp-context.spec.md` | 完成 | `mempal_context` MCP 工具：向 agent runtime 暴露 P14 mind-model context pack |
 | `specs/p16-context-skill-guidance.spec.md` | 完成 | context-guided skill selection protocol：`mempal_context` 辅助 workflow/skill/tool 选择，但 `trigger_hints` 只做 bias、不自动执行 |
+| `specs/p17-knowledge-lifecycle.spec.md` | 完成 | bootstrap knowledge lifecycle CLI：`mempal knowledge promote/demote` 受约束更新 knowledge drawer status 与 refs，并写 audit |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -88,6 +89,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（已完成）
 - `docs/plans/2026-04-24-p15-mcp-context-implementation.md` — P15 mempal_context MCP tool（已完成）
 - `docs/plans/2026-04-24-p16-context-skill-guidance-implementation.md` — P16 context-guided skill selection protocol（已完成）
+- `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md` — P17 bootstrap knowledge lifecycle CLI（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P16）
+### 已完成的 Spec（P0-P17）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -61,6 +61,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p14-context-assembler.spec.md` | 完成 | mind-model runtime assembler：`mempal context` 按 `dao_tian -> dao_ren -> shu -> qi -> evidence` 和 `worktree -> repo -> global` 组装 context pack |
 | `specs/p15-mcp-context.spec.md` | 完成 | `mempal_context` MCP 工具：向 agent runtime 暴露 P14 mind-model context pack |
 | `specs/p16-context-skill-guidance.spec.md` | 完成 | context-guided skill selection protocol：`mempal_context` 辅助 workflow/skill/tool 选择，但 `trigger_hints` 只做 bias、不自动执行 |
+| `specs/p17-knowledge-lifecycle.spec.md` | 完成 | bootstrap knowledge lifecycle CLI：`mempal knowledge promote/demote` 受约束更新 knowledge drawer status 与 refs，并写 audit |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -86,6 +87,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p14-context-assembler-implementation.md` — P14 mind-model runtime context assembler（已完成）
 - `docs/plans/2026-04-24-p15-mcp-context-implementation.md` — P15 mempal_context MCP tool（已完成）
 - `docs/plans/2026-04-24-p16-context-skill-guidance-implementation.md` — P16 context-guided skill selection protocol（已完成）
+- `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md` — P17 bootstrap knowledge lifecycle CLI（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -819,6 +819,8 @@ Implemented Phase-1 runtime surface:
 - `trigger_hints` are exposed as metadata only; they do not directly execute skills
 - MCP protocol guidance consumes context in order: read `dao_tian` and `dao_ren` for judgment, use `shu` to bias workflow / skill choice, and use `qi` to bias concrete tool choice
 - memory hints never override system, user, repo, or client-native skill rules
+- bootstrap lifecycle CLI supports manual `promote` / `demote` on existing knowledge drawers by updating status plus verification / counterexample refs and writing audit entries
+- lifecycle updates are metadata-only in Stage 1; they do not rewrite content, re-embed vectors, or create Phase-2 knowledge cards
 
 ### Phase 2: Knowledge Card Extraction
 

--- a/docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md
+++ b/docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md
@@ -1,0 +1,33 @@
+# P17 Knowledge Lifecycle Implementation Plan
+
+**Goal:** Add the smallest bootstrap lifecycle surface for knowledge drawers: manual promote / demote through CLI, using existing metadata fields and audit log.
+
+**Architecture:** Keep lifecycle as a CLI-only metadata update in P17. Add a narrow DB helper that updates `status`, `verification_refs`, and `counterexample_refs` without touching content, FTS, vectors, schema, or context assembly rules.
+
+**Tech Stack:** Rust 2024, clap subcommands, rusqlite metadata update, existing `audit.jsonl`, integration tests under `tests/`.
+
+## Source Spec
+
+- `specs/p17-knowledge-lifecycle.spec.md`
+
+## Tasks
+
+- [x] Add `mempal knowledge promote|demote` CLI commands.
+- [x] Add DB helper for metadata-only lifecycle updates.
+- [x] Enforce knowledge-only, tier/status, target-status, and required-ref gates.
+- [x] Append lifecycle audit entries.
+- [x] Add integration tests for promote, demote, invalid drawer kind, invalid tier/status, audit, and schema/vector stability.
+- [x] Update AGENTS.md, CLAUDE.md, usage docs, and mind-model design notes.
+- [x] Run final verification and commit.
+
+## Verification
+
+```bash
+agent-spec parse specs/p17-knowledge-lifecycle.spec.md
+agent-spec lint specs/p17-knowledge-lifecycle.spec.md --min-score 0.7
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+cargo check --features rest
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,6 +96,8 @@ Use this when you already know the concepts and just need the right command quic
 | `mempal ingest --wing <WING> <DIR> [--dry-run]` | chunk, embed, and store a project tree |
 | `mempal search <QUERY> [--wing W] [--room R] [--json]` | hybrid search (BM25 + vector + RRF) with tunnel hints |
 | `mempal context <QUERY> [--format json] [--include-evidence]` | assemble mind-model runtime context (`dao_tian -> dao_ren -> shu -> qi`) |
+| `mempal knowledge promote <ID> --status promoted --verification-ref <ID> --reason ...` | promote bootstrap knowledge into active runtime use |
+| `mempal knowledge demote <ID> --status demoted --evidence-ref <ID> --reason ... --reason-type contradicted` | demote or retire contradicted / obsolete bootstrap knowledge |
 | `mempal wake-up [--format aaak]` | context refresh sorted by importance (not just recency) |
 | `mempal compress <TEXT>` | format arbitrary text as AAAK |
 | `mempal kg add <S> <P> <O> [--source-drawer ID]` | add a knowledge graph triple |
@@ -172,6 +174,28 @@ Every ingest appends a JSONL audit record to:
 ```text
 ~/.mempal/audit.jsonl
 ```
+
+### Bootstrap Knowledge Lifecycle
+
+P17 adds manual lifecycle commands for Stage-1 knowledge drawers:
+
+```bash
+mempal knowledge promote drawer_knowledge \
+  --status promoted \
+  --verification-ref drawer_evidence \
+  --reason "validated across repeated runs" \
+  --reviewer "human"
+```
+
+```bash
+mempal knowledge demote drawer_knowledge \
+  --status demoted \
+  --evidence-ref drawer_counterexample \
+  --reason "new evidence contradicts this heuristic" \
+  --reason-type contradicted
+```
+
+These commands only update existing `memory_kind=knowledge` drawers. They do not create knowledge, change content, re-embed vectors, bump schema, or add Phase-2 `knowledge_cards`. Successful lifecycle changes append a JSONL audit entry with old/new status, refs, reason, and reviewer or reason type.
 
 ### 4. Search
 

--- a/specs/p17-knowledge-lifecycle.spec.md
+++ b/specs/p17-knowledge-lifecycle.spec.md
@@ -1,0 +1,138 @@
+spec: task
+name: "P17: bootstrap knowledge lifecycle CLI"
+inherits: project
+tags: [memory, knowledge, lifecycle, cli]
+estimate: 0.5d
+---
+
+## Intent
+
+P12-P16 已经把 knowledge drawer、runtime context、MCP context 和 skill guidance 串成闭环，但 knowledge 的 `status` 仍只能在 ingest 时一次性写入。P17 在 bootstrap drawer 架构上补最小 lifecycle CLI：允许人工或 agent 在有证据引用的前提下 promote / demote 现有 knowledge drawer，同时保持 context 只唤醒 active status。
+
+本任务不进入 Phase-2 `knowledge_cards`，不新增 schema，只在现有 drawer metadata 上做受约束的状态变更，并把 reason / reviewer 写入现有 JSONL audit log。
+
+## Decisions
+
+- 新增 CLI command group：`mempal knowledge`
+- 新增 `mempal knowledge promote <drawer_id>`：
+  - required `--status promoted|canonical`
+  - required one or more `--verification-ref <drawer_id>`
+  - required `--reason <text>`
+  - optional `--reviewer <text>`
+  - appends verification refs to `verification_refs` with stable de-duplication
+  - updates `status`
+- 新增 `mempal knowledge demote <drawer_id>`:
+  - required `--status demoted|retired`
+  - required one or more `--evidence-ref <drawer_id>`
+  - required `--reason <text>`
+  - required `--reason-type contradicted|obsolete|superseded|out_of_scope|unsafe`
+  - appends evidence refs to `counterexample_refs` with stable de-duplication
+  - updates `status`
+- Lifecycle commands only accept `memory_kind=knowledge`
+- Lifecycle commands reject missing drawer ids instead of creating new drawers
+- Lifecycle commands enforce existing tier/status policy:
+  - `dao_tian`: `canonical | demoted`
+  - `dao_ren`: `candidate | promoted | demoted | retired`
+  - `shu`: `promoted | demoted | retired`
+  - `qi`: `candidate | promoted | demoted | retired`
+- Promotion status is limited to `promoted | canonical`
+- Demotion status is limited to `demoted | retired`
+- Lifecycle commands do not change content, statement, tier, anchor metadata, vectors, FTS, or schema
+- Lifecycle commands append an audit entry with command, drawer_id, old_status, new_status, refs, reason, and reviewer / reason_type
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/db.rs`
+- `src/main.rs`
+- `tests/**`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `specs/p17-knowledge-lifecycle.spec.md`
+- `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md`
+
+### Forbidden
+- Do not add tables, columns, triggers, or migrations
+- Do not add a `knowledge_cards` implementation
+- Do not add MCP / REST lifecycle endpoints
+- Do not change `mempal_context` response schema
+- Do not change default context active status rules
+- Do not re-embed or mutate vectors
+- Do not rewrite source content
+- Do not introduce new dependencies
+
+## Out of Scope
+
+- automatic promotion or demotion
+- evaluator scoring
+- human review UI
+- Phase-2 `knowledge_cards`
+- lifecycle event table
+- MCP lifecycle tool
+- REST lifecycle endpoint
+- research-rs integration
+
+## Completion Criteria
+
+Scenario: promote candidate knowledge to active context
+  Test:
+    Filter: test_cli_knowledge_promote_updates_status_and_verification_refs
+    Level: integration
+  Given a `dao_ren` knowledge drawer with status `candidate`
+  And a supporting evidence drawer exists
+  When running `mempal knowledge promote <id> --status promoted --verification-ref <evidence_id> --reason "validated in test" --reviewer "human"`
+  Then the command exits successfully
+  And the drawer status becomes `promoted`
+  And `verification_refs` contains `<evidence_id>`
+  And default `mempal context` includes the promoted drawer
+
+Scenario: demote active knowledge out of default context
+  Test:
+    Filter: test_cli_knowledge_demote_updates_status_and_counterexample_refs
+    Level: integration
+  Given a `shu` knowledge drawer with status `promoted`
+  And a counterexample evidence drawer exists
+  When running `mempal knowledge demote <id> --status demoted --evidence-ref <evidence_id> --reason "contradicted in test" --reason-type contradicted`
+  Then the command exits successfully
+  And the drawer status becomes `demoted`
+  And `counterexample_refs` contains `<evidence_id>`
+  And default `mempal context` excludes the demoted drawer
+
+Scenario: lifecycle rejects evidence drawers
+  Test:
+    Filter: test_cli_knowledge_lifecycle_rejects_evidence_drawer
+    Level: integration
+  Given an evidence drawer exists
+  When running `mempal knowledge promote <evidence_id> --status promoted --verification-ref drawer_verify --reason "bad"`
+  Then the command fails
+  And the error says lifecycle requires a knowledge drawer
+
+Scenario: lifecycle enforces tier status policy
+  Test:
+    Filter: test_cli_knowledge_lifecycle_rejects_invalid_tier_status
+    Level: integration
+  Given a `dao_tian` knowledge drawer with status `canonical`
+  When running `mempal knowledge promote <id> --status promoted --verification-ref drawer_verify --reason "bad"`
+  Then the command fails
+  And the error says `dao_tian` only allows `canonical` or `demoted`
+
+Scenario: lifecycle writes audit entries
+  Test:
+    Filter: test_cli_knowledge_lifecycle_writes_audit_entry
+    Level: integration
+  Given a knowledge drawer exists
+  When running a successful lifecycle command with reason and reviewer
+  Then `~/.mempal/audit.jsonl` receives one lifecycle entry
+  And the entry includes old_status, new_status, refs, reason, and reviewer
+
+Scenario: lifecycle does not bump schema or rewrite vectors
+  Test:
+    Filter: test_knowledge_lifecycle_does_not_bump_schema_or_rewrite_vectors
+    Level: integration
+  Given a knowledge drawer exists with an embedding vector
+  And the current schema version is recorded
+  When running a successful lifecycle command
+  Then the schema version remains unchanged
+  And the vector row for that drawer still exists

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -673,6 +673,33 @@ impl Database {
         }
     }
 
+    pub fn update_knowledge_lifecycle(
+        &self,
+        drawer_id: &str,
+        status: &KnowledgeStatus,
+        verification_refs: &[String],
+        counterexample_refs: &[String],
+    ) -> Result<bool, DbError> {
+        let affected = self.conn.execute(
+            r#"
+            UPDATE drawers
+            SET status = ?2,
+                verification_refs = ?3,
+                counterexample_refs = ?4
+            WHERE id = ?1
+              AND deleted_at IS NULL
+              AND memory_kind = 'knowledge'
+            "#,
+            params![
+                drawer_id,
+                knowledge_status_as_str(status),
+                encode_json(verification_refs)?,
+                encode_json(counterexample_refs)?,
+            ],
+        )?;
+        Ok(affected > 0)
+    }
+
     pub fn neighbor_chunks(
         &self,
         source_file: &str,
@@ -1611,7 +1638,7 @@ fn knowledge_status_from_str(status: &str) -> Result<KnowledgeStatus, DbError> {
     }
 }
 
-fn encode_json<T: serde::Serialize>(value: &T) -> Result<String, DbError> {
+fn encode_json<T: serde::Serialize + ?Sized>(value: &T) -> Result<String, DbError> {
     Ok(serde_json::to_string(value)?)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,10 @@ enum Commands {
         #[command(subcommand)]
         command: KgCommands,
     },
+    Knowledge {
+        #[command(subcommand)]
+        command: KnowledgeCommands,
+    },
     Tunnels {
         #[command(subcommand)]
         command: Option<TunnelCommands>,
@@ -238,6 +242,32 @@ enum KgCommands {
     },
     Stats,
     List,
+}
+
+#[derive(Subcommand)]
+enum KnowledgeCommands {
+    Promote {
+        drawer_id: String,
+        #[arg(long)]
+        status: String,
+        #[arg(long = "verification-ref", required = true)]
+        verification_refs: Vec<String>,
+        #[arg(long)]
+        reason: String,
+        #[arg(long)]
+        reviewer: Option<String>,
+    },
+    Demote {
+        drawer_id: String,
+        #[arg(long)]
+        status: String,
+        #[arg(long = "evidence-ref", required = true)]
+        evidence_refs: Vec<String>,
+        #[arg(long)]
+        reason: String,
+        #[arg(long = "reason-type")]
+        reason_type: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -423,6 +453,7 @@ async fn run() -> Result<()> {
             dry_run,
         } => reindex_command(&db, &config, stale, force, dry_run).await,
         Commands::Kg { command } => kg_command(&db, command),
+        Commands::Knowledge { command } => knowledge_command(&db, command),
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::Serve { mcp } => serve_command(&config, mcp).await,
@@ -1109,6 +1140,210 @@ fn print_reindex_report(report: ReindexReport, dry_run: bool) {
         report.skipped_existing_chunks,
         report.skipped_missing_drawers
     );
+}
+
+fn knowledge_command(db: &Database, command: KnowledgeCommands) -> Result<()> {
+    match command {
+        KnowledgeCommands::Promote {
+            drawer_id,
+            status,
+            verification_refs,
+            reason,
+            reviewer,
+        } => {
+            let target_status = parse_lifecycle_status(&status)?;
+            if !matches!(
+                target_status,
+                KnowledgeStatus::Promoted | KnowledgeStatus::Canonical
+            ) {
+                bail!("promote status must be promoted or canonical");
+            }
+            let drawer = load_lifecycle_knowledge_drawer(db, &drawer_id)?;
+            validate_tier_status(
+                drawer.tier.as_ref().expect("knowledge drawer has tier"),
+                &target_status,
+            )?;
+            validate_lifecycle_refs(db, &verification_refs)?;
+
+            let old_status = drawer.status.clone().expect("knowledge drawer has status");
+            let mut updated_verification_refs = drawer.verification_refs.clone();
+            append_unique_refs(&mut updated_verification_refs, &verification_refs);
+            db.update_knowledge_lifecycle(
+                &drawer_id,
+                &target_status,
+                &updated_verification_refs,
+                &drawer.counterexample_refs,
+            )
+            .context("failed to update knowledge lifecycle")?;
+            append_audit_entry(
+                db,
+                "knowledge_promote",
+                &serde_json::json!({
+                    "drawer_id": drawer_id,
+                    "old_status": knowledge_status_slug(&old_status),
+                    "new_status": knowledge_status_slug(&target_status),
+                    "verification_refs": verification_refs,
+                    "reason": reason,
+                    "reviewer": reviewer,
+                }),
+            )
+            .context("failed to append audit log")?;
+            println!(
+                "promoted {}: {} -> {}",
+                drawer_id,
+                knowledge_status_slug(&old_status),
+                knowledge_status_slug(&target_status)
+            );
+        }
+        KnowledgeCommands::Demote {
+            drawer_id,
+            status,
+            evidence_refs,
+            reason,
+            reason_type,
+        } => {
+            let target_status = parse_lifecycle_status(&status)?;
+            if !matches!(
+                target_status,
+                KnowledgeStatus::Demoted | KnowledgeStatus::Retired
+            ) {
+                bail!("demote status must be demoted or retired");
+            }
+            validate_demote_reason_type(&reason_type)?;
+            let drawer = load_lifecycle_knowledge_drawer(db, &drawer_id)?;
+            validate_tier_status(
+                drawer.tier.as_ref().expect("knowledge drawer has tier"),
+                &target_status,
+            )?;
+            validate_lifecycle_refs(db, &evidence_refs)?;
+
+            let old_status = drawer.status.clone().expect("knowledge drawer has status");
+            let mut updated_counterexample_refs = drawer.counterexample_refs.clone();
+            append_unique_refs(&mut updated_counterexample_refs, &evidence_refs);
+            db.update_knowledge_lifecycle(
+                &drawer_id,
+                &target_status,
+                &drawer.verification_refs,
+                &updated_counterexample_refs,
+            )
+            .context("failed to update knowledge lifecycle")?;
+            append_audit_entry(
+                db,
+                "knowledge_demote",
+                &serde_json::json!({
+                    "drawer_id": drawer_id,
+                    "old_status": knowledge_status_slug(&old_status),
+                    "new_status": knowledge_status_slug(&target_status),
+                    "evidence_refs": evidence_refs,
+                    "reason": reason,
+                    "reason_type": reason_type,
+                }),
+            )
+            .context("failed to append audit log")?;
+            println!(
+                "demoted {}: {} -> {}",
+                drawer_id,
+                knowledge_status_slug(&old_status),
+                knowledge_status_slug(&target_status)
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn load_lifecycle_knowledge_drawer(
+    db: &Database,
+    drawer_id: &str,
+) -> Result<mempal::core::types::Drawer> {
+    let drawer = db
+        .get_drawer(drawer_id)
+        .context("failed to look up drawer")?
+        .with_context(|| format!("drawer not found: {drawer_id}"))?;
+    if drawer.memory_kind != MemoryKind::Knowledge {
+        bail!("knowledge lifecycle requires a knowledge drawer");
+    }
+    if drawer.tier.is_none() || drawer.status.is_none() {
+        bail!("knowledge lifecycle requires tier and status metadata");
+    }
+    Ok(drawer)
+}
+
+fn parse_lifecycle_status(value: &str) -> Result<KnowledgeStatus> {
+    match value {
+        "candidate" => Ok(KnowledgeStatus::Candidate),
+        "promoted" => Ok(KnowledgeStatus::Promoted),
+        "canonical" => Ok(KnowledgeStatus::Canonical),
+        "demoted" => Ok(KnowledgeStatus::Demoted),
+        "retired" => Ok(KnowledgeStatus::Retired),
+        other => bail!("unsupported knowledge status: {other}"),
+    }
+}
+
+fn validate_tier_status(tier: &KnowledgeTier, status: &KnowledgeStatus) -> Result<()> {
+    let allowed = match tier {
+        KnowledgeTier::DaoTian => &[KnowledgeStatus::Canonical, KnowledgeStatus::Demoted][..],
+        KnowledgeTier::DaoRen => &[
+            KnowledgeStatus::Candidate,
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+        KnowledgeTier::Shu => &[
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+        KnowledgeTier::Qi => &[
+            KnowledgeStatus::Candidate,
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+    };
+
+    if allowed.contains(status) {
+        return Ok(());
+    }
+
+    match tier {
+        KnowledgeTier::DaoTian => bail!("dao_tian only allows canonical or demoted"),
+        KnowledgeTier::DaoRen => {
+            bail!("dao_ren only allows candidate, promoted, demoted, or retired")
+        }
+        KnowledgeTier::Shu => bail!("shu only allows promoted, demoted, or retired"),
+        KnowledgeTier::Qi => bail!("qi only allows candidate, promoted, demoted, or retired"),
+    }
+}
+
+fn validate_demote_reason_type(value: &str) -> Result<()> {
+    match value {
+        "contradicted" | "obsolete" | "superseded" | "out_of_scope" | "unsafe" => Ok(()),
+        other => bail!("unsupported demote reason_type: {other}"),
+    }
+}
+
+fn validate_lifecycle_refs(db: &Database, refs: &[String]) -> Result<()> {
+    if refs.is_empty() {
+        bail!("at least one lifecycle evidence ref is required");
+    }
+    for drawer_id in refs {
+        if !db
+            .drawer_exists(drawer_id)
+            .with_context(|| format!("failed to check ref drawer {drawer_id}"))?
+        {
+            bail!("ref drawer not found: {drawer_id}");
+        }
+    }
+    Ok(())
+}
+
+fn append_unique_refs(target: &mut Vec<String>, refs: &[String]) {
+    for item in refs {
+        if !target.iter().any(|existing| existing == item) {
+            target.push(item.clone());
+        }
+    }
 }
 
 fn delete_command(db: &Database, drawer_id: &str) -> Result<()> {

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -1,0 +1,391 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use async_trait::async_trait;
+use mempal::context::{ContextRequest, assemble_context};
+use mempal::core::anchor;
+use mempal::core::db::Database;
+use mempal::core::types::{
+    AnchorKind, BootstrapEvidenceArgs, Drawer, KnowledgeStatus, KnowledgeTier, MemoryDomain,
+    MemoryKind, SourceType,
+};
+use mempal::embed::Embedder;
+use rusqlite::params;
+use serde_json::Value;
+use tempfile::TempDir;
+
+struct StubEmbedder;
+
+#[async_trait]
+impl Embedder for StubEmbedder {
+    async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| vector()).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        vector().len()
+    }
+
+    fn name(&self) -> &str {
+        "stub"
+    }
+}
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn vector() -> Vec<f32> {
+    vec![0.1, 0.2, 0.3]
+}
+
+fn setup_home() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_dir = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_dir).expect("create .mempal");
+    let db = Database::open(&mempal_dir.join("palace.db")).expect("open db");
+    (tmp, db)
+}
+
+fn run_mempal(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .env("HOME", home)
+        .args(args)
+        .output()
+        .expect("run mempal")
+}
+
+fn insert_evidence(db: &Database, id: &str, content: &str) {
+    let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("lifecycle".to_string()),
+        source_file: Some(format!("/tmp/{id}.md")),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        importance: 2,
+    });
+    db.insert_drawer(&drawer).expect("insert evidence");
+    db.insert_vector(id, &vector())
+        .expect("insert evidence vector");
+}
+
+fn insert_knowledge(
+    db: &Database,
+    id: &str,
+    tier: KnowledgeTier,
+    status: KnowledgeStatus,
+    statement: &str,
+    content: &str,
+) {
+    let drawer = Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("lifecycle".to_string()),
+        source_file: Some(format!("knowledge://project/lifecycle/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 4,
+        memory_kind: MemoryKind::Knowledge,
+        domain: MemoryDomain::Project,
+        field: anchor::DEFAULT_FIELD.to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        provenance: None,
+        statement: Some(statement.to_string()),
+        tier: Some(tier),
+        status: Some(status),
+        supporting_refs: vec!["drawer_supporting".to_string()],
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    };
+    db.insert_drawer(&drawer).expect("insert knowledge");
+    db.insert_vector(id, &vector())
+        .expect("insert knowledge vector");
+}
+
+async fn default_context_ids(db: &Database, cwd: &Path, query: &str) -> Vec<String> {
+    let pack = assemble_context(
+        db,
+        &StubEmbedder,
+        ContextRequest {
+            query: query.to_string(),
+            domain: MemoryDomain::Project,
+            field: anchor::DEFAULT_FIELD.to_string(),
+            cwd: cwd.to_path_buf(),
+            include_evidence: false,
+            max_items: 12,
+        },
+    )
+    .await
+    .expect("assemble context");
+    pack.sections
+        .into_iter()
+        .flat_map(|section| section.items)
+        .map(|item| item.drawer_id)
+        .collect()
+}
+
+fn vector_row_count(db: &Database, id: &str) -> i64 {
+    db.conn()
+        .query_row(
+            "SELECT COUNT(*) FROM drawer_vectors WHERE id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .expect("count vector rows")
+}
+
+#[tokio::test]
+async fn test_cli_knowledge_promote_updates_status_and_verification_refs() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_verify", "validated lifecycle evidence");
+    insert_knowledge(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Use lifecycle gates before trusting knowledge.",
+        "lifecycle promote candidate",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "promote",
+            "drawer_knowledge",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_verify",
+            "--reason",
+            "validated in test",
+            "--reviewer",
+            "human",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let drawer = db
+        .get_drawer("drawer_knowledge")
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.status, Some(KnowledgeStatus::Promoted));
+    assert_eq!(drawer.verification_refs, vec!["drawer_verify"]);
+
+    let ids = default_context_ids(&db, home.path(), "lifecycle promote").await;
+    assert!(ids.contains(&"drawer_knowledge".to_string()));
+}
+
+#[tokio::test]
+async fn test_cli_knowledge_demote_updates_status_and_counterexample_refs() {
+    let (home, db) = setup_home();
+    insert_evidence(
+        &db,
+        "drawer_counterexample",
+        "contradicted lifecycle evidence",
+    );
+    insert_knowledge(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Use the old lifecycle workflow.",
+        "lifecycle demote promoted",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "demote",
+            "drawer_knowledge",
+            "--status",
+            "demoted",
+            "--evidence-ref",
+            "drawer_counterexample",
+            "--reason",
+            "contradicted in test",
+            "--reason-type",
+            "contradicted",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let drawer = db
+        .get_drawer("drawer_knowledge")
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.status, Some(KnowledgeStatus::Demoted));
+    assert_eq!(drawer.counterexample_refs, vec!["drawer_counterexample"]);
+
+    let ids = default_context_ids(&db, home.path(), "lifecycle demote").await;
+    assert!(!ids.contains(&"drawer_knowledge".to_string()));
+}
+
+#[test]
+fn test_cli_knowledge_lifecycle_rejects_evidence_drawer() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_evidence", "raw evidence");
+    insert_evidence(&db, "drawer_verify", "validation evidence");
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "promote",
+            "drawer_evidence",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_verify",
+            "--reason",
+            "bad",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("knowledge lifecycle requires a knowledge drawer")
+    );
+}
+
+#[test]
+fn test_cli_knowledge_lifecycle_rejects_invalid_tier_status() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_verify", "validation evidence");
+    insert_knowledge(
+        &db,
+        "drawer_dao_tian",
+        KnowledgeTier::DaoTian,
+        KnowledgeStatus::Canonical,
+        "Evidence precedes assertion.",
+        "dao tian lifecycle",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "promote",
+            "drawer_dao_tian",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_verify",
+            "--reason",
+            "bad",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("dao_tian only allows canonical or demoted")
+    );
+}
+
+#[test]
+fn test_cli_knowledge_lifecycle_writes_audit_entry() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_verify", "validation evidence");
+    insert_knowledge(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Lifecycle changes require audit.",
+        "audit lifecycle",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "promote",
+            "drawer_knowledge",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_verify",
+            "--reason",
+            "validated in test",
+            "--reviewer",
+            "human",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let audit_path = home.path().join(".mempal").join("audit.jsonl");
+    let audit = fs::read_to_string(audit_path).expect("read audit");
+    let last_line = audit.lines().last().expect("audit line");
+    let value: Value = serde_json::from_str(last_line).expect("audit json");
+    assert_eq!(value["command"], "knowledge_promote");
+    assert_eq!(value["details"]["drawer_id"], "drawer_knowledge");
+    assert_eq!(value["details"]["old_status"], "candidate");
+    assert_eq!(value["details"]["new_status"], "promoted");
+    assert_eq!(value["details"]["verification_refs"][0], "drawer_verify");
+    assert_eq!(value["details"]["reason"], "validated in test");
+    assert_eq!(value["details"]["reviewer"], "human");
+}
+
+#[test]
+fn test_knowledge_lifecycle_does_not_bump_schema_or_rewrite_vectors() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_verify", "validation evidence");
+    insert_knowledge(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Lifecycle keeps vector rows stable.",
+        "schema vector lifecycle",
+    );
+    let schema_before = db.schema_version().expect("schema version");
+    assert_eq!(vector_row_count(&db, "drawer_knowledge"), 1);
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "promote",
+            "drawer_knowledge",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_verify",
+            "--reason",
+            "validated in test",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(db.schema_version().expect("schema version"), schema_before);
+    assert_eq!(vector_row_count(&db, "drawer_knowledge"), 1);
+}


### PR DESCRIPTION
## Summary

- Add `mempal knowledge promote|demote` as the bootstrap lifecycle CLI for existing knowledge drawers.
- Enforce knowledge-only updates, target status rules, tier/status policy, required refs, reason, and demote reason type.
- Update only lifecycle metadata: `status`, `verification_refs`, and `counterexample_refs`.
- Append lifecycle audit entries with old/new status, refs, reason, and reviewer or reason type.
- Keep P17 Stage-1 only: no schema bump, no vector rewrite, no MCP/REST endpoint, no context response change, no Phase-2 `knowledge_cards`.

## Verification

- `agent-spec parse specs/p17-knowledge-lifecycle.spec.md`
- `agent-spec lint specs/p17-knowledge-lifecycle.spec.md --min-score 0.7`
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `cargo check --features rest`
