### PR TITLE
P18: add bootstrap knowledge distill CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P17）
+### 已完成的 Spec（P0-P18）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -64,6 +64,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p15-mcp-context.spec.md` | 完成 | `mempal_context` MCP 工具：向 agent runtime 暴露 P14 mind-model context pack |
 | `specs/p16-context-skill-guidance.spec.md` | 完成 | context-guided skill selection protocol：`mempal_context` 辅助 workflow/skill/tool 选择，但 `trigger_hints` 只做 bias、不自动执行 |
 | `specs/p17-knowledge-lifecycle.spec.md` | 完成 | bootstrap knowledge lifecycle CLI：`mempal knowledge promote/demote` 受约束更新 knowledge drawer status 与 refs，并写 audit |
+| `specs/p18-knowledge-distill.spec.md` | 完成 | bootstrap knowledge distill CLI：`mempal knowledge distill` 从 evidence refs 创建 candidate knowledge drawer |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -90,6 +91,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p15-mcp-context-implementation.md` — P15 mempal_context MCP tool（已完成）
 - `docs/plans/2026-04-24-p16-context-skill-guidance-implementation.md` — P16 context-guided skill selection protocol（已完成）
 - `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md` — P17 bootstrap knowledge lifecycle CLI（已完成）
+- `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md` — P18 bootstrap knowledge distill CLI（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P17）
+### 已完成的 Spec（P0-P18）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -62,6 +62,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p15-mcp-context.spec.md` | 完成 | `mempal_context` MCP 工具：向 agent runtime 暴露 P14 mind-model context pack |
 | `specs/p16-context-skill-guidance.spec.md` | 完成 | context-guided skill selection protocol：`mempal_context` 辅助 workflow/skill/tool 选择，但 `trigger_hints` 只做 bias、不自动执行 |
 | `specs/p17-knowledge-lifecycle.spec.md` | 完成 | bootstrap knowledge lifecycle CLI：`mempal knowledge promote/demote` 受约束更新 knowledge drawer status 与 refs，并写 audit |
+| `specs/p18-knowledge-distill.spec.md` | 完成 | bootstrap knowledge distill CLI：`mempal knowledge distill` 从 evidence refs 创建 candidate knowledge drawer |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -88,6 +89,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p15-mcp-context-implementation.md` — P15 mempal_context MCP tool（已完成）
 - `docs/plans/2026-04-24-p16-context-skill-guidance-implementation.md` — P16 context-guided skill selection protocol（已完成）
 - `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md` — P17 bootstrap knowledge lifecycle CLI（已完成）
+- `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md` — P18 bootstrap knowledge distill CLI（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -819,6 +819,7 @@ Implemented Phase-1 runtime surface:
 - `trigger_hints` are exposed as metadata only; they do not directly execute skills
 - MCP protocol guidance consumes context in order: read `dao_tian` and `dao_ren` for judgment, use `shu` to bias workflow / skill choice, and use `qi` to bias concrete tool choice
 - memory hints never override system, user, repo, or client-native skill rules
+- bootstrap distill CLI creates candidate `dao_ren` / `qi` knowledge drawers from existing evidence refs without auto-promotion or LLM summarization
 - bootstrap lifecycle CLI supports manual `promote` / `demote` on existing knowledge drawers by updating status plus verification / counterexample refs and writing audit entries
 - lifecycle updates are metadata-only in Stage 1; they do not rewrite content, re-embed vectors, or create Phase-2 knowledge cards
 

--- a/docs/plans/2026-04-24-p18-knowledge-distill-implementation.md
+++ b/docs/plans/2026-04-24-p18-knowledge-distill-implementation.md
@@ -1,0 +1,35 @@
+# P18 Knowledge Distill Implementation Plan
+
+**Goal:** Add the missing Phase-1 `distill` operation: create candidate knowledge drawers from existing evidence refs through CLI.
+
+**Architecture:** Keep distill as a CLI-only bootstrap operation. Reuse existing drawer schema, bootstrap identity, knowledge source URI, embedder, and audit log. Do not add schema, MCP/REST endpoints, or automatic promotion/evaluation.
+
+**Tech Stack:** Rust 2024, clap subcommands, existing `Database`, existing embedder factory, integration tests under `tests/`.
+
+## Source Spec
+
+- `specs/p18-knowledge-distill.spec.md`
+
+## Tasks
+
+- [x] Add `mempal knowledge distill` CLI arguments.
+- [x] Build candidate knowledge drawer using bootstrap identity and existing knowledge source URI.
+- [x] Validate tier/status constraints and role refs.
+- [x] Support optional trigger hints and scope constraints.
+- [x] Implement dry-run and idempotent existing-drawer behavior.
+- [x] Append `knowledge_distill` audit entry on successful create.
+- [x] Add integration tests for create, dry-run, invalid tier, missing refs, trigger hints, audit, and schema stability.
+- [x] Update AGENTS.md, CLAUDE.md, usage docs, and mind-model design notes.
+- [x] Run final verification and commit.
+
+## Verification
+
+```bash
+agent-spec parse specs/p18-knowledge-distill.spec.md
+agent-spec lint specs/p18-knowledge-distill.spec.md --min-score 0.7
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+cargo check --features rest
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,6 +96,7 @@ Use this when you already know the concepts and just need the right command quic
 | `mempal ingest --wing <WING> <DIR> [--dry-run]` | chunk, embed, and store a project tree |
 | `mempal search <QUERY> [--wing W] [--room R] [--json]` | hybrid search (BM25 + vector + RRF) with tunnel hints |
 | `mempal context <QUERY> [--format json] [--include-evidence]` | assemble mind-model runtime context (`dao_tian -> dao_ren -> shu -> qi`) |
