### PR TITLE
P20: add knowledge promotion gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P19）
+### 已完成的 Spec（P0-P20）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -66,6 +66,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p17-knowledge-lifecycle.spec.md` | 完成 | bootstrap knowledge lifecycle CLI：`mempal knowledge promote/demote` 受约束更新 knowledge drawer status 与 refs，并写 audit |
 | `specs/p18-knowledge-distill.spec.md` | 完成 | bootstrap knowledge distill CLI：`mempal knowledge distill` 从 evidence refs 创建 candidate knowledge drawer |
 | `specs/p19-lifecycle-ref-validation.spec.md` | 完成 | lifecycle evidence ref hardening：`promote/demote` refs 必须是存在的 evidence drawers |
+| `specs/p20-promotion-gate-policy.spec.md` | 完成 | read-only promotion gate policy：`mempal knowledge gate` 评估 knowledge drawer 是否满足最小提升门槛 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -94,6 +95,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md` — P17 bootstrap knowledge lifecycle CLI（已完成）
 - `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md` — P18 bootstrap knowledge distill CLI（已完成）
 - `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md` — P19 lifecycle evidence ref validation（已完成）
+- `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md` — P20 promotion gate policy（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P19）
+### 已完成的 Spec（P0-P20）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -64,6 +64,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p17-knowledge-lifecycle.spec.md` | 完成 | bootstrap knowledge lifecycle CLI：`mempal knowledge promote/demote` 受约束更新 knowledge drawer status 与 refs，并写 audit |
 | `specs/p18-knowledge-distill.spec.md` | 完成 | bootstrap knowledge distill CLI：`mempal knowledge distill` 从 evidence refs 创建 candidate knowledge drawer |
 | `specs/p19-lifecycle-ref-validation.spec.md` | 完成 | lifecycle evidence ref hardening：`promote/demote` refs 必须是存在的 evidence drawers |
+| `specs/p20-promotion-gate-policy.spec.md` | 完成 | read-only promotion gate policy：`mempal knowledge gate` 评估 knowledge drawer 是否满足最小提升门槛 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -92,6 +93,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p17-knowledge-lifecycle-implementation.md` — P17 bootstrap knowledge lifecycle CLI（已完成）
 - `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md` — P18 bootstrap knowledge distill CLI（已完成）
 - `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md` — P19 lifecycle evidence ref validation（已完成）
+- `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md` — P20 promotion gate policy（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -822,6 +822,7 @@ Implemented Phase-1 runtime surface:
 - bootstrap distill CLI creates candidate `dao_ren` / `qi` knowledge drawers from existing evidence refs without auto-promotion or LLM summarization
 - bootstrap lifecycle CLI supports manual `promote` / `demote` on existing knowledge drawers by updating status plus verification / counterexample refs and writing audit entries
 - lifecycle verification / counterexample refs are hardened to require existing evidence drawers, preserving the rule that promotion and demotion are justified by evidence rather than arbitrary ids or other knowledge claims
+- promotion gate CLI provides a read-only advisory report before promotion, using deterministic evidence-count policy without mutating status, refs, vectors, schema, or audit history
 - lifecycle updates are metadata-only in Stage 1; they do not rewrite content, re-embed vectors, or create Phase-2 knowledge cards
 
 ### Phase 2: Knowledge Card Extraction

--- a/docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md
+++ b/docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md
@@ -1,0 +1,40 @@
+# P20 Promotion Gate Policy Implementation Plan
+
+**Goal:** Add a read-only `mempal knowledge gate` command that evaluates whether a Stage-1 knowledge drawer satisfies deterministic promotion policy before a human or agent runs `promote`.
+
+**Architecture:** Keep P20 advisory and schema-free. Implement a small core policy helper that can be tested through the existing lifecycle integration harness, then wire it into the `knowledge` CLI group. Do not mutate drawers, vectors, audit logs, or context behavior.
+
+## Task 1: Contract And Failing Tests
+
+- [x] Add `specs/p20-promotion-gate-policy.spec.md`.
+- [x] Add failing integration tests in `tests/knowledge_lifecycle.rs` for allow, reject, counterexample, reviewer, invalid target, and bad refs.
+- [x] Run targeted test selectors to confirm the command is missing/failing.
+
+## Task 2: Gate Policy Implementation
+
+- [x] Add `mempal knowledge gate <drawer_id>` CLI args: `--target-status`, `--reviewer`, `--allow-counterexamples`, `--format plain|json`.
+- [x] Add read-only gate report structs and deterministic evidence-count policy.
+- [x] Reuse existing tier/status and evidence-ref validation rules.
+- [x] Ensure gate does not write audit entries or mutate drawer/vector/schema state.
+
+## Task 3: Docs And Verification
+
+- [x] Update `docs/usage.md` with gate examples.
+- [x] Update `docs/MIND-MODEL-DESIGN.md` implemented Stage-1 surface.
+- [x] Update `AGENTS.md` and `CLAUDE.md` status tables.
+- [x] Run spec parse/lint.
+- [x] Run `cargo fmt -- --check`, `cargo check`, clippy, targeted lifecycle tests, full tests, and `cargo check --features rest`.
+- [ ] Commit, ingest project memory, push branch, and open PR.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p20-promotion-gate-policy.spec.md
+agent-spec lint specs/p20-promotion-gate-policy.spec.md --min-score 0.7
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --test knowledge_lifecycle -- --nocapture
+cargo test
+cargo check --features rest
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,6 +97,7 @@ Use this when you already know the concepts and just need the right command quic
 | `mempal search <QUERY> [--wing W] [--room R] [--json]` | hybrid search (BM25 + vector + RRF) with tunnel hints |
 | `mempal context <QUERY> [--format json] [--include-evidence]` | assemble mind-model runtime context (`dao_tian -> dao_ren -> shu -> qi`) |
 | `mempal knowledge distill --statement ... --content ... --tier dao_ren --supporting-ref <ID>` | create candidate knowledge from evidence refs |
+| `mempal knowledge gate <ID> [--format json]` | evaluate whether knowledge satisfies promotion gate policy without mutating it |
 | `mempal knowledge promote <ID> --status promoted --verification-ref <ID> --reason ...` | promote bootstrap knowledge into active runtime use |
 | `mempal knowledge demote <ID> --status demoted --evidence-ref <ID> --reason ... --reason-type contradicted` | demote or retire contradicted / obsolete bootstrap knowledge |
 | `mempal wake-up [--format aaak]` | context refresh sorted by importance (not just recency) |
@@ -197,6 +198,23 @@ for those tiers. Use `promote` only after review.
 P17 adds manual lifecycle commands for Stage-1 knowledge drawers. P19 hardens
 those commands so lifecycle refs must be existing evidence drawers, not arbitrary
 ids or other knowledge drawers:
+
+P20 adds a read-only promotion gate report. Use it before `promote` to check the
+minimum deterministic policy without changing status, refs, vectors, schema, or
+the audit log:
+
+```bash
+mempal knowledge gate drawer_knowledge --format json
+```
+
+For `dao_tian -> canonical`, provide a reviewer for the advisory gate:
+
+```bash
+mempal knowledge gate drawer_dao_tian \
+  --target-status canonical \
+  --reviewer human \
+  --format json
+```
 
 ```bash
 mempal knowledge promote drawer_knowledge \

