### PR TITLE
P19: harden knowledge lifecycle refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P18）
+### 已完成的 Spec（P0-P19）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -65,6 +65,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p16-context-skill-guidance.spec.md` | 完成 | context-guided skill selection protocol：`mempal_context` 辅助 workflow/skill/tool 选择，但 `trigger_hints` 只做 bias、不自动执行 |
 | `specs/p17-knowledge-lifecycle.spec.md` | 完成 | bootstrap knowledge lifecycle CLI：`mempal knowledge promote/demote` 受约束更新 knowledge drawer status 与 refs，并写 audit |
 | `specs/p18-knowledge-distill.spec.md` | 完成 | bootstrap knowledge distill CLI：`mempal knowledge distill` 从 evidence refs 创建 candidate knowledge drawer |
+| `specs/p19-lifecycle-ref-validation.spec.md` | 完成 | lifecycle evidence ref hardening：`promote/demote` refs 必须是存在的 evidence drawers |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -92,6 +93,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p16-context-skill-guidance-implementation.md` — P16 context-guided skill selection protocol（已完成）
 - `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md` — P17 bootstrap knowledge lifecycle CLI（已完成）
 - `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md` — P18 bootstrap knowledge distill CLI（已完成）
+- `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md` — P19 lifecycle evidence ref validation（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P18）
+### 已完成的 Spec（P0-P19）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -63,6 +63,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p16-context-skill-guidance.spec.md` | 完成 | context-guided skill selection protocol：`mempal_context` 辅助 workflow/skill/tool 选择，但 `trigger_hints` 只做 bias、不自动执行 |
 | `specs/p17-knowledge-lifecycle.spec.md` | 完成 | bootstrap knowledge lifecycle CLI：`mempal knowledge promote/demote` 受约束更新 knowledge drawer status 与 refs，并写 audit |
 | `specs/p18-knowledge-distill.spec.md` | 完成 | bootstrap knowledge distill CLI：`mempal knowledge distill` 从 evidence refs 创建 candidate knowledge drawer |
+| `specs/p19-lifecycle-ref-validation.spec.md` | 完成 | lifecycle evidence ref hardening：`promote/demote` refs 必须是存在的 evidence drawers |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -90,6 +91,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p16-context-skill-guidance-implementation.md` — P16 context-guided skill selection protocol（已完成）
 - `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md` — P17 bootstrap knowledge lifecycle CLI（已完成）
 - `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md` — P18 bootstrap knowledge distill CLI（已完成）
+- `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md` — P19 lifecycle evidence ref validation（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -821,6 +821,7 @@ Implemented Phase-1 runtime surface:
 - memory hints never override system, user, repo, or client-native skill rules
 - bootstrap distill CLI creates candidate `dao_ren` / `qi` knowledge drawers from existing evidence refs without auto-promotion or LLM summarization
 - bootstrap lifecycle CLI supports manual `promote` / `demote` on existing knowledge drawers by updating status plus verification / counterexample refs and writing audit entries
+- lifecycle verification / counterexample refs are hardened to require existing evidence drawers, preserving the rule that promotion and demotion are justified by evidence rather than arbitrary ids or other knowledge claims
 - lifecycle updates are metadata-only in Stage 1; they do not rewrite content, re-embed vectors, or create Phase-2 knowledge cards
 
 ### Phase 2: Knowledge Card Extraction

--- a/docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md
+++ b/docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md
@@ -1,0 +1,38 @@
+# P19 Lifecycle Ref Validation Implementation Plan
+
+**Goal:** Harden P17 lifecycle commands so promotion and demotion refs must point to evidence drawers, matching P18 distill ref discipline.
+
+**Architecture:** Keep validation in the CLI lifecycle path for Stage 1. Reuse existing `Database::get_drawer` and `MemoryKind` metadata; do not add schema, MCP/REST endpoints, or evaluator logic.
+
+## Task 1: Contract And Tests
+
+- [x] Add `specs/p19-lifecycle-ref-validation.spec.md`.
+- [x] Add failing integration tests for malformed refs, missing refs, wrong memory kind, and accepted evidence refs.
+- [x] Run focused test selectors and confirm failures before implementation.
+
+## Task 2: Lifecycle Ref Validation
+
+- [x] Replace existence-only lifecycle ref validation with evidence drawer validation.
+- [x] Preserve existing stable de-duplication and audit behavior.
+- [x] Keep success output and lifecycle state mutation unchanged.
+
+## Task 3: Docs And Verification
+
+- [x] Update usage and project status docs for P19.
+- [x] Update `MIND-MODEL-DESIGN.md` implemented Stage-1 surface.
+- [x] Run spec parse/lint.
+- [x] Run Rust formatting, clippy, targeted lifecycle tests, full tests, and `--features rest` check.
+- [ ] Commit, ingest project memory, push branch, and open PR.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p19-lifecycle-ref-validation.spec.md
+agent-spec lint specs/p19-lifecycle-ref-validation.spec.md --min-score 0.7
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --test knowledge_lifecycle -- --nocapture
+cargo test
+cargo check --features rest
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -194,7 +194,9 @@ or `tier=qi`. `dao_tian` and `shu` are intentionally excluded from candidate
 distill because the current P12 status policy does not allow candidate states
 for those tiers. Use `promote` only after review.
 
-P17 adds manual lifecycle commands for Stage-1 knowledge drawers:
+P17 adds manual lifecycle commands for Stage-1 knowledge drawers. P19 hardens
+those commands so lifecycle refs must be existing evidence drawers, not arbitrary
+ids or other knowledge drawers:
 
 ```bash
 mempal knowledge promote drawer_knowledge \