+| `mempal knowledge distill --statement ... --content ... --tier dao_ren --supporting-ref <ID>` | create candidate knowledge from evidence refs |
 | `mempal knowledge promote <ID> --status promoted --verification-ref <ID> --reason ...` | promote bootstrap knowledge into active runtime use |
 | `mempal knowledge demote <ID> --status demoted --evidence-ref <ID> --reason ... --reason-type contradicted` | demote or retire contradicted / obsolete bootstrap knowledge |
 | `mempal wake-up [--format aaak]` | context refresh sorted by importance (not just recency) |
@@ -177,6 +178,22 @@ Every ingest appends a JSONL audit record to:
 
 ### Bootstrap Knowledge Lifecycle
 
+P18 adds the explicit Stage-1 distillation entry point: create candidate knowledge
+from existing evidence drawers.
+
+```bash
+mempal knowledge distill \
+  --statement "Prefer evidence before asserting project facts" \
+  --content "When answering project-specific questions, cite source-backed memory before making claims." \
+  --tier dao_ren \
+  --supporting-ref drawer_evidence
+```
+
+Distill always creates `status=candidate` and currently only allows `tier=dao_ren`
+or `tier=qi`. `dao_tian` and `shu` are intentionally excluded from candidate
+distill because the current P12 status policy does not allow candidate states
+for those tiers. Use `promote` only after review.
+
 P17 adds manual lifecycle commands for Stage-1 knowledge drawers:
 
 ```bash
@@ -195,7 +212,7 @@ mempal knowledge demote drawer_knowledge \
   --reason-type contradicted
 ```
 
-These commands only update existing `memory_kind=knowledge` drawers. They do not create knowledge, change content, re-embed vectors, bump schema, or add Phase-2 `knowledge_cards`. Successful lifecycle changes append a JSONL audit entry with old/new status, refs, reason, and reviewer or reason type.
+Lifecycle commands only update existing `memory_kind=knowledge` drawers. They do not change content, re-embed vectors, bump schema, or add Phase-2 `knowledge_cards`. Successful distill and lifecycle changes append JSONL audit entries.
 
 ### 4. Search
 