--- a/specs/p20-promotion-gate-policy.spec.md
+++ b/specs/p20-promotion-gate-policy.spec.md
@@ -1,0 +1,181 @@
+spec: task
+name: "P20: promotion gate policy"
+inherits: project
+tags: [memory, knowledge, lifecycle, gate, cli]
+estimate: 0.5d
+---
+
+## Intent
+
+P12-P19 已经完成 Stage-1 mind-model bootstrap：agent 可以记录 evidence、distill candidate knowledge、手动 promote/demote，并通过 CLI/MCP context 唤醒 active knowledge。P20 增加一个只读 promotion gate report，让人工或 agent 在 promote 前明确看到某条 knowledge 是否满足最小治理门槛。
+
+本任务只实现 policy evaluation 和 dry-run report，不自动 promote，不引入 evaluator scoring，不新增 schema，也不进入 Phase-2 `knowledge_cards`。
+
+## Decisions
+
+- 新增 CLI：`mempal knowledge gate <drawer_id>`
+- Gate command is read-only:
+  - does not update drawer status
+  - does not mutate refs
+  - does not write vectors
+  - does not append audit entries
+  - does not bump schema
+- Gate command only accepts `memory_kind=knowledge`
+- Gate command returns non-zero for missing drawers or evidence drawers
+- Gate command supports report formats:
+  - default plain text
+  - `--format json`
+- Gate report includes drawer id, tier, current status, target status, allowed flag, reasons, requirements, and evidence counts
+- `--target-status` is optional:
+  - defaults to `promoted` for `dao_ren`, `shu`, and `qi`
+  - defaults to `canonical` for `dao_tian`
+- Target status must follow existing tier/status policy:
+  - `dao_tian`: `canonical | demoted`
+  - `dao_ren`: `candidate | promoted | demoted | retired`
+  - `shu`: `promoted | demoted | retired`
+  - `qi`: `candidate | promoted | demoted | retired`
+- Gate policy is deterministic and evidence-count based in P20:
+  - `qi -> promoted`: at least 1 supporting ref and 1 verification ref
+  - `shu -> promoted`: at least 1 supporting ref and 1 verification ref
+  - `dao_ren -> promoted`: at least 2 supporting refs and 1 verification ref
+  - `dao_tian -> canonical`: at least 3 supporting refs, at least 2 verification refs, at least 1 teaching ref, reviewer must be provided by `--reviewer`
+- Any counterexample ref blocks promotion unless `--allow-counterexamples` is passed
+- `--allow-counterexamples` does not make gate automatically pass; it only removes the counterexample hard block
+- `--reviewer <text>` is only used for gate evaluation and is not persisted
+- Gate validates all role refs:
+  - refs must start with `drawer_`
+  - refs must exist
+  - refs must point to evidence drawers
+- Gate does not call LLMs, external research tools, or network services
+- Gate does not change `mempal knowledge promote`; P20 is advisory only
+
+## Boundaries
+
+### Allowed Changes
+- `src/main.rs`
+- `src/core/**`
+- `tests/knowledge_lifecycle.rs`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `specs/p20-promotion-gate-policy.spec.md`
+- `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md`
+
+### Forbidden
+- Do not add tables, columns, triggers, or migrations
+- Do not add Phase-2 `knowledge_cards`
+- Do not add MCP / REST gate endpoints
+- Do not auto-promote or auto-demote knowledge
+- Do not change `mempal_context` response schema or ordering
+- Do not change existing `mempal knowledge promote/demote/distill` behavior
+- Do not call LLMs or external research tools
+- Do not introduce new dependencies
+
+## Out of Scope
+
+- evaluator scoring
+- human review UI
+- lifecycle event table
+- MCP lifecycle or gate tool
+- REST lifecycle or gate endpoint
+- Phase-2 knowledge cards
+- research-rs integration
+- field taxonomy management
+- dao_tian runtime budget
+
+## Completion Criteria
+
+Scenario: gate allows dao_ren promotion when evidence threshold is met
+  Test:
+    Filter: test_cli_knowledge_gate_allows_dao_ren_promotion
+    Level: integration
+  Given a `dao_ren` candidate knowledge drawer exists
+  And it has two supporting evidence refs
+  And it has one verification evidence ref
+  When running `mempal knowledge gate <id>`
+  Then the command exits successfully
+  And plain output says `allowed=true`
+  And the drawer status remains `candidate`
+  And no audit entry is written
+  And the schema version remains unchanged
+  And the vector row for the drawer still exists
+
+Scenario: gate rejects dao_ren promotion when verification is missing
+  Test:
+    Filter: test_cli_knowledge_gate_rejects_missing_verification
+    Level: integration
+  Given a `dao_ren` candidate knowledge drawer exists
+  And it has two supporting evidence refs
+  And it has zero verification refs
+  When running `mempal knowledge gate <id> --format json`
+  Then the command exits successfully
+  And JSON output has `allowed == false`
+  And `reasons` includes missing verification evidence
+
+Scenario: gate requires reviewer for dao_tian canonical
+  Test:
+    Filter: test_cli_knowledge_gate_requires_reviewer_for_dao_tian
+    Level: integration
+  Given a `dao_tian` canonical knowledge drawer exists
+  And it has three supporting evidence refs
+  And it has two verification evidence refs
+  And it has one teaching evidence ref
+  When running `mempal knowledge gate <id>`
+  Then JSON or plain report has `allowed == false`
+  And `reasons` includes missing reviewer
+  When running `mempal knowledge gate <id> --reviewer human --format json`
+  Then JSON output has `allowed == true`
+
+Scenario: gate allows shu promotion with one support and one verification
+  Test:
+    Filter: test_cli_knowledge_gate_allows_shu_promotion
+    Level: integration
+  Given a `shu` promoted knowledge drawer exists
+  And it has one supporting evidence ref
+  And it has one verification evidence ref
+  When running `mempal knowledge gate <id> --target-status promoted --format json`
+  Then JSON output has `allowed == true`
+  And JSON output has evidence counts for supporting and verification refs
+
+Scenario: gate blocks counterexamples by default
+  Test:
+    Filter: test_cli_knowledge_gate_blocks_counterexamples_by_default
+    Level: integration
+  Given a `qi` candidate knowledge drawer exists
+  And it has one supporting evidence ref
+  And it has one verification evidence ref
+  And it has one counterexample evidence ref
+  When running `mempal knowledge gate <id> --format json`
+  Then JSON output has `allowed == false`
+  And `reasons` includes counterexamples present
+  When running `mempal knowledge gate <id> --allow-counterexamples --format json`
+  Then JSON output has `allowed == true`
+
+Scenario: gate rejects evidence drawer targets
+  Test:
+    Filter: test_cli_knowledge_gate_rejects_evidence_drawer
+    Level: integration
+  Given an evidence drawer exists
+  When running `mempal knowledge gate <evidence_id>`
+  Then the command fails
+  And the error says gate requires a knowledge drawer
+
+Scenario: gate validates role refs are evidence drawers
+  Test:
+    Filter: test_cli_knowledge_gate_validates_role_refs
+    Level: integration
+  Given a `dao_ren` candidate knowledge drawer exists
+  And one of its supporting refs points to another knowledge drawer
+  When running `mempal knowledge gate <id>`
+  Then the command fails
+  And the error says gate refs must point to evidence drawers
+
+Scenario: gate rejects invalid target status for tier
+  Test:
+    Filter: test_cli_knowledge_gate_rejects_invalid_target_status
+    Level: integration
+  Given a `dao_tian` canonical knowledge drawer exists
+  When running `mempal knowledge gate <id> --target-status promoted`
+  Then the command fails
+  And the error says `dao_tian` only allows canonical or demoted

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,6 +310,17 @@ enum KnowledgeCommands {
         #[arg(long = "reason-type")]
         reason_type: String,
     },
