### PR TITLE
P21: expose knowledge gate over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P20）
+### 已完成的 Spec（P0-P21）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -67,6 +67,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p18-knowledge-distill.spec.md` | 完成 | bootstrap knowledge distill CLI：`mempal knowledge distill` 从 evidence refs 创建 candidate knowledge drawer |
 | `specs/p19-lifecycle-ref-validation.spec.md` | 完成 | lifecycle evidence ref hardening：`promote/demote` refs 必须是存在的 evidence drawers |
 | `specs/p20-promotion-gate-policy.spec.md` | 完成 | read-only promotion gate policy：`mempal knowledge gate` 评估 knowledge drawer 是否满足最小提升门槛 |
+| `specs/p21-mcp-knowledge-gate.spec.md` | 完成 | `mempal_knowledge_gate` MCP 工具：向 agent runtime 暴露 P20 read-only promotion gate |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -96,6 +97,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md` — P18 bootstrap knowledge distill CLI（已完成）
 - `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md` — P19 lifecycle evidence ref validation（已完成）
 - `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md` — P20 promotion gate policy（已完成）
+- `docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md` — P21 MCP knowledge gate（已完成）
 
 ### Spec 使用方式
 
@@ -114,15 +116,16 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，11 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，12 条规则
 
-## MCP 工具（11 个）
+## MCP 工具（12 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16） |
+| `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P20）
+### 已完成的 Spec（P0-P21）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -65,6 +65,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p18-knowledge-distill.spec.md` | 完成 | bootstrap knowledge distill CLI：`mempal knowledge distill` 从 evidence refs 创建 candidate knowledge drawer |
 | `specs/p19-lifecycle-ref-validation.spec.md` | 完成 | lifecycle evidence ref hardening：`promote/demote` refs 必须是存在的 evidence drawers |
 | `specs/p20-promotion-gate-policy.spec.md` | 完成 | read-only promotion gate policy：`mempal knowledge gate` 评估 knowledge drawer 是否满足最小提升门槛 |
+| `specs/p21-mcp-knowledge-gate.spec.md` | 完成 | `mempal_knowledge_gate` MCP 工具：向 agent runtime 暴露 P20 read-only promotion gate |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -94,6 +95,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p18-knowledge-distill-implementation.md` — P18 bootstrap knowledge distill CLI（已完成）
 - `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md` — P19 lifecycle evidence ref validation（已完成）
 - `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md` — P20 promotion gate policy（已完成）
+- `docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md` — P21 MCP knowledge gate（已完成）
 
 ### Spec 使用方式
 
@@ -112,15 +114,16 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，11 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，12 条规则
 
-## MCP 工具（11 个）
+## MCP 工具（12 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16） |
+| `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -823,6 +823,7 @@ Implemented Phase-1 runtime surface:
 - bootstrap lifecycle CLI supports manual `promote` / `demote` on existing knowledge drawers by updating status plus verification / counterexample refs and writing audit entries
 - lifecycle verification / counterexample refs are hardened to require existing evidence drawers, preserving the rule that promotion and demotion are justified by evidence rather than arbitrary ids or other knowledge claims
 - promotion gate CLI provides a read-only advisory report before promotion, using deterministic evidence-count policy without mutating status, refs, vectors, schema, or audit history
+- `mempal_knowledge_gate` exposes the same read-only promotion gate to MCP-connected agents, so runtime agents can check readiness without shelling out or mutating lifecycle state
 - lifecycle updates are metadata-only in Stage 1; they do not rewrite content, re-embed vectors, or create Phase-2 knowledge cards
 
 ### Phase 2: Knowledge Card Extraction

--- a/docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md
+++ b/docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md
@@ -1,0 +1,39 @@
+# P21 MCP Knowledge Gate Implementation Plan
+
+**Goal:** Expose the P20 read-only knowledge promotion gate through MCP as `mempal_knowledge_gate`, so agents can evaluate promotion readiness without shelling out.
+
+**Architecture:** Extract the gate evaluator into a shared library module and make both CLI and MCP call the same code path. Keep the tool read-only and schema-free.
+
+## Task 1: Contract And Shared Evaluator
+
+- [x] Add `specs/p21-mcp-knowledge-gate.spec.md`.
+- [x] Extract P20 gate report and evaluator into `src/knowledge_gate.rs`.
+- [x] Keep CLI `mempal knowledge gate` output compatible by reusing the shared evaluator.
+
+## Task 2: MCP Tool Surface
+
+- [x] Add `KnowledgeGateRequest` / `KnowledgeGateResponse` DTOs.
+- [x] Add `mempal_knowledge_gate` MCP handler.
+- [x] Map invalid drawer/status/ref errors to MCP invalid-params errors.
+- [x] Add MCP tests for allow, denial, reviewer, counterexamples, bad target, bad refs, and registry/protocol exposure.
+
+## Task 3: Docs And Verification
+
+- [x] Update `MEMORY_PROTOCOL`, usage docs, MIND-MODEL implemented surface, and repo status docs.
+- [x] Run spec parse/lint.
+- [ ] Run full verification, commit, ingest project memory, push branch, and open PR.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p21-mcp-knowledge-gate.spec.md
+agent-spec lint specs/p21-mcp-knowledge-gate.spec.md --min-score 0.7
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test mcp::server::tests::test_mcp_knowledge_gate -- --nocapture
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_mempal_knowledge_gate -- --nocapture
+cargo test --test knowledge_lifecycle test_cli_knowledge_gate -- --nocapture
+cargo test
+cargo check --features rest
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,7 +201,8 @@ ids or other knowledge drawers:
 
 P20 adds a read-only promotion gate report. Use it before `promote` to check the
 minimum deterministic policy without changing status, refs, vectors, schema, or