--- a/specs/p18-knowledge-distill.spec.md
+++ b/specs/p18-knowledge-distill.spec.md
@@ -1,0 +1,146 @@
+spec: task
+name: "P18: bootstrap knowledge distill CLI"
+inherits: project
+tags: [memory, knowledge, distill, cli]
+estimate: 0.5d
+---
+
+## Intent
+
+P17 补齐了 `promote` / `demote`，但 Phase-1 mind model 仍缺少显式 `distill`：从已有 evidence drawers 创建 candidate knowledge drawer。P18 新增 `mempal knowledge distill`，让人类或 agent 可以在引用证据的前提下生成候选知识，但不自动提升、不自动评价、不进入 Phase-2 `knowledge_cards`。
+
+本任务复用现有 drawer bootstrap identity、typed knowledge metadata、embedding、audit log 和 context 规则。
+
+## Decisions
+
+- 新增 CLI：`mempal knowledge distill`
+- Required arguments:
+  - `--statement <text>`
+  - `--content <text>`
+  - `--tier dao_ren|qi`
+  - one or more `--supporting-ref <drawer_id>`
+- Optional arguments:
+  - `--wing <wing>` default `mempal`
+  - `--room <room>` default `knowledge`
+  - `--domain project|agent|skill|global` default `project`
+  - `--field <field>` default `general`
+  - `--cwd <path>` for deriving worktree/repo anchor
+  - `--scope-constraints <text>`
+  - repeated `--counterexample-ref <drawer_id>`
+  - repeated `--teaching-ref <drawer_id>`
+  - repeated `--intent-tag <text>`
+  - repeated `--workflow-bias <text>`
+  - repeated `--tool-need <text>`
+  - `--importance <0-5>` default `2`
+  - `--dry-run`
+- Distill always creates `memory_kind=knowledge`
+- Distill always sets `status=candidate`
+- Distill only allows `tier=dao_ren|qi` because current P12 tier/status policy does not allow candidate `dao_tian` or candidate `shu`
+- Distill validates all role refs:
+  - each ref must look like a drawer id
+  - each ref must exist
+  - `supporting_refs` must be non-empty
+- Distill derives anchor from `--cwd` when provided, otherwise current process cwd
+- Distill uses existing bootstrap identity components so equivalent distill requests produce the same drawer_id
+- Distill writes `source_file=knowledge://...` using existing knowledge source URI format
+- Distill embeds `content` and inserts one vector unless `--dry-run`
+- Distill is idempotent:
+  - if the computed drawer already exists, it does not insert a duplicate
+  - output still reports the existing drawer_id
+- Distill appends an audit entry on successful non-dry-run create
+- Distill does not call LLMs, summarize evidence, score confidence, promote, demote, or create Phase-2 knowledge cards
+- No MCP / REST endpoint in P18
+- No schema bump
+
+## Boundaries
+
+### Allowed Changes
+- `src/main.rs`
+- `tests/**`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `specs/p18-knowledge-distill.spec.md`
+- `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md`
+
+### Forbidden
+- Do not add tables, columns, triggers, or migrations
+- Do not add Phase-2 `knowledge_cards`
+- Do not add MCP / REST distill endpoints
+- Do not change `mempal_context` response schema or ordering
+- Do not change search ranking
+- Do not auto-promote distilled knowledge
+- Do not call an LLM or external research tool
+- Do not introduce new dependencies
+
+## Out of Scope
+
+- automatic evidence summarization
+- evaluator scoring
+- promotion gates
+- human review UI
+- Phase-2 knowledge cards
+- MCP lifecycle/distill tools
+- REST lifecycle/distill endpoints
+- research-rs integration
+
+## Completion Criteria
+
+Scenario: distill creates candidate knowledge from evidence
+  Test:
+    Filter: test_cli_knowledge_distill_creates_candidate_knowledge
+    Level: integration
+  Given an evidence drawer exists
+  When running `mempal knowledge distill --statement "Prefer evidence first" --content "Use cited evidence before asserting project facts." --tier dao_ren --supporting-ref <evidence_id>`
+  Then the command exits successfully
+  And a knowledge drawer is inserted
+  And `status == candidate`
+  And `supporting_refs` contains `<evidence_id>`
+  And default `mempal context` does not include the candidate drawer
+
+Scenario: distill dry-run returns deterministic drawer id without writing
+  Test:
+    Filter: test_cli_knowledge_distill_dry_run_no_write
+    Level: integration
+  Given an evidence drawer exists
+  When running the same `mempal knowledge distill ... --dry-run` command twice
+  Then both outputs contain the same drawer_id
+  And the database drawer count is unchanged
+
+Scenario: distill rejects unsupported candidate tier
+  Test:
+    Filter: test_cli_knowledge_distill_rejects_dao_tian_candidate
+    Level: integration
+  Given an evidence drawer exists
+  When running `mempal knowledge distill --tier dao_tian`
+  Then the command fails
+  And the error says distill only allows candidate `dao_ren` or `qi`
+
+Scenario: distill rejects missing or nonexistent evidence refs
+  Test:
+    Filter: test_cli_knowledge_distill_rejects_missing_supporting_refs
+    Level: integration
+  Given no supporting refs are provided
+  When running `mempal knowledge distill`
+  Then clap rejects the command before writing
+  And no knowledge drawer is created
+
+Scenario: distill stores trigger hints as bias metadata
+  Test:
+    Filter: test_cli_knowledge_distill_stores_trigger_hints
+    Level: integration
+  Given an evidence drawer exists
+  When running distill with `--intent-tag debugging --workflow-bias reproduce-first --tool-need cargo-test`
+  Then the inserted knowledge drawer has `trigger_hints`
+  And the trigger hints contain those three values
+
+Scenario: distill writes audit and preserves schema
+  Test:
+    Filter: test_cli_knowledge_distill_writes_audit_and_preserves_schema
+    Level: integration
+  Given an evidence drawer exists
+  And the current schema version is recorded
+  When running a successful non-dry-run distill command
+  Then `~/.mempal/audit.jsonl` receives a `knowledge_distill` entry
+  And the schema version remains unchanged

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,18 +13,23 @@ use mempal::aaak::{AaakCodec, AaakMeta};
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
 use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