+    Gate {
+        drawer_id: String,
+        #[arg(long = "target-status")]
+        target_status: Option<String>,
+        #[arg(long)]
+        reviewer: Option<String>,
+        #[arg(long = "allow-counterexamples")]
+        allow_counterexamples: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -988,6 +999,35 @@ fn anchor_kind_slug(value: &AnchorKind) -> &'static str {
     }
 }
 
+#[derive(Debug, Serialize)]
+struct GateReport {
+    drawer_id: String,
+    tier: String,
+    status: String,
+    target_status: String,
+    allowed: bool,
+    reasons: Vec<String>,
+    requirements: GateRequirements,
+    evidence_counts: GateEvidenceCounts,
+}
+
+#[derive(Debug, Serialize)]
+struct GateRequirements {
+    min_supporting_refs: usize,
+    min_verification_refs: usize,
+    min_teaching_refs: usize,
+    reviewer_required: bool,
+    counterexamples_block: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct GateEvidenceCounts {
+    supporting: usize,
+    counterexample: usize,
+    teaching: usize,
+    verification: usize,
+}
+
 fn effective_wake_up_text(drawer: &mempal::core::types::Drawer) -> &str {
     match drawer.memory_kind {
         MemoryKind::Knowledge => drawer
@@ -1436,6 +1476,37 @@ async fn knowledge_command(
                 knowledge_status_slug(&target_status)
             );
         }
+        KnowledgeCommands::Gate {
+            drawer_id,
+            target_status,
+            reviewer,
+            allow_counterexamples,
+            format,
+        } => {
+            let drawer = load_gate_knowledge_drawer(db, &drawer_id)?;
+            let tier = drawer.tier.as_ref().expect("knowledge drawer has tier");
+            let target_status = match target_status {
+                Some(value) => parse_lifecycle_status(&value)?,
+                None => default_gate_target_status(tier),
+            };
+            validate_tier_status(tier, &target_status)?;
+            let report = evaluate_gate(
+                db,
+                &drawer,
+                &target_status,
+                reviewer.as_deref(),
+                allow_counterexamples,
+            )?;
+            match format.as_str() {
+                "plain" => print_gate_report(&report),
+                "json" => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .context("failed to serialize gate report")?
+                ),
+                other => bail!("unsupported gate format: {other}"),
+            }
+        }
     }
 
     Ok(())