-the audit log:
+the audit log. P21 exposes the same policy to MCP agents as
+`mempal_knowledge_gate`.
 
 ```bash
 mempal knowledge gate drawer_knowledge --format json
@@ -214,6 +215,16 @@ mempal knowledge gate drawer_dao_tian \
   --target-status canonical \
   --reviewer human \
   --format json
+```
+
+Equivalent MCP request:
+
+```json
+{
+  "drawer_id": "drawer_dao_tian",
+  "target_status": "canonical",
+  "reviewer": "human"
+}
 ```
 
 ```bash
@@ -496,11 +507,12 @@ mempal serve --mcp
 
 If `mempal` was built without the `rest` feature, plain `mempal serve` behaves the same way.
 
-The MCP server exposes eleven tools:
+The MCP server exposes twelve tools:
 
 - `mempal_status` — state + protocol + AAAK spec
 - `mempal_search` — hybrid search (BM25 + vector + RRF) with tunnel hints and AAAK-derived structured signals (`entities` / `topics` / `flags` / `emotions` / `importance_stars`)
 - `mempal_context` — mind-model runtime context pack (`dao_tian -> dao_ren -> shu -> qi`, evidence opt-in); guides workflow / skill / tool choice but never executes skills
+- `mempal_knowledge_gate` — read-only promotion readiness check for knowledge drawers; returns the same deterministic gate report as `mempal knowledge gate --format json`
 - `mempal_ingest` — store memories with optional importance (0-5) and dry_run
 - `mempal_delete` — soft-delete with audit
 - `mempal_taxonomy` — list or edit routing keywords

--- a/specs/p21-mcp-knowledge-gate.spec.md
+++ b/specs/p21-mcp-knowledge-gate.spec.md
@@ -1,0 +1,127 @@
+spec: task
+name: "P21: mempal_knowledge_gate MCP tool"
+inherits: project
+tags: [memory, knowledge, lifecycle, gate, mcp]
+---
+
+## Intent
+
+P20 added a read-only `mempal knowledge gate` CLI command, but MCP-connected agents still cannot evaluate promotion readiness without shelling out. P21 exposes the same deterministic promotion gate policy through a read-only MCP tool so agents can inspect whether a knowledge drawer is eligible for promotion before proposing or performing lifecycle work.
+
+## Decisions
+
+- Add one MCP tool named `mempal_knowledge_gate`.
+- The MCP tool reuses the same evaluator as CLI `mempal knowledge gate`; CLI and MCP must not drift.
+- Request fields are `drawer_id`, optional `target_status`, optional `reviewer`, and optional `allow_counterexamples`.
+- Response fields match the P20 JSON gate report: `drawer_id`, `tier`, `status`, `target_status`, `allowed`, `reasons`, `requirements`, and `evidence_counts`.
+- Default `target_status` remains tier-derived: `dao_tian -> canonical`; `dao_ren`, `shu`, and `qi -> promoted`.
+- The MCP tool is pure read: it must not mutate drawers, vectors, triples, tunnels, inbox files, schema version, or audit log.
+- Invalid target drawers, invalid target status, malformed refs, missing refs, and refs pointing to knowledge drawers are MCP invalid-params errors.
+- `MEMORY_PROTOCOL` tool list mentions `mempal_knowledge_gate` and describes it as a read-only promotion readiness check.
+- Docs and repo instructions list the new MCP tool and P21 completion state.
+
+## Boundaries
+
+### Allowed Changes
+- `src/knowledge_gate.rs`
+- `src/lib.rs`
+- `src/main.rs`
+- `src/mcp/tools.rs`
+- `src/mcp/server.rs`
+- `src/core/protocol.rs`
+- `tests/knowledge_lifecycle.rs`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/plans/**`
+
+### Forbidden
+- Do not add a schema migration.
+- Do not add MCP promote or demote tools.
+- Do not change existing CLI gate output shape.
+- Do not change `mempal_context` response schema or ordering.
+- Do not change `mempal_search` request or response schema.
+- Do not auto-promote knowledge from the gate result.
+
+## Acceptance Criteria
+
+Scenario: MCP gate allows dao_ren promotion
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_gate_allows_dao_ren_promotion
+  Given one candidate `dao_ren` knowledge drawer with two supporting evidence refs and one verification evidence ref
+  When an MCP client calls `mempal_knowledge_gate` with only `drawer_id`
+  Then the response has `target_status="promoted"`
+  And `allowed=true`
+  And `evidence_counts.supporting=2`
+  And `evidence_counts.verification=1`
+
+Scenario: MCP gate rejects missing verification
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_gate_rejects_missing_verification
+  Given one candidate `dao_ren` knowledge drawer with two supporting evidence refs and no verification refs
+  When an MCP client calls `mempal_knowledge_gate`
+  Then the response has `allowed=false`
+  And `reasons` mentions missing verification evidence
+  And no drawer, vector, schema, or audit-log state changes
+
+Scenario: MCP gate requires reviewer for dao_tian canonical
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_gate_requires_reviewer_for_dao_tian
+  Given one canonical-eligible `dao_tian` knowledge drawer with three supporting refs, two verification refs, and one teaching ref
+  When an MCP client calls `mempal_knowledge_gate` without `reviewer`
+  Then the response has `target_status="canonical"`
+  And `allowed=false`
+  And `reasons` mentions reviewer is required
+  When the same request includes `reviewer="alex"`
+  Then the response has `allowed=true`
+
+Scenario: MCP gate blocks counterexamples by default
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_gate_blocks_counterexamples_by_default
+  Given one `shu` knowledge drawer with one supporting ref, one verification ref, and one counterexample ref
+  When an MCP client calls `mempal_knowledge_gate` without `allow_counterexamples`
+  Then the response has `allowed=false`
+  And `reasons` mentions counterexample refs
+  When the same request sets `allow_counterexamples=true`
+  Then the response has `allowed=true`
+
+Scenario: MCP gate rejects evidence drawer targets
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_gate_rejects_evidence_drawer
+  Given an evidence drawer id
+  When an MCP client calls `mempal_knowledge_gate` for that drawer
+  Then the call fails with invalid params
+  And the error mentions `knowledge drawer`
+
+Scenario: MCP gate validates refs are evidence drawers
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_gate_validates_role_refs
+  Given one knowledge drawer whose `verification_refs` contains another knowledge drawer id
+  When an MCP client calls `mempal_knowledge_gate`
+  Then the call fails with invalid params
+  And the error mentions refs must point to evidence drawers
+
+Scenario: MCP tool registry and protocol include mempal_knowledge_gate
+  Test:
+    Package: mempal
+    Filter: test_mcp_tool_registry_and_protocol_include_mempal_knowledge_gate
+  Given the MCP server tool registry and `MEMORY_PROTOCOL`
+  When they are inspected
+  Then the tool registry contains `mempal_knowledge_gate`
+  And the tool description mentions read-only promotion readiness
+  And `MEMORY_PROTOCOL` tool list mentions `mempal_knowledge_gate`
+
+## Out of Scope
+
+- Enforcing the gate inside `mempal knowledge promote`.
+- Adding MCP lifecycle mutation tools.
+- LLM-based scoring or confidence derivation.
+- Cross-drawer automatic distillation.
+- Phase-2 `knowledge_cards` tables.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -157,10 +157,18 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    Skip for brainstorming or scratch text — it is for load-bearing
    claims only.
 