@@ -212,7 +214,7 @@ mempal knowledge demote drawer_knowledge \
   --reason-type contradicted
 ```
 
-Lifecycle commands only update existing `memory_kind=knowledge` drawers. They do not change content, re-embed vectors, bump schema, or add Phase-2 `knowledge_cards`. Successful distill and lifecycle changes append JSONL audit entries.
+Lifecycle commands only update existing `memory_kind=knowledge` drawers. They validate that `--verification-ref` / `--evidence-ref` values start with `drawer_`, exist, and point to `memory_kind=evidence`. They do not change content, re-embed vectors, bump schema, or add Phase-2 `knowledge_cards`. Successful distill and lifecycle changes append JSONL audit entries.
 
 ### 4. Search
 

--- a/specs/p19-lifecycle-ref-validation.spec.md
+++ b/specs/p19-lifecycle-ref-validation.spec.md
@@ -1,0 +1,103 @@
+spec: task
+name: "P19: lifecycle evidence ref validation"
+inherits: project
+tags: [memory, knowledge, lifecycle, validation]
+estimate: 0.25d
+---
+
+## Intent
+
+P17 added manual knowledge lifecycle commands, and P18 made `distill` require
+role refs to point to evidence drawers. P19 applies the same evidence discipline
+to `promote` and `demote`, so lifecycle state changes cannot be justified by
+missing refs, malformed ids, or knowledge drawers masquerading as evidence.
+
+This is a Stage-1 governance hardening task. It does not introduce evaluator
+scoring, MCP/REST lifecycle endpoints, schema changes, or Phase-2 knowledge
+cards.
+
+## Decisions
+
+- `mempal knowledge promote` `--verification-ref` values must be evidence drawer ids
+- `mempal knowledge demote` `--evidence-ref` values must be evidence drawer ids
+- A valid lifecycle evidence ref must:
+  - start with `drawer_`
+  - exist in the database
+  - have evidence memory kind
+- The existing requirement for at least one lifecycle ref remains unchanged
+- Refs are still appended with stable de-duplication after validation
+- Error messages should distinguish malformed ids, missing drawers, and wrong drawer kind
+- No MCP / REST lifecycle endpoint
+
+## Boundaries
+
+### Allowed Changes
+- `src/main.rs`
+- `tests/knowledge_lifecycle.rs`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `specs/p19-lifecycle-ref-validation.spec.md`
+- `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md`
+
+### Forbidden
+- Do not add tables, columns, triggers, or migrations
+- Do not add Phase-2 `knowledge_cards`
+- Do not add MCP / REST lifecycle endpoints
+- Do not change `mempal_context` response schema or ordering
+- Do not change search ranking
+- Do not introduce new dependencies
+
+## Out of Scope
+
+- evaluator scoring
+- automatic promotion or demotion
+- human review UI
+- lifecycle event table
+- research-rs integration
+- ref role inference
+
+## Completion Criteria
+
+Scenario: promote rejects malformed verification refs
+  Test:
+    Filter: test_cli_knowledge_promote_rejects_malformed_verification_ref
+    Level: integration
+  Given a candidate knowledge drawer exists
+  When running `mempal knowledge promote <id> --status promoted --verification-ref not_a_drawer --reason bad`
+  Then the command fails
+  And the error says lifecycle refs must contain drawer ids
+  And the knowledge status remains unchanged
+
+Scenario: promote rejects knowledge drawers as verification evidence
+  Test:
+    Filter: test_cli_knowledge_promote_rejects_knowledge_verification_ref
+    Level: integration
+  Given a candidate knowledge drawer exists
+  And another knowledge drawer exists
+  When running `mempal knowledge promote <id> --status promoted --verification-ref <knowledge_id> --reason bad`
+  Then the command fails
+  And the error says lifecycle refs must point to evidence drawers
+  And the knowledge status remains unchanged
+
+Scenario: demote rejects missing evidence refs
+  Test:
+    Filter: test_cli_knowledge_demote_rejects_missing_evidence_ref
+    Level: integration
+  Given a promoted knowledge drawer exists
+  When running `mempal knowledge demote <id> --status demoted --evidence-ref drawer_missing --reason bad --reason-type contradicted`
+  Then the command fails
+  And the error says ref drawer not found
+  And the knowledge status remains unchanged
+
+Scenario: lifecycle still accepts real evidence refs
+  Test:
+    Filter: test_cli_knowledge_lifecycle_accepts_evidence_refs
+    Level: integration
+  Given a candidate knowledge drawer exists
+  And an evidence drawer exists
+  When running `mempal knowledge promote <id> --status promoted --verification-ref <evidence_id> --reason validated`
+  Then the command succeeds
+  And the knowledge status becomes promoted
+  And `verification_refs` contains `<evidence_id>`

--- a/src/main.rs
+++ b/src/main.rs
@@ -1596,11 +1596,15 @@ fn validate_lifecycle_refs(db: &Database, refs: &[String]) -> Result<()> {
         bail!("at least one lifecycle evidence ref is required");
     }
     for drawer_id in refs {
-        if !db
-            .drawer_exists(drawer_id)
-            .with_context(|| format!("failed to check ref drawer {drawer_id}"))?
-        {
-            bail!("ref drawer not found: {drawer_id}");
+        if !drawer_id.starts_with("drawer_") {
+            bail!("lifecycle refs must contain drawer ids");
+        }
+        let drawer = db
+            .get_drawer(drawer_id)
+            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
+            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
+        if drawer.memory_kind != MemoryKind::Evidence {
+            bail!("lifecycle refs must point to evidence drawers");
         }
     }
     Ok(())

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -199,6 +199,14 @@ fn vector_row_count(db: &Database, id: &str) -> i64 {
         .expect("count vector rows")
 }
 
+fn knowledge_status(db: &Database, id: &str) -> KnowledgeStatus {
+    db.get_drawer(id)
+        .expect("load drawer")
+        .expect("drawer exists")
+        .status
+        .expect("knowledge status")
+}
+
 #[tokio::test]
 async fn test_cli_knowledge_promote_updates_status_and_verification_refs() {
     let (home, db) = setup_home();
@@ -243,6 +251,163 @@ async fn test_cli_knowledge_promote_updates_status_and_verification_refs() {
 
     let ids = default_context_ids(&db, home.path(), "lifecycle promote").await;
     assert!(ids.contains(&"drawer_knowledge".to_string()));
+}
+
+#[test]
+fn test_cli_knowledge_promote_rejects_malformed_verification_ref() {
+    let (home, db) = setup_home();
+    insert_knowledge(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Lifecycle refs must be drawer ids.",
+        "malformed ref lifecycle",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "promote",
+            "drawer_knowledge",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "not_a_drawer",
+            "--reason",
+            "bad",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("lifecycle refs must contain drawer ids")
+    );
+    assert_eq!(
+        knowledge_status(&db, "drawer_knowledge"),
+        KnowledgeStatus::Candidate
+    );
+}
+
+#[test]
+fn test_cli_knowledge_promote_rejects_knowledge_verification_ref() {
+    let (home, db) = setup_home();
+    insert_knowledge(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Promotion requires evidence refs.",
+        "wrong kind lifecycle",
+    );
+    insert_knowledge(
+        &db,
+        "drawer_other_knowledge",
+        KnowledgeTier::Qi,
+        KnowledgeStatus::Candidate,
+        "Knowledge is not evidence.",
+        "wrong kind ref",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "promote",
+            "drawer_knowledge",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_other_knowledge",
+            "--reason",
+            "bad",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("lifecycle refs must point to evidence drawers")
+    );
+    assert_eq!(
+        knowledge_status(&db, "drawer_knowledge"),
+        KnowledgeStatus::Candidate
+    );
+}
+
+#[test]
+fn test_cli_knowledge_demote_rejects_missing_evidence_ref() {
+    let (home, db) = setup_home();
+    insert_knowledge(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Demotion requires existing evidence refs.",
+        "missing evidence lifecycle",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "demote",
+            "drawer_knowledge",
+            "--status",
+            "demoted",
+            "--evidence-ref",
+            "drawer_missing",
+            "--reason",
+            "bad",
+            "--reason-type",
+            "contradicted",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("ref drawer not found"));
+    assert_eq!(
+        knowledge_status(&db, "drawer_knowledge"),
+        KnowledgeStatus::Promoted
+    );
+}
+
+#[test]
+fn test_cli_knowledge_lifecycle_accepts_evidence_refs() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_verify", "validation evidence");
+    insert_knowledge(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Lifecycle accepts real evidence.",
+        "accepted evidence lifecycle",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "promote",
+            "drawer_knowledge",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_verify",
+            "--reason",
+            "validated",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let drawer = db
+        .get_drawer("drawer_knowledge")
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.status, Some(KnowledgeStatus::Promoted));
+    assert_eq!(drawer.verification_refs, vec!["drawer_verify"]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Implements P19 lifecycle evidence ref validation.

- Hardens `mempal knowledge promote` so `--verification-ref` must point to existing evidence drawers.
- Hardens `mempal knowledge demote` so `--evidence-ref` must point to existing evidence drawers.
- Rejects malformed ids, missing drawers, and non-evidence drawer refs.
- Preserves existing lifecycle mutation, stable ref de-duplication, audit behavior, context behavior, vectors, and schema.

## Verification

- `agent-spec parse specs/p19-lifecycle-ref-validation.spec.md`
- `agent-spec lint specs/p19-lifecycle-ref-validation.spec.md --min-score 0.7`
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --test knowledge_lifecycle -- --nocapture`
- `cargo test`
- `cargo check --features rest`