+    anchor,
     config::Config,
     db::Database,
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
-        AnchorKind, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, TaxonomyEntry,
-        TunnelEndpoint,
+        AnchorKind, BootstrapIdentityParts, Drawer, KnowledgeStatus, KnowledgeTier, MemoryDomain,
+        MemoryKind, SourceType, TaxonomyEntry, TriggerHints, TunnelEndpoint,
     },
-    utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
+    utils::{
+        build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp,
+        format_tunnel_endpoint, knowledge_source_file,
+    },
 };
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
 use mempal::ingest::{
     IngestOptions, IngestStats, ingest_dir_with_options, ingest_file_with_options,
+    normalize::CURRENT_NORMALIZE_VERSION,
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
 use mempal::mcp::MempalMcpServer;
@@ -245,7 +250,44 @@ enum KgCommands {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum KnowledgeCommands {
+    Distill {
+        #[arg(long)]
+        statement: String,
+        #[arg(long)]
+        content: String,
+        #[arg(long)]
+        tier: String,
+        #[arg(long = "supporting-ref", required = true)]
+        supporting_refs: Vec<String>,
+        #[arg(long, default_value = "mempal")]
+        wing: String,
+        #[arg(long, default_value = "knowledge")]
+        room: String,
+        #[arg(long, default_value = "project")]
+        domain: String,
+        #[arg(long, default_value = "general")]
+        field: String,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+        #[arg(long = "scope-constraints")]
+        scope_constraints: Option<String>,
+        #[arg(long = "counterexample-ref")]
+        counterexample_refs: Vec<String>,
+        #[arg(long = "teaching-ref")]
+        teaching_refs: Vec<String>,
+        #[arg(long = "intent-tag")]
+        intent_tags: Vec<String>,
+        #[arg(long = "workflow-bias")]
+        workflow_bias: Vec<String>,
+        #[arg(long = "tool-need")]
+        tool_needs: Vec<String>,
+        #[arg(long, default_value_t = 2)]
+        importance: i32,
+        #[arg(long)]
+        dry_run: bool,
+    },
     Promote {
         drawer_id: String,
         #[arg(long)]
@@ -453,7 +495,7 @@ async fn run() -> Result<()> {
             dry_run,
         } => reindex_command(&db, &config, stale, force, dry_run).await,
         Commands::Kg { command } => kg_command(&db, command),
-        Commands::Knowledge { command } => knowledge_command(&db, command),
+        Commands::Knowledge { command } => knowledge_command(&db, &config, command).await,
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::Serve { mcp } => serve_command(&config, mcp).await,
@@ -1142,8 +1184,155 @@ fn print_reindex_report(report: ReindexReport, dry_run: bool) {
     );
 }
 
-fn knowledge_command(db: &Database, command: KnowledgeCommands) -> Result<()> {
+async fn knowledge_command(
+    db: &Database,
+    config: &Config,
+    command: KnowledgeCommands,
+) -> Result<()> {
     match command {
+        KnowledgeCommands::Distill {
+            statement,
+            content,
+            tier,
+            supporting_refs,
+            wing,
+            room,
+            domain,
+            field,
+            cwd,
+            scope_constraints,
+            counterexample_refs,
+            teaching_refs,
+            intent_tags,
+            workflow_bias,
+            tool_needs,
+            importance,
+            dry_run,
+        } => {
+            if !(0..=5).contains(&importance) {
+                bail!("importance must be between 0 and 5");
+            }
+            let statement = trim_required(&statement, "statement")?;
+            let content = trim_required(&content, "content")?;
+            let wing = trim_required(&wing, "wing")?;
+            let room = trim_required(&room, "room")?;
+            let field = trim_required(&field, "field")?;
+            let domain = parse_domain(&domain)?;
+            let tier = parse_distill_tier(&tier)?;
+            let memory_kind = MemoryKind::Knowledge;
+            let status = KnowledgeStatus::Candidate;
+            let verification_refs: &[String] = &[];
+
+            let supporting_refs = normalized_nonempty_strings(&supporting_refs);
+            let counterexample_refs = normalized_nonempty_strings(&counterexample_refs);
+            let teaching_refs = normalized_nonempty_strings(&teaching_refs);
+            validate_distill_refs(db, "supporting_refs", &supporting_refs)?;
+            validate_distill_refs(db, "counterexample_refs", &counterexample_refs)?;
+            validate_distill_refs(db, "teaching_refs", &teaching_refs)?;
+
+            let scope_constraints = scope_constraints
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned);
+            let trigger_hints = build_trigger_hints(intent_tags, workflow_bias, tool_needs);
+            let anchor = distill_anchor(&domain, cwd.as_deref())?;
+            anchor::validate_anchor_domain(&domain, &anchor.anchor_kind)
+                .map_err(|message| anyhow::anyhow!(message.to_string()))?;
+
+            let drawer_id = build_bootstrap_drawer_id_from_parts(
+                &wing,
+                Some(&room),
+                &content,
+                BootstrapIdentityParts {
+                    memory_kind: &memory_kind,
+                    domain: &domain,
+                    field: &field,
+                    anchor_kind: &anchor.anchor_kind,
+                    anchor_id: &anchor.anchor_id,
+                    parent_anchor_id: anchor.parent_anchor_id.as_deref(),
+                    provenance: None,
+                    statement: Some(&statement),
+                    tier: Some(&tier),
+                    status: Some(&status),
+                    supporting_refs: &supporting_refs,
+                    counterexample_refs: &counterexample_refs,
+                    teaching_refs: &teaching_refs,
+                    verification_refs,
+                    scope_constraints: scope_constraints.as_deref(),
+                    trigger_hints: trigger_hints.as_ref(),
+                },
+            );
+
+            if dry_run {
+                println!("dry_run=true drawer_id={drawer_id}");
+                return Ok(());
+            }
+
+            if db
+                .drawer_exists(&drawer_id)
+                .context("failed to check existing distilled drawer")?
+            {
+                println!("drawer_id={drawer_id} created=false");
+                return Ok(());
+            }
+
+            let embedder = build_embedder(config).await?;
+            let vector = embedder
+                .embed(&[content.as_str()])
+                .await
+                .context("failed to embed distilled knowledge")?
+                .into_iter()
+                .next()
+                .context("embedder returned no vector")?;
+            let drawer = Drawer {
+                id: drawer_id.clone(),
+                content,
+                wing,
+                room: Some(room),
+                source_file: Some(knowledge_source_file(&domain, &field, &tier, &statement)),
+                source_type: SourceType::Manual,
+                added_at: current_timestamp(),
+                chunk_index: Some(0),
+                normalize_version: CURRENT_NORMALIZE_VERSION,
+                importance,
+                memory_kind: MemoryKind::Knowledge,
+                domain,
+                field,
+                anchor_kind: anchor.anchor_kind,
+                anchor_id: anchor.anchor_id,
+                parent_anchor_id: anchor.parent_anchor_id,
+                provenance: None,
+                statement: Some(statement),
+                tier: Some(tier),
+                status: Some(status),
+                supporting_refs: supporting_refs.clone(),
+                counterexample_refs: counterexample_refs.clone(),
+                teaching_refs: teaching_refs.clone(),
+                verification_refs: Vec::new(),
+                scope_constraints,
+                trigger_hints,
+            };
+            db.insert_drawer(&drawer)
+                .context("failed to insert distilled knowledge drawer")?;
+            db.insert_vector(&drawer_id, &vector)
+                .context("failed to insert distilled knowledge vector")?;
+            append_audit_entry(
+                db,
+                "knowledge_distill",
+                &serde_json::json!({
+                    "drawer_id": drawer_id,
+                    "statement": drawer.statement,
+                    "tier": drawer.tier.as_ref().map(knowledge_tier_slug),
+                    "status": drawer.status.as_ref().map(knowledge_status_slug),
+                    "supporting_refs": supporting_refs,
+                    "counterexample_refs": counterexample_refs,
+                    "teaching_refs": teaching_refs,
+                }),
+            )
+            .context("failed to append audit log")?;
+            println!("drawer_id={drawer_id} created=true");
+        }
         KnowledgeCommands::Promote {
             drawer_id,
             status,
@@ -1249,6 +1438,85 @@ fn knowledge_command(db: &Database, command: KnowledgeCommands) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+fn trim_required(value: &str, field: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("{field} must not be empty");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn normalized_nonempty_strings(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .filter_map(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .collect()
+}
+
+fn parse_distill_tier(value: &str) -> Result<KnowledgeTier> {
+    match value.trim() {
+        "dao_ren" => Ok(KnowledgeTier::DaoRen),
+        "qi" => Ok(KnowledgeTier::Qi),
+        "dao_tian" | "shu" => bail!("distill only allows candidate dao_ren or qi"),
+        other => bail!("unsupported knowledge tier: {other}"),
+    }
+}
+
+fn build_trigger_hints(
+    intent_tags: Vec<String>,
+    workflow_bias: Vec<String>,
+    tool_needs: Vec<String>,
+) -> Option<TriggerHints> {
+    let intent_tags = normalized_nonempty_strings(&intent_tags);
+    let workflow_bias = normalized_nonempty_strings(&workflow_bias);
+    let tool_needs = normalized_nonempty_strings(&tool_needs);
+    if intent_tags.is_empty() && workflow_bias.is_empty() && tool_needs.is_empty() {
+        return None;
+    }
+    Some(TriggerHints {
+        intent_tags,
+        workflow_bias,
+        tool_needs,
+    })
+}
+
+fn distill_anchor(domain: &MemoryDomain, cwd: Option<&Path>) -> Result<anchor::DerivedAnchor> {
+    if matches!(domain, MemoryDomain::Global) {
+        return Ok(anchor::DerivedAnchor {
+            anchor_kind: AnchorKind::Global,
+            anchor_id: "global://default".to_string(),
+            parent_anchor_id: None,
+        });
+    }
+    let cwd = match cwd {
+        Some(path) => path.to_path_buf(),
+        None => env::current_dir().context("failed to read current directory")?,
+    };
+    anchor::derive_anchor_from_cwd(Some(&cwd)).context("failed to derive distill anchor")
+}
+
+fn validate_distill_refs(db: &Database, field: &str, refs: &[String]) -> Result<()> {
+    if field == "supporting_refs" && refs.is_empty() {
+        bail!("supporting_refs must not be empty");
+    }
+    for drawer_id in refs {
+        if !drawer_id.starts_with("drawer_") {
+            bail!("{field} must contain drawer ids");
+        }
+        let drawer = db
+            .get_drawer(drawer_id)
+            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
+            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
+        if drawer.memory_kind != MemoryKind::Evidence {
+            bail!("{field} must point to evidence drawers");
+        }
+    }
     Ok(())
 }
 

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -1,6 +1,9 @@
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::Path;
 use std::process::{Command, Output};
+use std::thread;
 
 use async_trait::async_trait;
 use mempal::context::{ContextRequest, assemble_context};
@@ -37,7 +40,7 @@ fn mempal_bin() -> String {
 }
 
 fn vector() -> Vec<f32> {
-    vec![0.1, 0.2, 0.3]
+    vec![0.1; 384]
 }
 
 fn setup_home() -> (TempDir, Database) {
@@ -48,12 +51,62 @@ fn setup_home() -> (TempDir, Database) {
     (tmp, db)
 }
 
+fn start_openai_embedding_stub(expected_input: &str) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding stub");
+    listener
+        .set_nonblocking(false)
+        .expect("set embedding stub blocking");
+    let address = listener.local_addr().expect("local addr");
+    let expected_input = expected_input.to_string();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept embedding request");
+        let mut request = [0_u8; 8192];
+        let bytes_read = stream.read(&mut request).expect("read embedding request");
+        let request_text = String::from_utf8_lossy(&request[..bytes_read]);
+        let body = request_text.split("\r\n\r\n").nth(1).expect("request body");
+        let payload: Value = serde_json::from_str(body).expect("parse embedding request body");
+        let input = payload["input"].as_array().expect("input array");
+        assert_eq!(input[0].as_str(), Some(expected_input.as_str()));
+        let response = serde_json::json!({
+            "data": [{ "embedding": vector() }]
+        });
+        let response_body = response.to_string();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        )
+        .expect("write embedding response");
+    });
+    (format!("http://{address}/v1/embeddings"), handle)
+}
+
+fn write_api_config(home: &Path, endpoint: &str) {
+    let config_path = home.join(".mempal").join("config.toml");
+    fs::write(
+        config_path,
+        format!(
+            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+        ),
+    )
+    .expect("write config");
+}
+
 fn run_mempal(home: &Path, args: &[&str]) -> Output {
     Command::new(mempal_bin())
         .env("HOME", home)
         .args(args)
         .output()
         .expect("run mempal")
+}
+
+fn parse_drawer_id(stdout: &[u8]) -> String {
+    let text = String::from_utf8_lossy(stdout);
+    text.split_whitespace()
+        .find_map(|part| part.strip_prefix("drawer_id="))
+        .expect("drawer_id in output")
+        .to_string()
 }
 
 fn insert_evidence(db: &Database, id: &str, content: &str) {
@@ -388,4 +441,212 @@ fn test_knowledge_lifecycle_does_not_bump_schema_or_rewrite_vectors() {
 
     assert_eq!(db.schema_version().expect("schema version"), schema_before);
     assert_eq!(vector_row_count(&db, "drawer_knowledge"), 1);
+}
+
+#[tokio::test]
+async fn test_cli_knowledge_distill_creates_candidate_knowledge() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_evidence", "evidence first observation");
+    let content = "Use cited evidence before asserting project facts.";
+    let (endpoint, handle) = start_openai_embedding_stub(content);
+    write_api_config(home.path(), &endpoint);
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "distill",
+            "--statement",
+            "Prefer evidence first",
+            "--content",
+            content,
+            "--tier",
+            "dao_ren",
+            "--supporting-ref",
+            "drawer_evidence",
+        ],
+    );
+    handle.join().expect("join embedding stub");
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let drawer_id = parse_drawer_id(&output.stdout);
+    let drawer = db
+        .get_drawer(&drawer_id)
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.memory_kind, MemoryKind::Knowledge);
+    assert_eq!(drawer.status, Some(KnowledgeStatus::Candidate));
+    assert_eq!(drawer.tier, Some(KnowledgeTier::DaoRen));
+    assert_eq!(drawer.supporting_refs, vec!["drawer_evidence"]);
+
+    let ids = default_context_ids(&db, home.path(), "evidence first").await;
+    assert!(!ids.contains(&drawer_id));
+}
+
+#[test]
+fn test_cli_knowledge_distill_dry_run_no_write() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_evidence", "dry run evidence");
+    let baseline = db.drawer_count().expect("drawer count");
+    let args = [
+        "knowledge",
+        "distill",
+        "--statement",
+        "Dry run candidate",
+        "--content",
+        "This should not be written.",
+        "--tier",
+        "qi",
+        "--supporting-ref",
+        "drawer_evidence",
+        "--dry-run",
+    ];
+
+    let first = run_mempal(home.path(), &args);
+    let second = run_mempal(home.path(), &args);
+    assert!(first.status.success());
+    assert!(second.status.success());
+    assert_eq!(
+        parse_drawer_id(&first.stdout),
+        parse_drawer_id(&second.stdout)
+    );
+    assert_eq!(db.drawer_count().expect("drawer count"), baseline);
+}
+
+#[test]
+fn test_cli_knowledge_distill_rejects_dao_tian_candidate() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_evidence", "dao tian evidence");
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "distill",
+            "--statement",
+            "Universal law",
+            "--content",
+            "This should not be candidate dao_tian.",
+            "--tier",
+            "dao_tian",
+            "--supporting-ref",
+            "drawer_evidence",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("distill only allows candidate dao_ren or qi")
+    );
+}
+
+#[test]
+fn test_cli_knowledge_distill_rejects_missing_supporting_refs() {
+    let (home, db) = setup_home();
+    let baseline = db.drawer_count().expect("drawer count");
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "distill",
+            "--statement",
+            "Missing refs",
+            "--content",
+            "This should fail before writing.",
+            "--tier",
+            "qi",
+        ],
+    );
+    assert!(!output.status.success());
+    assert_eq!(db.drawer_count().expect("drawer count"), baseline);
+}
+
+#[test]
+fn test_cli_knowledge_distill_stores_trigger_hints() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_evidence", "trigger hint evidence");
+    let content = "Reproduce failures before changing code.";
+    let (endpoint, handle) = start_openai_embedding_stub(content);
+    write_api_config(home.path(), &endpoint);
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "distill",
+            "--statement",
+            "Reproduce before patching",
+            "--content",
+            content,
+            "--tier",
+            "qi",
+            "--supporting-ref",
+            "drawer_evidence",
+            "--intent-tag",
+            "debugging",
+            "--workflow-bias",
+            "reproduce-first",
+            "--tool-need",
+            "cargo-test",
+        ],
+    );
+    handle.join().expect("join embedding stub");
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let drawer_id = parse_drawer_id(&output.stdout);
+    let drawer = db
+        .get_drawer(&drawer_id)
+        .expect("load drawer")
+        .expect("drawer exists");
+    let hints = drawer.trigger_hints.expect("trigger hints");
+    assert_eq!(hints.intent_tags, vec!["debugging"]);
+    assert_eq!(hints.workflow_bias, vec!["reproduce-first"]);
+    assert_eq!(hints.tool_needs, vec!["cargo-test"]);
+}
+
+#[test]
+fn test_cli_knowledge_distill_writes_audit_and_preserves_schema() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_evidence", "audit distill evidence");
+    let schema_before = db.schema_version().expect("schema version");
+    let content = "Audit every distilled candidate.";
+    let (endpoint, handle) = start_openai_embedding_stub(content);
+    write_api_config(home.path(), &endpoint);
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "distill",
+            "--statement",
+            "Audit distilled candidates",
+            "--content",
+            content,
+            "--tier",
+            "dao_ren",
+            "--supporting-ref",
+            "drawer_evidence",
+        ],
+    );
+    handle.join().expect("join embedding stub");
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(db.schema_version().expect("schema version"), schema_before);
+
+    let audit_path = home.path().join(".mempal").join("audit.jsonl");
+    let audit = fs::read_to_string(audit_path).expect("read audit");
+    let last_line = audit.lines().last().expect("audit line");
+    let value: Value = serde_json::from_str(last_line).expect("audit json");
+    assert_eq!(value["command"], "knowledge_distill");
+    assert_eq!(value["details"]["status"], "candidate");
+    assert_eq!(value["details"]["tier"], "dao_ren");
+    assert_eq!(value["details"]["supporting_refs"][0], "drawer_evidence");
 }


### PR DESCRIPTION
## Summary

Implements P18 bootstrap knowledge distill CLI.

- Adds `mempal knowledge distill` for creating candidate knowledge drawers from evidence refs.
- Restricts distill candidates to `dao_ren` and `qi`, matching Phase-1 lifecycle policy.
- Validates evidence refs and writes deterministic bootstrap identity, trigger hints, embeddings, and audit entries.
- Updates mind-model docs, usage docs, AGENTS/CLAUDE status, and P18 spec/plan.

## Verification

- `agent-spec parse specs/p18-knowledge-distill.spec.md`
- `agent-spec lint specs/p18-knowledge-distill.spec.md --min-score 0.7`
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --test knowledge_lifecycle -- --nocapture`
- `cargo test`
- `cargo check --features rest`