+12. CHECK KNOWLEDGE PROMOTION READINESS
+   Before proposing that a knowledge drawer should be promoted or treated as
+   canonical, call mempal_knowledge_gate with its drawer_id. The tool is a
+   read-only policy check over existing evidence refs. If allowed=false, use
+   the reasons to gather more evidence or keep the drawer at its current
+   lifecycle status. A passing gate is advisory; it does not auto-promote.
+
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
   mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi)
+  mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_ingest        — save a new drawer (wing required, room optional, importance 0-5)
   mempal_delete        — soft-delete a drawer by ID
   mempal_taxonomy      — list or edit routing keywords
@@ -309,6 +317,22 @@ mod tests {
         assert!(
             MEMORY_PROTOCOL.contains("Use\n   mempal_search to verify project facts"),
             "MEMORY_PROTOCOL must keep fact verification and citations on mempal_search"
+        );
+    }
+
+    #[test]
+    fn contains_knowledge_gate_guidance() {
+        assert!(
+            MEMORY_PROTOCOL.contains("12. CHECK KNOWLEDGE PROMOTION READINESS"),
+            "MEMORY_PROTOCOL must include Rule 12 knowledge gate guidance"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("mempal_knowledge_gate"),
+            "MEMORY_PROTOCOL must mention mempal_knowledge_gate in TOOLS list"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("A passing gate is advisory; it does not auto-promote"),
+            "MEMORY_PROTOCOL must state that the gate is advisory"
         );
     }
 