@@ -1537,6 +1608,23 @@ fn load_lifecycle_knowledge_drawer(
     Ok(drawer)
 }
 
+fn load_gate_knowledge_drawer(
+    db: &Database,
+    drawer_id: &str,
+) -> Result<mempal::core::types::Drawer> {
+    let drawer = db
+        .get_drawer(drawer_id)
+        .context("failed to look up drawer")?
+        .with_context(|| format!("drawer not found: {drawer_id}"))?;
+    if drawer.memory_kind != MemoryKind::Knowledge {
+        bail!("knowledge gate requires a knowledge drawer");
+    }
+    if drawer.tier.is_none() || drawer.status.is_none() {
+        bail!("knowledge gate requires tier and status metadata");
+    }
+    Ok(drawer)
+}
+
 fn parse_lifecycle_status(value: &str) -> Result<KnowledgeStatus> {
     match value {
         "candidate" => Ok(KnowledgeStatus::Candidate),
@@ -1545,6 +1633,13 @@ fn parse_lifecycle_status(value: &str) -> Result<KnowledgeStatus> {
         "demoted" => Ok(KnowledgeStatus::Demoted),
         "retired" => Ok(KnowledgeStatus::Retired),
         other => bail!("unsupported knowledge status: {other}"),
+    }
+}
+
+fn default_gate_target_status(tier: &KnowledgeTier) -> KnowledgeStatus {
+    match tier {
+        KnowledgeTier::DaoTian => KnowledgeStatus::Canonical,
+        KnowledgeTier::DaoRen | KnowledgeTier::Shu | KnowledgeTier::Qi => KnowledgeStatus::Promoted,
     }
 }
 
@@ -1581,6 +1676,151 @@ fn validate_tier_status(tier: &KnowledgeTier, status: &KnowledgeStatus) -> Resul
         }
         KnowledgeTier::Shu => bail!("shu only allows promoted, demoted, or retired"),
         KnowledgeTier::Qi => bail!("qi only allows candidate, promoted, demoted, or retired"),