--- a/src/knowledge_gate.rs
+++ b/src/knowledge_gate.rs
@@ -1,0 +1,259 @@
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+use crate::core::{
+    db::Database,
+    types::{Drawer, KnowledgeStatus, KnowledgeTier, MemoryKind},
+};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GateReport {
+    pub drawer_id: String,
+    pub tier: String,
+    pub status: String,
+    pub target_status: String,
+    pub allowed: bool,
+    pub reasons: Vec<String>,
+    pub requirements: GateRequirements,
+    pub evidence_counts: GateEvidenceCounts,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GateRequirements {
+    pub min_supporting_refs: usize,
+    pub min_verification_refs: usize,
+    pub min_teaching_refs: usize,
+    pub reviewer_required: bool,
+    pub counterexamples_block: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GateEvidenceCounts {
+    pub supporting: usize,
+    pub counterexample: usize,
+    pub teaching: usize,
+    pub verification: usize,
+}
+
+pub fn evaluate_gate_by_id(
+    db: &Database,
+    drawer_id: &str,
+    target_status: Option<&str>,
+    reviewer: Option<&str>,
+    allow_counterexamples: bool,
+) -> Result<GateReport> {
+    let drawer = load_gate_knowledge_drawer(db, drawer_id)?;
+    let tier = drawer.tier.as_ref().expect("knowledge drawer has tier");
+    let target_status = match target_status {
+        Some(value) => parse_status(value)?,
+        None => default_target_status(tier),
+    };
+    validate_tier_status(tier, &target_status)?;
+    evaluate_gate(db, &drawer, &target_status, reviewer, allow_counterexamples)
+}
+
+fn load_gate_knowledge_drawer(db: &Database, drawer_id: &str) -> Result<Drawer> {
+    let drawer = db
+        .get_drawer(drawer_id)
+        .context("failed to look up drawer")?
+        .with_context(|| format!("drawer not found: {drawer_id}"))?;
+    if drawer.memory_kind != MemoryKind::Knowledge {
+        bail!("knowledge gate requires a knowledge drawer");
+    }
+    if drawer.tier.is_none() || drawer.status.is_none() {
+        bail!("knowledge gate requires tier and status metadata");
+    }
+    Ok(drawer)
+}
+
+fn parse_status(value: &str) -> Result<KnowledgeStatus> {
+    match value.trim() {
+        "candidate" => Ok(KnowledgeStatus::Candidate),
+        "promoted" => Ok(KnowledgeStatus::Promoted),
+        "canonical" => Ok(KnowledgeStatus::Canonical),
+        "demoted" => Ok(KnowledgeStatus::Demoted),
+        "retired" => Ok(KnowledgeStatus::Retired),
+        other => bail!("unsupported knowledge status: {other}"),
+    }
+}
+
+fn default_target_status(tier: &KnowledgeTier) -> KnowledgeStatus {
+    match tier {
+        KnowledgeTier::DaoTian => KnowledgeStatus::Canonical,
+        KnowledgeTier::DaoRen | KnowledgeTier::Shu | KnowledgeTier::Qi => KnowledgeStatus::Promoted,
+    }
+}
+
+fn validate_tier_status(tier: &KnowledgeTier, status: &KnowledgeStatus) -> Result<()> {
+    let allowed = match tier {
+        KnowledgeTier::DaoTian => &[KnowledgeStatus::Canonical, KnowledgeStatus::Demoted][..],
+        KnowledgeTier::DaoRen => &[
+            KnowledgeStatus::Candidate,
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+        KnowledgeTier::Shu => &[
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+        KnowledgeTier::Qi => &[
+            KnowledgeStatus::Candidate,
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+    };
+
+    if allowed.contains(status) {
+        return Ok(());
+    }
+
+    match tier {
+        KnowledgeTier::DaoTian => bail!("dao_tian only allows canonical or demoted"),
+        KnowledgeTier::DaoRen => {
+            bail!("dao_ren only allows candidate, promoted, demoted, or retired")
+        }
+        KnowledgeTier::Shu => bail!("shu only allows promoted, demoted, or retired"),
+        KnowledgeTier::Qi => bail!("qi only allows candidate, promoted, demoted, or retired"),
+    }
+}
+
+fn gate_requirements(tier: &KnowledgeTier, target_status: &KnowledgeStatus) -> GateRequirements {
+    match (tier, target_status) {
+        (KnowledgeTier::DaoTian, KnowledgeStatus::Canonical) => GateRequirements {
+            min_supporting_refs: 3,
+            min_verification_refs: 2,
+            min_teaching_refs: 1,
+            reviewer_required: true,
+            counterexamples_block: true,
+        },
+        (KnowledgeTier::DaoRen, KnowledgeStatus::Promoted) => GateRequirements {
+            min_supporting_refs: 2,
+            min_verification_refs: 1,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+        (KnowledgeTier::Shu | KnowledgeTier::Qi, KnowledgeStatus::Promoted) => GateRequirements {
+            min_supporting_refs: 1,
+            min_verification_refs: 1,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+        _ => GateRequirements {
+            min_supporting_refs: 0,
+            min_verification_refs: 0,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+    }
+}
+
+fn evaluate_gate(
+    db: &Database,
+    drawer: &Drawer,
+    target_status: &KnowledgeStatus,
+    reviewer: Option<&str>,
+    allow_counterexamples: bool,
+) -> Result<GateReport> {
+    validate_gate_refs(db, &drawer.supporting_refs)?;
+    validate_gate_refs(db, &drawer.counterexample_refs)?;
+    validate_gate_refs(db, &drawer.teaching_refs)?;
+    validate_gate_refs(db, &drawer.verification_refs)?;
+
+    let tier = drawer.tier.as_ref().expect("knowledge drawer has tier");
+    let status = drawer.status.as_ref().expect("knowledge drawer has status");
+    let requirements = gate_requirements(tier, target_status);
+    let evidence_counts = GateEvidenceCounts {
+        supporting: drawer.supporting_refs.len(),
+        counterexample: drawer.counterexample_refs.len(),
+        teaching: drawer.teaching_refs.len(),
+        verification: drawer.verification_refs.len(),
+    };
+    let mut reasons = Vec::new();
+    if evidence_counts.supporting < requirements.min_supporting_refs {
+        reasons.push(format!(
+            "supporting evidence refs below requirement: have {}, need {}",
+            evidence_counts.supporting, requirements.min_supporting_refs
+        ));
+    }
+    if evidence_counts.verification < requirements.min_verification_refs {
+        reasons.push(format!(
+            "verification evidence refs below requirement: have {}, need {}",
+            evidence_counts.verification, requirements.min_verification_refs
+        ));
+    }
+    if evidence_counts.teaching < requirements.min_teaching_refs {
+        reasons.push(format!(
+            "teaching evidence refs below requirement: have {}, need {}",
+            evidence_counts.teaching, requirements.min_teaching_refs
+        ));
+    }
+    if requirements.reviewer_required
+        && reviewer
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none()
+    {
+        reasons.push("reviewer is required for this gate".to_string());
+    }
+    if requirements.counterexamples_block
+        && evidence_counts.counterexample > 0
+        && !allow_counterexamples
+    {
+        reasons.push(format!(
+            "counterexample refs present: {}",
+            evidence_counts.counterexample
+        ));
+    }
+
+    Ok(GateReport {
+        drawer_id: drawer.id.clone(),
+        tier: tier_slug(tier).to_string(),
+        status: status_slug(status).to_string(),
+        target_status: status_slug(target_status).to_string(),
+        allowed: reasons.is_empty(),
+        reasons,
+        requirements,
+        evidence_counts,
+    })
+}
+
+fn validate_gate_refs(db: &Database, refs: &[String]) -> Result<()> {
+    for drawer_id in refs {
+        if !drawer_id.starts_with("drawer_") {
+            bail!("gate refs must contain drawer ids");
+        }
+        let drawer = db
+            .get_drawer(drawer_id)
+            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
+            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
+        if drawer.memory_kind != MemoryKind::Evidence {
+            bail!("gate refs must point to evidence drawers");
+        }
+    }
+    Ok(())
+}
+
+fn tier_slug(value: &KnowledgeTier) -> &'static str {
+    match value {
+        KnowledgeTier::Qi => "qi",
+        KnowledgeTier::Shu => "shu",
+        KnowledgeTier::DaoRen => "dao_ren",
+        KnowledgeTier::DaoTian => "dao_tian",
+    }
+}
+
+fn status_slug(value: &KnowledgeStatus) -> &'static str {
+    match value {
+        KnowledgeStatus::Candidate => "candidate",
+        KnowledgeStatus::Promoted => "promoted",
+        KnowledgeStatus::Canonical => "canonical",
+        KnowledgeStatus::Demoted => "demoted",
+        KnowledgeStatus::Retired => "retired",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ pub mod cowork;
 pub mod embed;
 pub mod factcheck;
 pub mod ingest;
+pub mod knowledge_gate;
 pub mod mcp;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use mempal::ingest::{
     normalize::CURRENT_NORMALIZE_VERSION,
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
+use mempal::knowledge_gate::{GateReport, evaluate_gate_by_id};
 use mempal::mcp::MempalMcpServer;
 use mempal::search::{SearchFilters, SearchOptions, search_with_options};
 use serde::Serialize;
@@ -999,35 +1000,6 @@ fn anchor_kind_slug(value: &AnchorKind) -> &'static str {
     }
 }
 
-#[derive(Debug, Serialize)]
-struct GateReport {
-    drawer_id: String,
-    tier: String,
-    status: String,
-    target_status: String,
-    allowed: bool,
-    reasons: Vec<String>,
-    requirements: GateRequirements,
-    evidence_counts: GateEvidenceCounts,
-}
-
-#[derive(Debug, Serialize)]
-struct GateRequirements {
-    min_supporting_refs: usize,
-    min_verification_refs: usize,
-    min_teaching_refs: usize,
-    reviewer_required: bool,
-    counterexamples_block: bool,
-}
-
-#[derive(Debug, Serialize)]
-struct GateEvidenceCounts {
-    supporting: usize,
-    counterexample: usize,
-    teaching: usize,
-    verification: usize,
-}
-
 fn effective_wake_up_text(drawer: &mempal::core::types::Drawer) -> &str {
     match drawer.memory_kind {
         MemoryKind::Knowledge => drawer
@@ -1483,17 +1455,10 @@ async fn knowledge_command(
             allow_counterexamples,
             format,
         } => {
-            let drawer = load_gate_knowledge_drawer(db, &drawer_id)?;
-            let tier = drawer.tier.as_ref().expect("knowledge drawer has tier");
-            let target_status = match target_status {
-                Some(value) => parse_lifecycle_status(&value)?,
-                None => default_gate_target_status(tier),
-            };
-            validate_tier_status(tier, &target_status)?;
-            let report = evaluate_gate(
+            let report = evaluate_gate_by_id(
                 db,
-                &drawer,
-                &target_status,
+                &drawer_id,
+                target_status.as_deref(),
                 reviewer.as_deref(),
                 allow_counterexamples,
             )?;
@@ -1608,23 +1573,6 @@ fn load_lifecycle_knowledge_drawer(
     Ok(drawer)
 }
 
-fn load_gate_knowledge_drawer(
-    db: &Database,
-    drawer_id: &str,
-) -> Result<mempal::core::types::Drawer> {
-    let drawer = db
-        .get_drawer(drawer_id)
-        .context("failed to look up drawer")?
-        .with_context(|| format!("drawer not found: {drawer_id}"))?;
-    if drawer.memory_kind != MemoryKind::Knowledge {
-        bail!("knowledge gate requires a knowledge drawer");
-    }
-    if drawer.tier.is_none() || drawer.status.is_none() {
-        bail!("knowledge gate requires tier and status metadata");
-    }
-    Ok(drawer)
-}
-
 fn parse_lifecycle_status(value: &str) -> Result<KnowledgeStatus> {
     match value {
         "candidate" => Ok(KnowledgeStatus::Candidate),
@@ -1633,13 +1581,6 @@ fn parse_lifecycle_status(value: &str) -> Result<KnowledgeStatus> {
         "demoted" => Ok(KnowledgeStatus::Demoted),
         "retired" => Ok(KnowledgeStatus::Retired),
         other => bail!("unsupported knowledge status: {other}"),
-    }
-}
-
-fn default_gate_target_status(tier: &KnowledgeTier) -> KnowledgeStatus {
-    match tier {
-        KnowledgeTier::DaoTian => KnowledgeStatus::Canonical,
-        KnowledgeTier::DaoRen | KnowledgeTier::Shu | KnowledgeTier::Qi => KnowledgeStatus::Promoted,
     }
 }
 
@@ -1677,125 +1618,6 @@ fn validate_tier_status(tier: &KnowledgeTier, status: &KnowledgeStatus) -> Resul
         KnowledgeTier::Shu => bail!("shu only allows promoted, demoted, or retired"),
         KnowledgeTier::Qi => bail!("qi only allows candidate, promoted, demoted, or retired"),
     }
-}
-
-fn gate_requirements(tier: &KnowledgeTier, target_status: &KnowledgeStatus) -> GateRequirements {
-    match (tier, target_status) {
-        (KnowledgeTier::DaoTian, KnowledgeStatus::Canonical) => GateRequirements {
-            min_supporting_refs: 3,
-            min_verification_refs: 2,
-            min_teaching_refs: 1,
-            reviewer_required: true,
-            counterexamples_block: true,
-        },
-        (KnowledgeTier::DaoRen, KnowledgeStatus::Promoted) => GateRequirements {
-            min_supporting_refs: 2,
-            min_verification_refs: 1,
-            min_teaching_refs: 0,
-            reviewer_required: false,
-            counterexamples_block: true,
-        },
-        (KnowledgeTier::Shu | KnowledgeTier::Qi, KnowledgeStatus::Promoted) => GateRequirements {
-            min_supporting_refs: 1,
-            min_verification_refs: 1,
-            min_teaching_refs: 0,
-            reviewer_required: false,
-            counterexamples_block: true,
-        },
-        _ => GateRequirements {
-            min_supporting_refs: 0,
-            min_verification_refs: 0,
-            min_teaching_refs: 0,
-            reviewer_required: false,
-            counterexamples_block: true,
-        },
-    }
-}
-
-fn evaluate_gate(
-    db: &Database,
-    drawer: &mempal::core::types::Drawer,
-    target_status: &KnowledgeStatus,
-    reviewer: Option<&str>,
-    allow_counterexamples: bool,
-) -> Result<GateReport> {
-    validate_gate_refs(db, &drawer.supporting_refs)?;
-    validate_gate_refs(db, &drawer.counterexample_refs)?;
-    validate_gate_refs(db, &drawer.teaching_refs)?;
-    validate_gate_refs(db, &drawer.verification_refs)?;
-
-    let tier = drawer.tier.as_ref().expect("knowledge drawer has tier");
-    let status = drawer.status.as_ref().expect("knowledge drawer has status");
-    let requirements = gate_requirements(tier, target_status);
-    let evidence_counts = GateEvidenceCounts {
-        supporting: drawer.supporting_refs.len(),
-        counterexample: drawer.counterexample_refs.len(),
-        teaching: drawer.teaching_refs.len(),
-        verification: drawer.verification_refs.len(),
-    };
-    let mut reasons = Vec::new();
-    if evidence_counts.supporting < requirements.min_supporting_refs {
-        reasons.push(format!(
-            "supporting evidence refs below requirement: have {}, need {}",
-            evidence_counts.supporting, requirements.min_supporting_refs
-        ));
-    }
-    if evidence_counts.verification < requirements.min_verification_refs {
-        reasons.push(format!(
-            "verification evidence refs below requirement: have {}, need {}",
-            evidence_counts.verification, requirements.min_verification_refs
-        ));
-    }
-    if evidence_counts.teaching < requirements.min_teaching_refs {
-        reasons.push(format!(
-            "teaching evidence refs below requirement: have {}, need {}",
-            evidence_counts.teaching, requirements.min_teaching_refs
-        ));
-    }
-    if requirements.reviewer_required
-        && reviewer
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .is_none()
-    {
-        reasons.push("reviewer is required for this gate".to_string());
-    }
-    if requirements.counterexamples_block
-        && evidence_counts.counterexample > 0
-        && !allow_counterexamples
-    {
-        reasons.push(format!(
-            "counterexample refs present: {}",
-            evidence_counts.counterexample
-        ));
-    }
-
-    Ok(GateReport {
-        drawer_id: drawer.id.clone(),
-        tier: knowledge_tier_slug(tier).to_string(),
-        status: knowledge_status_slug(status).to_string(),
-        target_status: knowledge_status_slug(target_status).to_string(),
-        allowed: reasons.is_empty(),
-        reasons,
-        requirements,
-        evidence_counts,
-    })
-}
-
-fn validate_gate_refs(db: &Database, refs: &[String]) -> Result<()> {
-    for drawer_id in refs {
-        if !drawer_id.starts_with("drawer_") {
-            bail!("gate refs must contain drawer ids");
-        }
-        let drawer = db
-            .get_drawer(drawer_id)
-            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
-            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
-        if drawer.memory_kind != MemoryKind::Evidence {
-            bail!("gate refs must point to evidence drawers");
-        }
-    }
-    Ok(())
 }
 
 fn print_gate_report(report: &GateReport) {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -24,6 +24,7 @@ use crate::ingest::{
     },
     normalize::CURRENT_NORMALIZE_VERSION,
 };
+use crate::knowledge_gate::evaluate_gate_by_id;
 use crate::search::{SearchFilters, SearchOptions, resolve_route, search_with_vector_options};
 use anyhow::Context;
 use rmcp::{
@@ -37,10 +38,11 @@ use serde_json::Value;
 use super::tools::{
     ContextRequest, ContextResponse, CoworkPushRequest, CoworkPushResponse, DeleteRequest,
     DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, IngestRequest,
-    IngestResponse, KgRequest, KgResponse, KgStatsDto, PeekMessageDto, PeekPartnerRequest,
-    PeekPartnerResponse, ScopeCount, SearchRequest, SearchResponse, SearchResultDto,
-    StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto,
-    TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
+    IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeGateRequest, KnowledgeGateResponse,
+    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest,
+    SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest,
+    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
+    TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -113,6 +115,17 @@ impl MempalMcpServer {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         self.mempal_context(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn knowledge_gate_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<KnowledgeGateResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_knowledge_gate(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -660,6 +673,27 @@ impl MempalMcpServer {
         .map_err(context_error)?;
 
         Ok(Json(ContextResponse::from(pack)))
+    }
+
+    #[tool(
+        name = "mempal_knowledge_gate",
+        description = "Read-only promotion readiness check for a knowledge drawer. Evaluates whether dao_tian/dao_ren/shu/qi knowledge has enough supporting, verification, teaching, reviewer, and counterexample evidence for the target status. Does not mutate drawers, vectors, schema, audit logs, or lifecycle state."
+    )]
+    async fn mempal_knowledge_gate(
+        &self,
+        Parameters(request): Parameters<KnowledgeGateRequest>,
+    ) -> std::result::Result<Json<KnowledgeGateResponse>, ErrorData> {
+        let db = self.open_db()?;
+        let report = evaluate_gate_by_id(
+            &db,
+            &request.drawer_id,
+            request.target_status.as_deref(),
+            request.reviewer.as_deref(),
+            request.allow_counterexamples.unwrap_or(false),
+        )
+        .map_err(knowledge_gate_error)?;
+
+        Ok(Json(KnowledgeGateResponse::from(report)))
     }
 
     #[tool(
@@ -1360,6 +1394,10 @@ fn fact_check_error(error: crate::factcheck::FactCheckError) -> ErrorData {
     }
 }
 
+fn knowledge_gate_error(error: anyhow::Error) -> ErrorData {
+    ErrorData::invalid_params(error.to_string(), None)
+}
+
 fn context_error(error: crate::context::ContextError) -> ErrorData {
     match error {
         crate::context::ContextError::DeriveAnchor(_) => {
@@ -1474,6 +1512,7 @@ fn passive_tunnel_id(room: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
@@ -1491,6 +1530,14 @@ mod tests {
 
     struct StubEmbedder {
         vector: Vec<f32>,
+    }
+
+    #[derive(Default)]
+    struct KnowledgeRefs {
+        supporting: Vec<String>,
+        counterexample: Vec<String>,
+        teaching: Vec<String>,
+        verification: Vec<String>,
     }
 
     #[async_trait]
@@ -1563,6 +1610,29 @@ mod tests {
         statement: &str,
         content: &str,
     ) {
+        insert_knowledge_drawer_with_refs(
+            db_path,
+            id,
+            tier,
+            status,
+            statement,
+            content,
+            KnowledgeRefs {
+                supporting: vec!["drawer_supporting_ev".to_string()],
+                ..KnowledgeRefs::default()
+            },
+        );
+    }
+
+    fn insert_knowledge_drawer_with_refs(
+        db_path: &Path,
+        id: &str,
+        tier: KnowledgeTier,
+        status: KnowledgeStatus,
+        statement: &str,
+        content: &str,
+        refs: KnowledgeRefs,
+    ) {
         let db = Database::open(db_path).expect("open db");
         let drawer = Drawer {
             id: id.to_string(),
@@ -1585,16 +1655,26 @@ mod tests {
             statement: Some(statement.to_string()),
             tier: Some(tier),
             status: Some(status),
-            supporting_refs: vec!["drawer_supporting_ev".to_string()],
-            counterexample_refs: Vec::new(),
-            teaching_refs: Vec::new(),
-            verification_refs: Vec::new(),
+            supporting_refs: refs.supporting,
+            counterexample_refs: refs.counterexample,
+            teaching_refs: refs.teaching,
+            verification_refs: refs.verification,
             scope_constraints: None,
             trigger_hints: None,
         };
         db.insert_drawer(&drawer).expect("insert knowledge drawer");
         db.insert_vector(id, &[0.1, 0.2, 0.3])
             .expect("insert vector");
+    }
+
+    fn audit_line_count(db_path: &Path) -> usize {
+        let audit_path = db_path
+            .parent()
+            .expect("db path has parent")
+            .join("audit.jsonl");
+        fs::read_to_string(audit_path)
+            .map(|content| content.lines().count())
+            .unwrap_or(0)
     }
 
     fn insert_triple(
@@ -1945,6 +2025,357 @@ mod tests {
                 .unwrap_or_default()
                 .contains("dao_tian -> dao_ren -> shu -> qi")
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_gate_allows_dao_ren_promotion() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_support_1",
+            "support 1",
+            "mempal",
+            Some("gate"),
+            "/tmp/support-1.md",
+            2,
+        );
+        insert_drawer(
+            &db_path,
+            "drawer_support_2",
+            "support 2",
+            "mempal",
+            Some("gate"),
+            "/tmp/support-2.md",
+            2,
+        );
+        insert_drawer(
+            &db_path,
+            "drawer_verify_1",
+            "verify 1",
+            "mempal",
+            Some("gate"),
+            "/tmp/verify-1.md",
+            2,
+        );
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_knowledge_gate",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Candidate,
+            "Domain rules need evidence.",
+            "Knowledge content",
+            KnowledgeRefs {
+                supporting: vec![
+                    "drawer_support_1".to_string(),
+                    "drawer_support_2".to_string(),
+                ],
+                verification: vec!["drawer_verify_1".to_string()],
+                ..KnowledgeRefs::default()
+            },
+        );
+
+        let response = server
+            .knowledge_gate_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_knowledge_gate"
+            }))
+            .await
+            .expect("gate should succeed");
+
+        assert!(response.allowed, "reasons={:?}", response.reasons);
+        assert_eq!(response.target_status, "promoted");
+        assert_eq!(response.evidence_counts.supporting, 2);
+        assert_eq!(response.evidence_counts.verification, 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_gate_rejects_missing_verification() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_support_1",
+            "support 1",
+            "mempal",
+            Some("gate"),
+            "/tmp/support-1.md",
+            2,
+        );
+        insert_drawer(
+            &db_path,
+            "drawer_support_2",
+            "support 2",
+            "mempal",
+            Some("gate"),
+            "/tmp/support-2.md",
+            2,
+        );
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_knowledge_gate",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Candidate,
+            "Domain rules need verification.",
+            "Knowledge content",
+            KnowledgeRefs {
+                supporting: vec![
+                    "drawer_support_1".to_string(),
+                    "drawer_support_2".to_string(),
+                ],
+                ..KnowledgeRefs::default()
+            },
+        );
+
+        let db = Database::open(&db_path).expect("open db");
+        let schema_before = db.schema_version().expect("schema");
+        let drawer_count_before = db.drawer_count().expect("drawer count");
+        let triple_count_before = db.triple_count().expect("triple count");
+        let audit_before = audit_line_count(&db_path);
+
+        let response = server
+            .knowledge_gate_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_knowledge_gate"
+            }))
+            .await
+            .expect("gate should return advisory denial");
+
+        assert!(!response.allowed);
+        assert!(
+            response
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("verification evidence refs below requirement")),
+            "reasons={:?}",
+            response.reasons
+        );
+        assert_eq!(db.schema_version().expect("schema"), schema_before);
+        assert_eq!(
+            db.drawer_count().expect("drawer count"),
+            drawer_count_before
+        );
+        assert_eq!(
+            db.triple_count().expect("triple count"),
+            triple_count_before
+        );
+        assert_eq!(audit_line_count(&db_path), audit_before);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_gate_requires_reviewer_for_dao_tian() {
+        let (_tempdir, db_path, server) = setup_server();
+        for id in [
+            "drawer_support_1",
+            "drawer_support_2",
+            "drawer_support_3",
+            "drawer_verify_1",
+            "drawer_verify_2",
+            "drawer_teach_1",
+        ] {
+            insert_drawer(
+                &db_path,
+                id,
+                id,
+                "mempal",
+                Some("gate"),
+                &format!("/tmp/{id}.md"),
+                2,
+            );
+        }
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_knowledge_gate",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Stable cross-domain principle.",
+            "Knowledge content",
+            KnowledgeRefs {
+                supporting: vec![
+                    "drawer_support_1".to_string(),
+                    "drawer_support_2".to_string(),
+                    "drawer_support_3".to_string(),
+                ],
+                verification: vec!["drawer_verify_1".to_string(), "drawer_verify_2".to_string()],
+                teaching: vec!["drawer_teach_1".to_string()],
+                ..KnowledgeRefs::default()
+            },
+        );
+
+        let without_reviewer = server
+            .knowledge_gate_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_knowledge_gate"
+            }))
+            .await
+            .expect("gate should return advisory denial");
+        assert!(!without_reviewer.allowed);
+        assert!(
+            without_reviewer
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("reviewer is required")),
+            "reasons={:?}",
+            without_reviewer.reasons
+        );
+
+        let with_reviewer = server
+            .knowledge_gate_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_knowledge_gate",
+                "reviewer": "alex"
+            }))
+            .await
+            .expect("gate should allow with reviewer");
+        assert!(with_reviewer.allowed, "reasons={:?}", with_reviewer.reasons);
+        assert_eq!(with_reviewer.target_status, "canonical");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_gate_blocks_counterexamples_by_default() {
+        let (_tempdir, db_path, server) = setup_server();
+        for id in ["drawer_support_1", "drawer_verify_1", "drawer_counter_1"] {
+            insert_drawer(
+                &db_path,
+                id,
+                id,
+                "mempal",
+                Some("gate"),
+                &format!("/tmp/{id}.md"),
+                2,
+            );
+        }
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_knowledge_gate",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Reusable method.",
+            "Knowledge content",
+            KnowledgeRefs {
+                supporting: vec!["drawer_support_1".to_string()],
+                verification: vec!["drawer_verify_1".to_string()],
+                counterexample: vec!["drawer_counter_1".to_string()],
+                ..KnowledgeRefs::default()
+            },
+        );
+
+        let blocked = server
+            .knowledge_gate_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_knowledge_gate"
+            }))
+            .await
+            .expect("gate should return advisory denial");
+        assert!(!blocked.allowed);
+        assert!(
+            blocked
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("counterexample refs present")),
+            "reasons={:?}",
+            blocked.reasons
+        );
+
+        let allowed = server
+            .knowledge_gate_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_knowledge_gate",
+                "allow_counterexamples": true
+            }))
+            .await
+            .expect("gate should allow explicit counterexample override");
+        assert!(allowed.allowed, "reasons={:?}", allowed.reasons);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_gate_rejects_evidence_drawer() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "evidence",
+            "mempal",
+            Some("gate"),
+            "/tmp/evidence.md",
+            2,
+        );
+
+        let error = server
+            .knowledge_gate_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_evidence"
+            }))
+            .await
+            .expect_err("evidence drawer should be rejected");
+        assert!(
+            error.to_string().contains("knowledge drawer"),
+            "error={error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_gate_validates_role_refs() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_support_1",
+            "support",
+            "mempal",
+            Some("gate"),
+            "/tmp/support.md",
+            2,
+        );
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_ref_knowledge",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Candidate,
+            "Tool capability.",
+            "Knowledge ref content",
+            KnowledgeRefs {
+                supporting: vec!["drawer_support_1".to_string()],
+                ..KnowledgeRefs::default()
+            },
+        );
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_knowledge_gate",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Candidate,
+            "Domain rule.",
+            "Knowledge content",
+            KnowledgeRefs {
+                supporting: vec![
+                    "drawer_support_1".to_string(),
+                    "drawer_support_1".to_string(),
+                ],
+                verification: vec!["drawer_ref_knowledge".to_string()],
+                ..KnowledgeRefs::default()
+            },
+        );
+
+        let error = server
+            .knowledge_gate_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_knowledge_gate"
+            }))
+            .await
+            .expect_err("knowledge ref should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("gate refs must point to evidence drawers"),
+            "error={error}"
+        );
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_mempal_knowledge_gate() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let gate_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_knowledge_gate")
+            .expect("mempal_knowledge_gate tool exists");
+        assert!(
+            gate_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Read-only promotion readiness")
+        );
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_gate"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3,6 +3,7 @@ use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
     NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry, TunnelEndpoint,
 };
+use crate::knowledge_gate::GateReport;
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 
@@ -72,6 +73,69 @@ pub struct ContextResponse {
     pub field: String,
     pub anchors: Vec<ContextAnchorDto>,
     pub sections: Vec<ContextSectionDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct KnowledgeGateRequest {
+    pub drawer_id: String,
+    pub target_status: Option<String>,
+    pub reviewer: Option<String>,
+    pub allow_counterexamples: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeGateResponse {
+    pub drawer_id: String,
+    pub tier: String,
+    pub status: String,
+    pub target_status: String,
+    pub allowed: bool,
+    pub reasons: Vec<String>,
+    pub requirements: KnowledgeGateRequirementsDto,
+    pub evidence_counts: KnowledgeGateEvidenceCountsDto,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeGateRequirementsDto {
+    pub min_supporting_refs: usize,
+    pub min_verification_refs: usize,
+    pub min_teaching_refs: usize,
+    pub reviewer_required: bool,
+    pub counterexamples_block: bool,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeGateEvidenceCountsDto {
+    pub supporting: usize,
+    pub counterexample: usize,
+    pub teaching: usize,
+    pub verification: usize,
+}
+
+impl From<GateReport> for KnowledgeGateResponse {
+    fn from(report: GateReport) -> Self {
+        Self {
+            drawer_id: report.drawer_id,
+            tier: report.tier,
+            status: report.status,
+            target_status: report.target_status,
+            allowed: report.allowed,
+            reasons: report.reasons,
+            requirements: KnowledgeGateRequirementsDto {
+                min_supporting_refs: report.requirements.min_supporting_refs,
+                min_verification_refs: report.requirements.min_verification_refs,
+                min_teaching_refs: report.requirements.min_teaching_refs,
+                reviewer_required: report.requirements.reviewer_required,
+                counterexamples_block: report.requirements.counterexamples_block,
+            },
+            evidence_counts: KnowledgeGateEvidenceCountsDto {
+                supporting: report.evidence_counts.supporting,
+                counterexample: report.evidence_counts.counterexample,
+                teaching: report.evidence_counts.teaching,
+                verification: report.evidence_counts.verification,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]


### PR DESCRIPTION
## Summary
- add shared knowledge gate evaluator used by CLI and MCP
- add read-only mempal_knowledge_gate MCP tool and response DTOs
- update MEMORY_PROTOCOL, usage docs, MIND-MODEL, AGENTS/CLAUDE, and P21 spec/plan

## Verification
- agent-spec parse specs/p21-mcp-knowledge-gate.spec.md
- agent-spec lint specs/p21-mcp-knowledge-gate.spec.md --min-score 0.7
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test mcp::server::tests::test_mcp_knowledge_gate -- --nocapture
- cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_mempal_knowledge_gate -- --nocapture
- cargo test --test knowledge_lifecycle test_cli_knowledge_gate -- --nocapture
- cargo test