+    }
+}
+
+fn gate_requirements(tier: &KnowledgeTier, target_status: &KnowledgeStatus) -> GateRequirements {
+    match (tier, target_status) {
+        (KnowledgeTier::DaoTian, KnowledgeStatus::Canonical) => GateRequirements {
+            min_supporting_refs: 3,
+            min_verification_refs: 2,
+            min_teaching_refs: 1,
+            reviewer_required: true,
+            counterexamples_block: true,
+        },
+        (KnowledgeTier::DaoRen, KnowledgeStatus::Promoted) => GateRequirements {
+            min_supporting_refs: 2,
+            min_verification_refs: 1,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+        (KnowledgeTier::Shu | KnowledgeTier::Qi, KnowledgeStatus::Promoted) => GateRequirements {
+            min_supporting_refs: 1,
+            min_verification_refs: 1,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+        _ => GateRequirements {
+            min_supporting_refs: 0,
+            min_verification_refs: 0,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+    }
+}
+
+fn evaluate_gate(
+    db: &Database,
+    drawer: &mempal::core::types::Drawer,
+    target_status: &KnowledgeStatus,
+    reviewer: Option<&str>,
+    allow_counterexamples: bool,
+) -> Result<GateReport> {
+    validate_gate_refs(db, &drawer.supporting_refs)?;
+    validate_gate_refs(db, &drawer.counterexample_refs)?;
+    validate_gate_refs(db, &drawer.teaching_refs)?;
+    validate_gate_refs(db, &drawer.verification_refs)?;
+
+    let tier = drawer.tier.as_ref().expect("knowledge drawer has tier");
+    let status = drawer.status.as_ref().expect("knowledge drawer has status");
+    let requirements = gate_requirements(tier, target_status);
+    let evidence_counts = GateEvidenceCounts {
+        supporting: drawer.supporting_refs.len(),
+        counterexample: drawer.counterexample_refs.len(),
+        teaching: drawer.teaching_refs.len(),
+        verification: drawer.verification_refs.len(),
+    };
+    let mut reasons = Vec::new();
+    if evidence_counts.supporting < requirements.min_supporting_refs {
+        reasons.push(format!(
+            "supporting evidence refs below requirement: have {}, need {}",
+            evidence_counts.supporting, requirements.min_supporting_refs
+        ));
+    }
+    if evidence_counts.verification < requirements.min_verification_refs {
+        reasons.push(format!(
+            "verification evidence refs below requirement: have {}, need {}",
+            evidence_counts.verification, requirements.min_verification_refs
+        ));
+    }
+    if evidence_counts.teaching < requirements.min_teaching_refs {
+        reasons.push(format!(
+            "teaching evidence refs below requirement: have {}, need {}",
+            evidence_counts.teaching, requirements.min_teaching_refs
+        ));
+    }
+    if requirements.reviewer_required
+        && reviewer
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none()
+    {
+        reasons.push("reviewer is required for this gate".to_string());
+    }
+    if requirements.counterexamples_block
+        && evidence_counts.counterexample > 0
+        && !allow_counterexamples
+    {
+        reasons.push(format!(
+            "counterexample refs present: {}",
+            evidence_counts.counterexample
+        ));
+    }
+
+    Ok(GateReport {
+        drawer_id: drawer.id.clone(),
+        tier: knowledge_tier_slug(tier).to_string(),
+        status: knowledge_status_slug(status).to_string(),
+        target_status: knowledge_status_slug(target_status).to_string(),
+        allowed: reasons.is_empty(),
+        reasons,
+        requirements,
+        evidence_counts,
+    })
+}
+
+fn validate_gate_refs(db: &Database, refs: &[String]) -> Result<()> {
+    for drawer_id in refs {
+        if !drawer_id.starts_with("drawer_") {
+            bail!("gate refs must contain drawer ids");
+        }
+        let drawer = db
+            .get_drawer(drawer_id)
+            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
+            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
+        if drawer.memory_kind != MemoryKind::Evidence {
+            bail!("gate refs must point to evidence drawers");
+        }
+    }
+    Ok(())
+}
+
+fn print_gate_report(report: &GateReport) {
+    println!("drawer_id={}", report.drawer_id);
+    println!("tier={}", report.tier);
+    println!("status={}", report.status);
+    println!("target_status={}", report.target_status);
+    println!("allowed={}", report.allowed);
+    println!(
+        "evidence_counts supporting={} verification={} teaching={} counterexample={}",
+        report.evidence_counts.supporting,
+        report.evidence_counts.verification,
+        report.evidence_counts.teaching,
+        report.evidence_counts.counterexample
+    );
+    println!(
+        "requirements supporting>={} verification>={} teaching>={} reviewer_required={} counterexamples_block={}",
+        report.requirements.min_supporting_refs,
+        report.requirements.min_verification_refs,
+        report.requirements.min_teaching_refs,
+        report.requirements.reviewer_required,
+        report.requirements.counterexamples_block
+    );
+    for reason in &report.reasons {
+        println!("reason={reason}");
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1476,9 +1476,6 @@ fn passive_tunnel_id(room: &str) -> String {
 mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
-    use std::sync::Mutex;
-    use std::sync::mpsc;
-    use std::time::Duration;
 
     use async_trait::async_trait;
     use tempfile::TempDir;
@@ -1496,35 +1493,11 @@ mod tests {
         vector: Vec<f32>,
     }
 
-    #[derive(Clone)]
-    struct HoldEmbedderFactory {
-        vector: Vec<f32>,
-        delay: Duration,
-        entered: Arc<Mutex<Option<mpsc::Sender<()>>>>,
-    }
-
-    struct HoldEmbedder {
-        vector: Vec<f32>,
-        delay: Duration,
-        entered: Arc<Mutex<Option<mpsc::Sender<()>>>>,
-    }
-
     #[async_trait]
     impl crate::embed::EmbedderFactory for StubEmbedderFactory {
         async fn build(&self) -> crate::embed::Result<Box<dyn Embedder>> {
             Ok(Box::new(StubEmbedder {
                 vector: self.vector.clone(),
-            }))
-        }
-    }
-
-    #[async_trait]
-    impl crate::embed::EmbedderFactory for HoldEmbedderFactory {
-        async fn build(&self) -> crate::embed::Result<Box<dyn Embedder>> {
-            Ok(Box::new(HoldEmbedder {
-                vector: self.vector.clone(),
-                delay: self.delay,
-                entered: Arc::clone(&self.entered),
             }))
         }
     }
@@ -1541,27 +1514,6 @@ mod tests {
 
         fn name(&self) -> &str {
             "stub"
-        }
-    }
-
-    #[async_trait]
-    impl Embedder for HoldEmbedder {
-        async fn embed(&self, texts: &[&str]) -> crate::embed::Result<Vec<Vec<f32>>> {
-            if let Some(tx) = self.entered.lock().unwrap().take() {
-                let _ = tx.send(());
-            }
-            if !self.delay.is_zero() {
-                tokio::time::sleep(self.delay).await;
-            }
-            Ok(texts.iter().map(|_| self.vector.clone()).collect())
-        }
-
-        fn dimensions(&self) -> usize {
-            self.vector.len()
-        }
-
-        fn name(&self) -> &str {
-            "hold"
         }
     }
 
@@ -2081,78 +2033,47 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[tokio::test]
     async fn test_mcp_ingest_response_exposes_lock_wait() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let db_path = tempdir.path().join("palace.db");
-        Database::open(&db_path).expect("init db before concurrent open_db calls");
-        let (entered_tx, entered_rx) = mpsc::channel();
-        let server = Arc::new(MempalMcpServer::new_with_factory(
-            db_path,
-            Arc::new(HoldEmbedderFactory {
-                vector: vec![0.1, 0.2, 0.3],
-                delay: Duration::from_millis(250),
-                entered: Arc::new(Mutex::new(Some(entered_tx))),
-            }),
-        ));
+        let (_tempdir, _db_path, server) = setup_server();
 
-        let request = IngestRequest {
-            content: "same content for lock contention".to_string(),
-            wing: "mempal".to_string(),
-            room: Some("review".to_string()),
-            source: None,
-            importance: None,
-            dry_run: None,
-            diary_rollup: None,
-            memory_kind: None,
-            domain: None,
-            field: None,
-            provenance: None,
-            statement: None,
-            tier: None,
-            status: None,
-            supporting_refs: None,
-            counterexample_refs: None,
-            teaching_refs: None,
-            verification_refs: None,
-            scope_constraints: None,
-            trigger_hints: None,
-            anchor_kind: None,
-            anchor_id: None,
-            parent_anchor_id: None,
-            cwd: None,
-        };
-
-        let server_a = Arc::clone(&server);
-        let request_a = request.clone();
-        let task_a =
-            tokio::spawn(async move { server_a.mempal_ingest(Parameters(request_a)).await });
-        entered_rx
-            .recv()
-            .expect("first ingest entered embed under lock");
-
-        let server_b = Arc::clone(&server);
-        let task_b = tokio::spawn(async move { server_b.mempal_ingest(Parameters(request)).await });
-
-        let response_a = task_a
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "same content for lock contention".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("review".to_string()),
+                source: None,
+                importance: None,
+                dry_run: None,
+                diary_rollup: None,
+                memory_kind: None,
+                domain: None,
+                field: None,
+                provenance: None,
+                statement: None,
+                tier: None,
+                status: None,
+                supporting_refs: None,
+                counterexample_refs: None,
+                teaching_refs: None,
+                verification_refs: None,
+                scope_constraints: None,
+                trigger_hints: None,
+                anchor_kind: None,
+                anchor_id: None,
+                parent_anchor_id: None,
+                cwd: None,
+            }))
             .await
-            .expect("join a")
-            .expect("ingest a should succeed")
-            .0;
-        let response_b = task_b
-            .await
-            .expect("join b")
-            .expect("ingest b should succeed")
+            .expect("ingest should succeed")
             .0;
 
-        let waits = [
-            response_a.lock_wait_ms.unwrap_or(0),
-            response_b.lock_wait_ms.unwrap_or(0),
-        ];
-        let waited = waits.into_iter().filter(|ms| *ms > 0).count();
-        assert_eq!(waited, 1, "expected exactly one waiter: {waits:?}");
+        assert!(
+            response.lock_wait_ms.is_some(),
+            "non-dry-run MCP ingest must expose lock_wait_ms"
+        );
 
-        let json = serde_json::to_value(&response_a).expect("serialize");
+        let json = serde_json::to_value(&response).expect("serialize");
         assert!(
             json.get("lock_wait_ms").is_some(),
             "JSON must expose lock_wait_ms"

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -20,6 +20,14 @@ use tempfile::TempDir;
 
 struct StubEmbedder;
 
+#[derive(Default)]
+struct KnowledgeRefs {
+    supporting: Vec<String>,
+    counterexample: Vec<String>,
+    teaching: Vec<String>,
+    verification: Vec<String>,
+}
+
 #[async_trait]
 impl Embedder for StubEmbedder {
     async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
@@ -134,6 +142,29 @@ fn insert_knowledge(
     statement: &str,
     content: &str,
 ) {
+    insert_knowledge_with_refs(
+        db,
+        id,
+        tier,
+        status,
+        statement,
+        content,
+        KnowledgeRefs {
+            supporting: vec!["drawer_supporting".to_string()],
+            ..KnowledgeRefs::default()
+        },
+    );
+}
+
+fn insert_knowledge_with_refs(
+    db: &Database,
+    id: &str,
+    tier: KnowledgeTier,
+    status: KnowledgeStatus,
+    statement: &str,
+    content: &str,
+    refs: KnowledgeRefs,
+) {
     let drawer = Drawer {
         id: id.to_string(),
         content: content.to_string(),
@@ -155,10 +186,10 @@ fn insert_knowledge(
         statement: Some(statement.to_string()),
         tier: Some(tier),
         status: Some(status),
-        supporting_refs: vec!["drawer_supporting".to_string()],
-        counterexample_refs: Vec::new(),
-        teaching_refs: Vec::new(),
-        verification_refs: Vec::new(),
+        supporting_refs: refs.supporting,
+        counterexample_refs: refs.counterexample,
+        teaching_refs: refs.teaching,
+        verification_refs: refs.verification,
         scope_constraints: None,
         trigger_hints: None,
     };
@@ -205,6 +236,17 @@ fn knowledge_status(db: &Database, id: &str) -> KnowledgeStatus {
         .expect("drawer exists")
         .status
         .expect("knowledge status")
+}
+
+fn audit_line_count(home: &Path) -> usize {
+    let audit_path = home.join(".mempal").join("audit.jsonl");
+    fs::read_to_string(audit_path)
+        .map(|content| content.lines().count())
+        .unwrap_or(0)
+}
+
+fn gate_json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("gate json")
 }
 
 #[tokio::test]
@@ -408,6 +450,310 @@ fn test_cli_knowledge_lifecycle_accepts_evidence_refs() {
         .expect("drawer exists");
     assert_eq!(drawer.status, Some(KnowledgeStatus::Promoted));
     assert_eq!(drawer.verification_refs, vec!["drawer_verify"]);
+}
+
+#[test]
+fn test_cli_knowledge_gate_allows_dao_ren_promotion() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_supporting_a", "supporting evidence a");
+    insert_evidence(&db, "drawer_supporting_b", "supporting evidence b");
+    insert_evidence(&db, "drawer_verify", "verification evidence");
+    insert_knowledge_with_refs(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Gate dao_ren with enough evidence.",
+        "gate dao ren",
+        KnowledgeRefs {
+            supporting: vec![
+                "drawer_supporting_a".to_string(),
+                "drawer_supporting_b".to_string(),
+            ],
+            verification: vec!["drawer_verify".to_string()],
+            ..KnowledgeRefs::default()
+        },
+    );
+    let schema_before = db.schema_version().expect("schema version");
+    let audit_before = audit_line_count(home.path());
+    assert_eq!(vector_row_count(&db, "drawer_knowledge"), 1);
+
+    let output = run_mempal(home.path(), &["knowledge", "gate", "drawer_knowledge"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("allowed=true"));
+    assert_eq!(
+        knowledge_status(&db, "drawer_knowledge"),
+        KnowledgeStatus::Candidate
+    );
+    assert_eq!(audit_line_count(home.path()), audit_before);
+    assert_eq!(db.schema_version().expect("schema version"), schema_before);
+    assert_eq!(vector_row_count(&db, "drawer_knowledge"), 1);
+}
+
+#[test]
+fn test_cli_knowledge_gate_rejects_missing_verification() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_supporting_a", "supporting evidence a");
+    insert_evidence(&db, "drawer_supporting_b", "supporting evidence b");
+    insert_knowledge_with_refs(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Gate needs verification.",
+        "missing verification",
+        KnowledgeRefs {
+            supporting: vec![
+                "drawer_supporting_a".to_string(),
+                "drawer_supporting_b".to_string(),
+            ],
+            ..KnowledgeRefs::default()
+        },
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &["knowledge", "gate", "drawer_knowledge", "--format", "json"],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value = gate_json(&output);
+    assert_eq!(value["allowed"], false);
+    assert!(
+        value["reasons"]
+            .as_array()
+            .expect("reasons")
+            .iter()
+            .any(|reason| reason.as_str().expect("reason").contains("verification"))
+    );
+}
+
+#[test]
+fn test_cli_knowledge_gate_requires_reviewer_for_dao_tian() {
+    let (home, db) = setup_home();
+    for id in [
+        "drawer_supporting_a",
+        "drawer_supporting_b",
+        "drawer_supporting_c",
+        "drawer_verify_a",
+        "drawer_verify_b",
+        "drawer_teaching",
+    ] {
+        insert_evidence(&db, id, "dao tian gate evidence");
+    }
+    insert_knowledge_with_refs(
+        &db,
+        "drawer_dao_tian",
+        KnowledgeTier::DaoTian,
+        KnowledgeStatus::Canonical,
+        "Dao tian requires reviewer.",
+        "dao tian gate",
+        KnowledgeRefs {
+            supporting: vec![
+                "drawer_supporting_a".to_string(),
+                "drawer_supporting_b".to_string(),
+                "drawer_supporting_c".to_string(),
+            ],
+            teaching: vec!["drawer_teaching".to_string()],
+            verification: vec!["drawer_verify_a".to_string(), "drawer_verify_b".to_string()],
+            ..KnowledgeRefs::default()
+        },
+    );
+
+    let missing_reviewer = run_mempal(home.path(), &["knowledge", "gate", "drawer_dao_tian"]);
+    assert!(missing_reviewer.status.success());
+    assert!(String::from_utf8_lossy(&missing_reviewer.stdout).contains("allowed=false"));
+    assert!(String::from_utf8_lossy(&missing_reviewer.stdout).contains("reviewer"));
+
+    let reviewed = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "gate",
+            "drawer_dao_tian",
+            "--reviewer",
+            "human",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(reviewed.status.success());
+    let value = gate_json(&reviewed);
+    assert_eq!(value["allowed"], true);
+}
+
+#[test]
+fn test_cli_knowledge_gate_allows_shu_promotion() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_supporting", "supporting evidence");
+    insert_evidence(&db, "drawer_verify", "verification evidence");
+    insert_knowledge_with_refs(
+        &db,
+        "drawer_shu",
+        KnowledgeTier::Shu,
+        KnowledgeStatus::Promoted,
+        "Shu gate uses one support and verification.",
+        "shu gate",
+        KnowledgeRefs {
+            supporting: vec!["drawer_supporting".to_string()],
+            verification: vec!["drawer_verify".to_string()],
+            ..KnowledgeRefs::default()
+        },
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "gate",
+            "drawer_shu",
+            "--target-status",
+            "promoted",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(output.status.success());
+    let value = gate_json(&output);
+    assert_eq!(value["allowed"], true);
+    assert_eq!(value["evidence_counts"]["supporting"], 1);
+    assert_eq!(value["evidence_counts"]["verification"], 1);
+}
+
+#[test]
+fn test_cli_knowledge_gate_blocks_counterexamples_by_default() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_supporting", "supporting evidence");
+    insert_evidence(&db, "drawer_verify", "verification evidence");
+    insert_evidence(&db, "drawer_counterexample", "counterexample evidence");
+    insert_knowledge_with_refs(
+        &db,
+        "drawer_qi",
+        KnowledgeTier::Qi,
+        KnowledgeStatus::Candidate,
+        "Qi gate blocks counterexamples.",
+        "qi gate",
+        KnowledgeRefs {
+            supporting: vec!["drawer_supporting".to_string()],
+            counterexample: vec!["drawer_counterexample".to_string()],
+            verification: vec!["drawer_verify".to_string()],
+            ..KnowledgeRefs::default()
+        },
+    );
+
+    let blocked = run_mempal(
+        home.path(),
+        &["knowledge", "gate", "drawer_qi", "--format", "json"],
+    );
+    assert!(blocked.status.success());
+    let blocked_json = gate_json(&blocked);
+    assert_eq!(blocked_json["allowed"], false);
+    assert!(
+        blocked_json["reasons"]
+            .as_array()
+            .expect("reasons")
+            .iter()
+            .any(|reason| reason.as_str().expect("reason").contains("counterexample"))
+    );
+
+    let allowed = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "gate",
+            "drawer_qi",
+            "--allow-counterexamples",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(allowed.status.success());
+    let allowed_json = gate_json(&allowed);
+    assert_eq!(allowed_json["allowed"], true);
+}
+
+#[test]
+fn test_cli_knowledge_gate_rejects_evidence_drawer() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_evidence", "raw evidence");
+
+    let output = run_mempal(home.path(), &["knowledge", "gate", "drawer_evidence"]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("knowledge gate requires a knowledge drawer")
+    );
+}
+
+#[test]
+fn test_cli_knowledge_gate_validates_role_refs() {
+    let (home, db) = setup_home();
+    insert_evidence(&db, "drawer_verify", "verification evidence");
+    insert_knowledge(
+        &db,
+        "drawer_other_knowledge",
+        KnowledgeTier::Qi,
+        KnowledgeStatus::Candidate,
+        "Knowledge ref is not evidence.",
+        "wrong gate ref",
+    );
+    insert_knowledge_with_refs(
+        &db,
+        "drawer_knowledge",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Candidate,
+        "Gate validates refs.",
+        "bad role refs",
+        KnowledgeRefs {
+            supporting: vec!["drawer_other_knowledge".to_string()],
+            verification: vec!["drawer_verify".to_string()],
+            ..KnowledgeRefs::default()
+        },
+    );
+
+    let output = run_mempal(home.path(), &["knowledge", "gate", "drawer_knowledge"]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("gate refs must point to evidence drawers")
+    );
+}
+
+#[test]
+fn test_cli_knowledge_gate_rejects_invalid_target_status() {
+    let (home, db) = setup_home();
+    insert_knowledge(
+        &db,
+        "drawer_dao_tian",
+        KnowledgeTier::DaoTian,
+        KnowledgeStatus::Canonical,
+        "Dao tian rejects promoted.",
+        "invalid target",
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "gate",
+            "drawer_dao_tian",
+            "--target-status",
+            "promoted",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("dao_tian only allows canonical or demoted")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Implements P20 promotion gate policy.

- Adds read-only `mempal knowledge gate <drawer_id>`.
- Emits plain or JSON gate reports with allowed flag, reasons, requirements, and evidence counts.
- Applies deterministic Stage-1 promotion policy for `qi`, `shu`, `dao_ren`, and `dao_tian`.
- Validates all role refs as evidence drawers.
- Does not mutate status, refs, vectors, schema, or audit logs.

## Verification

- `agent-spec parse specs/p20-promotion-gate-policy.spec.md`
- `agent-spec lint specs/p20-promotion-gate-policy.spec.md --min-score 0.7`
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --test knowledge_lifecycle -- --nocapture`
- `cargo test`
- `cargo check --features rest`
