### PR TITLE
P22: expose knowledge distill over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P21）
+### 已完成的 Spec（P0-P22）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -68,6 +68,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p19-lifecycle-ref-validation.spec.md` | 完成 | lifecycle evidence ref hardening：`promote/demote` refs 必须是存在的 evidence drawers |
 | `specs/p20-promotion-gate-policy.spec.md` | 完成 | read-only promotion gate policy：`mempal knowledge gate` 评估 knowledge drawer 是否满足最小提升门槛 |
 | `specs/p21-mcp-knowledge-gate.spec.md` | 完成 | `mempal_knowledge_gate` MCP 工具：向 agent runtime 暴露 P20 read-only promotion gate |
+| `specs/p22-mcp-knowledge-distill.spec.md` | 完成 | `mempal_knowledge_distill` MCP 工具：从 evidence refs 创建 candidate knowledge drawer |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -98,6 +99,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md` — P19 lifecycle evidence ref validation（已完成）
 - `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md` — P20 promotion gate policy（已完成）
 - `docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md` — P21 MCP knowledge gate（已完成）
+- `docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md` — P22 MCP knowledge distill（已完成）
 
 ### Spec 使用方式
 
@@ -116,15 +118,16 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，12 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，13 条规则
 
-## MCP 工具（12 个）
+## MCP 工具（13 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16） |
+| `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P21）
+### 已完成的 Spec（P0-P22）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -66,6 +66,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p19-lifecycle-ref-validation.spec.md` | 完成 | lifecycle evidence ref hardening：`promote/demote` refs 必须是存在的 evidence drawers |
 | `specs/p20-promotion-gate-policy.spec.md` | 完成 | read-only promotion gate policy：`mempal knowledge gate` 评估 knowledge drawer 是否满足最小提升门槛 |
 | `specs/p21-mcp-knowledge-gate.spec.md` | 完成 | `mempal_knowledge_gate` MCP 工具：向 agent runtime 暴露 P20 read-only promotion gate |
+| `specs/p22-mcp-knowledge-distill.spec.md` | 完成 | `mempal_knowledge_distill` MCP 工具：从 evidence refs 创建 candidate knowledge drawer |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -96,6 +97,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-24-p19-lifecycle-ref-validation-implementation.md` — P19 lifecycle evidence ref validation（已完成）
 - `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md` — P20 promotion gate policy（已完成）
 - `docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md` — P21 MCP knowledge gate（已完成）
+- `docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md` — P22 MCP knowledge distill（已完成）
 
 ### Spec 使用方式
 
@@ -114,15 +116,16 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，12 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，13 条规则
 
-## MCP 工具（12 个）
+## MCP 工具（13 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16） |
+| `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -820,6 +820,7 @@ Implemented Phase-1 runtime surface:
 - MCP protocol guidance consumes context in order: read `dao_tian` and `dao_ren` for judgment, use `shu` to bias workflow / skill choice, and use `qi` to bias concrete tool choice
 - memory hints never override system, user, repo, or client-native skill rules
 - bootstrap distill CLI creates candidate `dao_ren` / `qi` knowledge drawers from existing evidence refs without auto-promotion or LLM summarization
+- `mempal_knowledge_distill` exposes the same deterministic distill operation to MCP-connected agents, letting runtime agents create candidate knowledge from evidence refs without shelling out
 - bootstrap lifecycle CLI supports manual `promote` / `demote` on existing knowledge drawers by updating status plus verification / counterexample refs and writing audit entries
 - lifecycle verification / counterexample refs are hardened to require existing evidence drawers, preserving the rule that promotion and demotion are justified by evidence rather than arbitrary ids or other knowledge claims
 - promotion gate CLI provides a read-only advisory report before promotion, using deterministic evidence-count policy without mutating status, refs, vectors, schema, or audit history

--- a/docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md
+++ b/docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md
@@ -1,0 +1,40 @@
+# P22 MCP Knowledge Distill Implementation Plan
+
+**Goal:** Expose P18 deterministic knowledge distill through MCP as `mempal_knowledge_distill`, so agents can create candidate knowledge drawers from evidence refs without shelling out.
+
+**Architecture:** Extract distill preparation and commit into a shared library module. Keep database work synchronous and separated from async embedding so MCP futures remain `Send`.
+
+## Task 1: Contract And Shared Distill Core
+
+- [x] Add `specs/p22-mcp-knowledge-distill.spec.md`.
+- [x] Add `src/knowledge_distill.rs` with `prepare_distill` and `commit_distill`.
+- [x] Update CLI `mempal knowledge distill` to reuse the shared core.
+- [x] Preserve P18 behavior: dry-run deterministic, existing drawer idempotent, no LLM, no auto-promotion.
+
+## Task 2: MCP Tool Surface
+
+- [x] Add `KnowledgeDistillRequest` / `KnowledgeDistillResponse`.
+- [x] Add `mempal_knowledge_distill` MCP handler.
+- [x] Avoid holding `Database` across `.await` in the MCP handler.
+- [x] Add MCP tests for create, dry-run, bad tier, bad refs, trigger hints, idempotency, registry, and protocol exposure.
+
+## Task 3: Docs And Verification
+
+- [x] Update `MEMORY_PROTOCOL`, usage docs, MIND-MODEL implemented surface, and repo status docs.
+- [x] Run spec parse/lint.
+- [ ] Run full verification, commit, ingest project memory, push branch, and open PR.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p22-mcp-knowledge-distill.spec.md
+agent-spec lint specs/p22-mcp-knowledge-distill.spec.md --min-score 0.7
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test mcp::server::tests::test_mcp_knowledge_distill -- --nocapture
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_mempal_knowledge_distill -- --nocapture
+cargo test --test knowledge_lifecycle test_cli_knowledge_distill -- --nocapture
+cargo test
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -199,6 +199,21 @@ P17 adds manual lifecycle commands for Stage-1 knowledge drawers. P19 hardens
 those commands so lifecycle refs must be existing evidence drawers, not arbitrary
 ids or other knowledge drawers:
 
+P18 adds deterministic CLI distill. P22 exposes the same operation to MCP agents
+as `mempal_knowledge_distill`: create candidate `dao_ren` / `qi` knowledge from
+existing evidence refs without LLM summarization or auto-promotion.
+
+Equivalent MCP distill request:
+
+```json
+{
+  "statement": "Prefer evidence first",
+  "content": "Use cited evidence before asserting project facts.",
+  "tier": "dao_ren",
+  "supporting_refs": ["drawer_evidence"]
+}
+```
+
 P20 adds a read-only promotion gate report. Use it before `promote` to check the
 minimum deterministic policy without changing status, refs, vectors, schema, or
 the audit log. P21 exposes the same policy to MCP agents as
@@ -507,11 +522,12 @@ mempal serve --mcp
 
 If `mempal` was built without the `rest` feature, plain `mempal serve` behaves the same way.
 
-The MCP server exposes twelve tools:
+The MCP server exposes thirteen tools:
 
 - `mempal_status` — state + protocol + AAAK spec
 - `mempal_search` — hybrid search (BM25 + vector + RRF) with tunnel hints and AAAK-derived structured signals (`entities` / `topics` / `flags` / `emotions` / `importance_stars`)
 - `mempal_context` — mind-model runtime context pack (`dao_tian -> dao_ren -> shu -> qi`, evidence opt-in); guides workflow / skill / tool choice but never executes skills
+- `mempal_knowledge_distill` — create candidate `dao_ren` / `qi` knowledge from existing evidence refs; deterministic and never auto-promotes
 - `mempal_knowledge_gate` — read-only promotion readiness check for knowledge drawers; returns the same deterministic gate report as `mempal knowledge gate --format json`
 - `mempal_ingest` — store memories with optional importance (0-5) and dry_run
 - `mempal_delete` — soft-delete with audit

--- a/specs/p22-mcp-knowledge-distill.spec.md
+++ b/specs/p22-mcp-knowledge-distill.spec.md
@@ -1,0 +1,133 @@
+spec: task
+name: "P22: mempal_knowledge_distill MCP tool"
+inherits: project
+tags: [memory, knowledge, distill, mcp]
+---
+
+## Intent
+
+P18 added CLI-only deterministic knowledge distillation from evidence refs, and P21 exposed promotion gate checks to MCP agents. P22 closes the agent-facing Stage-1 loop by adding a read/write MCP tool that creates candidate knowledge drawers from existing evidence refs without using an LLM, auto-promoting, or changing the Phase-1 drawer model.
+
+## Decisions
+
+- Add one MCP tool named `mempal_knowledge_distill`.
+- The MCP tool reuses the same shared distill implementation as CLI `mempal knowledge distill`; CLI and MCP must not drift.
+- Request fields are `statement`, `content`, `tier`, `supporting_refs`, optional `counterexample_refs`, optional `teaching_refs`, optional `domain`, optional `field`, optional `wing`, optional `room`, optional `scope_constraints`, optional `trigger_hints`, optional `cwd`, optional `importance`, and optional `dry_run`.
+- Default request values match the CLI: `domain="project"`, `field="general"`, `wing="mempal"`, `room="knowledge"`, `importance=3`, and `dry_run=false`.
+- Distill always creates `memory_kind=knowledge`, `status=candidate`, and empty `verification_refs`.
+- Distill only allows candidate `tier=dao_ren|qi`.
+- All role refs must be existing evidence drawer ids; refs to knowledge drawers, missing drawers, or non-`drawer_` ids are invalid-params errors.
+- Dry-run returns the deterministic `drawer_id` and `created=false` without building an embedder, inserting drawers/vectors, or writing audit.
+- If the computed drawer already exists, the tool returns `created=false` without inserting duplicate drawer/vector rows and without appending audit.
+- Successful non-dry-run create embeds `content`, inserts the drawer/vector, appends a `knowledge_distill` audit entry, and returns `created=true`.
+- The tool is local-only and deterministic; it must not call LLMs, external research tools, or network services beyond the configured embedder used by existing ingest/distill paths.
+- `MEMORY_PROTOCOL`, docs, and repo instructions list `mempal_knowledge_distill` as the MCP surface for creating candidate knowledge from evidence.
+
+## Boundaries
+
+### Allowed Changes
+- `src/knowledge_distill.rs`
+- `src/lib.rs`
+- `src/main.rs`
+- `src/mcp/tools.rs`
+- `src/mcp/server.rs`
+- `src/core/protocol.rs`
+- `tests/knowledge_lifecycle.rs`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/plans/**`
+
+### Forbidden
+- Do not add tables, columns, triggers, or migrations.
+- Do not add MCP promote or demote tools.
+- Do not change `mempal_knowledge_gate` behavior.
+- Do not change `mempal_context` response schema or ordering.
+- Do not change `mempal_search` request or response schema.
+- Do not auto-promote distilled knowledge.
+- Do not call an LLM or external research tool.
+- Do not introduce new dependencies.
+
+## Acceptance Criteria
+
+Scenario: MCP distill creates candidate knowledge from evidence
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_distill_creates_candidate_knowledge
+  Given one existing evidence drawer id
+  When an MCP client calls `mempal_knowledge_distill` with `statement`, `content`, `tier="dao_ren"`, and `supporting_refs=[evidence_id]`
+  Then the response has `created=true`
+  And the response contains a deterministic `drawer_id`
+  And the stored drawer has `memory_kind=knowledge`, `tier=dao_ren`, `status=candidate`, and `supporting_refs=[evidence_id]`
+  And default `mempal_context` does not include the candidate drawer
+
+Scenario: MCP distill dry-run is deterministic and read-only
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_distill_dry_run_no_write
+  Given one existing evidence drawer id
+  When the same dry-run `mempal_knowledge_distill` request is called twice
+  Then both responses have the same `drawer_id`
+  And both responses have `dry_run=true` and `created=false`
+  And drawer count, vector count, schema version, and audit line count do not change
+
+Scenario: MCP distill rejects unsupported candidate tier
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_distill_rejects_dao_tian_candidate
+  Given one existing evidence drawer id
+  When an MCP client calls `mempal_knowledge_distill` with `tier="dao_tian"`
+  Then the call fails with invalid params
+  And the error says distill only allows candidate `dao_ren` or `qi`
+
+Scenario: MCP distill validates supporting refs
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_distill_rejects_missing_supporting_refs
+  Given no supporting refs
+  When an MCP client calls `mempal_knowledge_distill`
+  Then the call fails with invalid params
+  And the error mentions `supporting_refs`
+  Given one supporting ref that points to a knowledge drawer
+  When an MCP client calls `mempal_knowledge_distill`
+  Then the call fails with invalid params
+  And the error says refs must point to evidence drawers
+
+Scenario: MCP distill stores trigger hints as bias metadata
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_distill_stores_trigger_hints
+  Given one existing evidence drawer id
+  When an MCP client calls `mempal_knowledge_distill` with `trigger_hints.intent_tags=["debugging"]`, `trigger_hints.workflow_bias=["reproduce-first"]`, and `trigger_hints.tool_needs=["cargo-test"]`
+  Then the stored drawer preserves those trigger hints
+  And `MEMORY_PROTOCOL` still says trigger hints are bias metadata only
+
+Scenario: MCP distill is idempotent for existing drawer
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_distill_existing_drawer_no_duplicate_or_audit
+  Given one existing evidence drawer id
+  When an MCP client calls the same non-dry-run `mempal_knowledge_distill` request twice
+  Then the first response has `created=true`
+  And the second response has `created=false`
+  And drawer count and vector count do not increase after the second call
+  And no second audit entry is appended
+
+Scenario: MCP tool registry and protocol include mempal_knowledge_distill
+  Test:
+    Package: mempal
+    Filter: test_mcp_tool_registry_and_protocol_include_mempal_knowledge_distill
+  Given the MCP server tool registry and `MEMORY_PROTOCOL`
+  When they are inspected
+  Then the tool registry contains `mempal_knowledge_distill`
+  And the tool description mentions candidate knowledge from evidence
+  And `MEMORY_PROTOCOL` tool list mentions `mempal_knowledge_distill`
+
+## Out of Scope
+
+- MCP promote/demote tools.
+- LLM-generated summaries.
+- Research tool integration.
+- Enforcing promotion gates inside distill.
+- Phase-2 `knowledge_cards` tables.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -164,10 +164,18 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    the reasons to gather more evidence or keep the drawer at its current
    lifecycle status. A passing gate is advisory; it does not auto-promote.
 
+13. DISTILL KNOWLEDGE FROM EVIDENCE
+   When repeated evidence suggests a reusable rule, call
+   mempal_knowledge_distill to create candidate knowledge from evidence
+   drawer refs. Distill is not summarization magic: provide the statement,
+   content, tier, and evidence refs explicitly. The tool only creates
+   candidate dao_ren or qi knowledge and never promotes it automatically.
+
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
   mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi)
+  mempal_knowledge_distill — create candidate knowledge from evidence refs
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_ingest        — save a new drawer (wing required, room optional, importance 0-5)
   mempal_delete        — soft-delete a drawer by ID
@@ -333,6 +341,22 @@ mod tests {
         assert!(
             MEMORY_PROTOCOL.contains("A passing gate is advisory; it does not auto-promote"),
             "MEMORY_PROTOCOL must state that the gate is advisory"
+        );
+    }
+
+    #[test]
+    fn contains_knowledge_distill_guidance() {
+        assert!(
+            MEMORY_PROTOCOL.contains("13. DISTILL KNOWLEDGE FROM EVIDENCE"),
+            "MEMORY_PROTOCOL must include Rule 13 knowledge distill guidance"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("mempal_knowledge_distill"),
+            "MEMORY_PROTOCOL must mention mempal_knowledge_distill in TOOLS list"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("never promotes it automatically"),
+            "MEMORY_PROTOCOL must state that distill never auto-promotes"
         );
     }
 

--- a/src/knowledge_distill.rs
+++ b/src/knowledge_distill.rs
@@ -1,0 +1,334 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+use crate::core::{
+    anchor,
+    db::Database,
+    types::{
+        BootstrapIdentityParts, Drawer, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
+        SourceType, TriggerHints,
+    },
+    utils::{build_bootstrap_drawer_id_from_parts, current_timestamp, knowledge_source_file},
+};
+use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
+
+#[derive(Debug, Clone)]
+pub struct DistillRequest {
+    pub statement: String,
+    pub content: String,
+    pub tier: String,
+    pub supporting_refs: Vec<String>,
+    pub wing: String,
+    pub room: String,
+    pub domain: String,
+    pub field: String,
+    pub cwd: Option<PathBuf>,
+    pub scope_constraints: Option<String>,
+    pub counterexample_refs: Vec<String>,
+    pub teaching_refs: Vec<String>,
+    pub trigger_hints: Option<TriggerHints>,
+    pub importance: i32,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DistillOutcome {
+    pub drawer_id: String,
+    pub created: bool,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum DistillPlan {
+    Done(DistillOutcome),
+    Create(Box<PreparedDistill>),
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedDistill {
+    pub drawer_id: String,
+    pub content: String,
+    drawer: Drawer,
+    supporting_refs: Vec<String>,
+    counterexample_refs: Vec<String>,
+    teaching_refs: Vec<String>,
+}
+
+pub fn prepare_distill(db: &Database, request: DistillRequest) -> Result<DistillPlan> {
+    if !(0..=5).contains(&request.importance) {
+        bail!("importance must be between 0 and 5");
+    }
+    let statement = trim_required(&request.statement, "statement")?;
+    let content = trim_required(&request.content, "content")?;
+    let wing = trim_required(&request.wing, "wing")?;
+    let room = trim_required(&request.room, "room")?;
+    let field = trim_required(&request.field, "field")?;
+    let domain = parse_domain(&request.domain)?;
+    let tier = parse_distill_tier(&request.tier)?;
+    let memory_kind = MemoryKind::Knowledge;
+    let status = KnowledgeStatus::Candidate;
+    let verification_refs: &[String] = &[];
+
+    let supporting_refs = normalized_nonempty_strings(&request.supporting_refs);
+    let counterexample_refs = normalized_nonempty_strings(&request.counterexample_refs);
+    let teaching_refs = normalized_nonempty_strings(&request.teaching_refs);
+    validate_distill_refs(db, "supporting_refs", &supporting_refs)?;
+    validate_distill_refs(db, "counterexample_refs", &counterexample_refs)?;
+    validate_distill_refs(db, "teaching_refs", &teaching_refs)?;
+
+    let scope_constraints = request
+        .scope_constraints
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let trigger_hints = request.trigger_hints.and_then(normalize_trigger_hints);
+    let anchor = distill_anchor(&domain, request.cwd.as_deref())?;
+    anchor::validate_anchor_domain(&domain, &anchor.anchor_kind)
+        .map_err(|message| anyhow::anyhow!(message.to_string()))?;
+
+    let drawer_id = build_bootstrap_drawer_id_from_parts(
+        &wing,
+        Some(&room),
+        &content,
+        BootstrapIdentityParts {
+            memory_kind: &memory_kind,
+            domain: &domain,
+            field: &field,
+            anchor_kind: &anchor.anchor_kind,
+            anchor_id: &anchor.anchor_id,
+            parent_anchor_id: anchor.parent_anchor_id.as_deref(),
+            provenance: None,
+            statement: Some(&statement),
+            tier: Some(&tier),
+            status: Some(&status),
+            supporting_refs: &supporting_refs,
+            counterexample_refs: &counterexample_refs,
+            teaching_refs: &teaching_refs,
+            verification_refs,
+            scope_constraints: scope_constraints.as_deref(),
+            trigger_hints: trigger_hints.as_ref(),
+        },
+    );
+
+    if request.dry_run {
+        return Ok(DistillPlan::Done(DistillOutcome {
+            drawer_id,
+            created: false,
+            dry_run: true,
+        }));
+    }
+
+    if db
+        .drawer_exists(&drawer_id)
+        .context("failed to check existing distilled drawer")?
+    {
+        return Ok(DistillPlan::Done(DistillOutcome {
+            drawer_id,
+            created: false,
+            dry_run: false,
+        }));
+    }
+
+    let drawer = Drawer {
+        id: drawer_id.clone(),
+        content: content.clone(),
+        wing,
+        room: Some(room),
+        source_file: Some(knowledge_source_file(&domain, &field, &tier, &statement)),
+        source_type: SourceType::Manual,
+        added_at: current_timestamp(),
+        chunk_index: Some(0),
+        normalize_version: CURRENT_NORMALIZE_VERSION,
+        importance: request.importance,
+        memory_kind: MemoryKind::Knowledge,
+        domain,
+        field,
+        anchor_kind: anchor.anchor_kind,
+        anchor_id: anchor.anchor_id,
+        parent_anchor_id: anchor.parent_anchor_id,
+        provenance: None,
+        statement: Some(statement),
+        tier: Some(tier),
+        status: Some(status),
+        supporting_refs: supporting_refs.clone(),
+        counterexample_refs: counterexample_refs.clone(),
+        teaching_refs: teaching_refs.clone(),
+        verification_refs: Vec::new(),
+        scope_constraints,
+        trigger_hints,
+    };
+
+    Ok(DistillPlan::Create(Box::new(PreparedDistill {
+        drawer_id,
+        content,
+        drawer,
+        supporting_refs,
+        counterexample_refs,
+        teaching_refs,
+    })))
+}
+
+pub fn commit_distill(
+    db: &Database,
+    prepared: PreparedDistill,
+    vector: &[f32],
+) -> Result<DistillOutcome> {
+    db.insert_drawer(&prepared.drawer)
+        .context("failed to insert distilled knowledge drawer")?;
+    db.insert_vector(&prepared.drawer_id, vector)
+        .context("failed to insert distilled knowledge vector")?;
+    append_audit_entry(
+        db,
+        "knowledge_distill",
+        &serde_json::json!({
+            "drawer_id": prepared.drawer_id,
+            "statement": prepared.drawer.statement,
+            "tier": prepared.drawer.tier.as_ref().map(tier_slug),
+            "status": prepared.drawer.status.as_ref().map(status_slug),
+            "supporting_refs": prepared.supporting_refs,
+            "counterexample_refs": prepared.counterexample_refs,
+            "teaching_refs": prepared.teaching_refs,
+        }),
+    )
+    .context("failed to append audit log")?;
+
+    Ok(DistillOutcome {
+        drawer_id: prepared.drawer_id,
+        created: true,
+        dry_run: false,
+    })
+}
+
+fn trim_required(value: &str, field: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("{field} must not be empty");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn normalized_nonempty_strings(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .filter_map(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .collect()
+}
+
+fn normalize_trigger_hints(hints: TriggerHints) -> Option<TriggerHints> {
+    let intent_tags = normalized_nonempty_strings(&hints.intent_tags);
+    let workflow_bias = normalized_nonempty_strings(&hints.workflow_bias);
+    let tool_needs = normalized_nonempty_strings(&hints.tool_needs);
+    if intent_tags.is_empty() && workflow_bias.is_empty() && tool_needs.is_empty() {
+        return None;
+    }
+    Some(TriggerHints {
+        intent_tags,
+        workflow_bias,
+        tool_needs,
+    })
+}
+
+fn parse_domain(value: &str) -> Result<MemoryDomain> {
+    match value.trim() {
+        "project" => Ok(MemoryDomain::Project),
+        "agent" => Ok(MemoryDomain::Agent),
+        "skill" => Ok(MemoryDomain::Skill),
+        "global" => Ok(MemoryDomain::Global),
+        other => bail!("unsupported domain: {other}"),
+    }
+}
+
+fn parse_distill_tier(value: &str) -> Result<KnowledgeTier> {
+    match value.trim() {
+        "dao_ren" => Ok(KnowledgeTier::DaoRen),
+        "qi" => Ok(KnowledgeTier::Qi),
+        "dao_tian" | "shu" => bail!("distill only allows candidate dao_ren or qi"),
+        other => bail!("unsupported knowledge tier: {other}"),
+    }
+}
+
+fn distill_anchor(domain: &MemoryDomain, cwd: Option<&Path>) -> Result<anchor::DerivedAnchor> {
+    if matches!(domain, MemoryDomain::Global) {
+        return Ok(anchor::DerivedAnchor {
+            anchor_kind: crate::core::types::AnchorKind::Global,
+            anchor_id: "global://default".to_string(),
+            parent_anchor_id: None,
+        });
+    }
+    let cwd = match cwd {
+        Some(path) => path.to_path_buf(),
+        None => std::env::current_dir().context("failed to read current directory")?,
+    };
+    anchor::derive_anchor_from_cwd(Some(&cwd)).context("failed to derive distill anchor")
+}
+
+fn validate_distill_refs(db: &Database, field: &str, refs: &[String]) -> Result<()> {
+    if field == "supporting_refs" && refs.is_empty() {
+        bail!("supporting_refs must not be empty");
+    }
+    for drawer_id in refs {
+        if !drawer_id.starts_with("drawer_") {
+            bail!("{field} must contain drawer ids");
+        }
+        let drawer = db
+            .get_drawer(drawer_id)
+            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
+            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
+        if drawer.memory_kind != MemoryKind::Evidence {
+            bail!("{field} must point to evidence drawers");
+        }
+    }
+    Ok(())
+}
+
+fn append_audit_entry(db: &Database, command: &str, details: &serde_json::Value) -> Result<()> {
+    let audit_path = db
+        .path()
+        .parent()
+        .map(|parent| parent.join("audit.jsonl"))
+        .unwrap_or_else(|| PathBuf::from("audit.jsonl"));
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&audit_path)
+        .with_context(|| format!("failed to open audit log {}", audit_path.display()))?;
+    let entry = serde_json::json!({
+        "ts": current_timestamp(),
+        "command": command,
+        "details": details,
+    });
+    writeln!(
+        file,
+        "{}",
+        serde_json::to_string(&entry).context("failed to serialize audit entry")?
+    )
+    .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
+    Ok(())
+}
+
+fn tier_slug(value: &KnowledgeTier) -> &'static str {
+    match value {
+        KnowledgeTier::Qi => "qi",
+        KnowledgeTier::Shu => "shu",
+        KnowledgeTier::DaoRen => "dao_ren",
+        KnowledgeTier::DaoTian => "dao_tian",
+    }
+}
+
+fn status_slug(value: &KnowledgeStatus) -> &'static str {
+    match value {
+        KnowledgeStatus::Candidate => "candidate",
+        KnowledgeStatus::Promoted => "promoted",
+        KnowledgeStatus::Canonical => "canonical",
+        KnowledgeStatus::Demoted => "demoted",
+        KnowledgeStatus::Retired => "retired",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cowork;
 pub mod embed;
 pub mod factcheck;
 pub mod ingest;
+pub mod knowledge_distill;
 pub mod knowledge_gate;
 pub mod mcp;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,25 +13,21 @@ use mempal::aaak::{AaakCodec, AaakMeta};
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
 use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
-    anchor,
     config::Config,
     db::Database,
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
-        AnchorKind, BootstrapIdentityParts, Drawer, KnowledgeStatus, KnowledgeTier, MemoryDomain,
-        MemoryKind, SourceType, TaxonomyEntry, TriggerHints, TunnelEndpoint,
+        AnchorKind, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, TaxonomyEntry,
+        TriggerHints, TunnelEndpoint,
     },
-    utils::{
-        build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp,
-        format_tunnel_endpoint, knowledge_source_file,
-    },
+    utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
 };
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
 use mempal::ingest::{
     IngestOptions, IngestStats, ingest_dir_with_options, ingest_file_with_options,
-    normalize::CURRENT_NORMALIZE_VERSION,
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
+use mempal::knowledge_distill::{DistillPlan, DistillRequest, commit_distill, prepare_distill};
 use mempal::knowledge_gate::{GateReport, evaluate_gate_by_id};
 use mempal::mcp::MempalMcpServer;
 use mempal::search::{SearchFilters, SearchOptions, search_with_options};
@@ -1221,129 +1217,48 @@ async fn knowledge_command(
             importance,
             dry_run,
         } => {
-            if !(0..=5).contains(&importance) {
-                bail!("importance must be between 0 and 5");
-            }
-            let statement = trim_required(&statement, "statement")?;
-            let content = trim_required(&content, "content")?;
-            let wing = trim_required(&wing, "wing")?;
-            let room = trim_required(&room, "room")?;
-            let field = trim_required(&field, "field")?;
-            let domain = parse_domain(&domain)?;
-            let tier = parse_distill_tier(&tier)?;
-            let memory_kind = MemoryKind::Knowledge;
-            let status = KnowledgeStatus::Candidate;
-            let verification_refs: &[String] = &[];
-
-            let supporting_refs = normalized_nonempty_strings(&supporting_refs);
-            let counterexample_refs = normalized_nonempty_strings(&counterexample_refs);
-            let teaching_refs = normalized_nonempty_strings(&teaching_refs);
-            validate_distill_refs(db, "supporting_refs", &supporting_refs)?;
-            validate_distill_refs(db, "counterexample_refs", &counterexample_refs)?;
-            validate_distill_refs(db, "teaching_refs", &teaching_refs)?;
-
-            let scope_constraints = scope_constraints
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned);
             let trigger_hints = build_trigger_hints(intent_tags, workflow_bias, tool_needs);
-            let anchor = distill_anchor(&domain, cwd.as_deref())?;
-            anchor::validate_anchor_domain(&domain, &anchor.anchor_kind)
-                .map_err(|message| anyhow::anyhow!(message.to_string()))?;
-
-            let drawer_id = build_bootstrap_drawer_id_from_parts(
-                &wing,
-                Some(&room),
-                &content,
-                BootstrapIdentityParts {
-                    memory_kind: &memory_kind,
-                    domain: &domain,
-                    field: &field,
-                    anchor_kind: &anchor.anchor_kind,
-                    anchor_id: &anchor.anchor_id,
-                    parent_anchor_id: anchor.parent_anchor_id.as_deref(),
-                    provenance: None,
-                    statement: Some(&statement),
-                    tier: Some(&tier),
-                    status: Some(&status),
-                    supporting_refs: &supporting_refs,
-                    counterexample_refs: &counterexample_refs,
-                    teaching_refs: &teaching_refs,
-                    verification_refs,
-                    scope_constraints: scope_constraints.as_deref(),
-                    trigger_hints: trigger_hints.as_ref(),
-                },
-            );
-
-            if dry_run {
-                println!("dry_run=true drawer_id={drawer_id}");
-                return Ok(());
-            }
-
-            if db
-                .drawer_exists(&drawer_id)
-                .context("failed to check existing distilled drawer")?
-            {
-                println!("drawer_id={drawer_id} created=false");
-                return Ok(());
-            }
-
-            let embedder = build_embedder(config).await?;
-            let vector = embedder
-                .embed(&[content.as_str()])
-                .await
-                .context("failed to embed distilled knowledge")?
-                .into_iter()
-                .next()
-                .context("embedder returned no vector")?;
-            let drawer = Drawer {
-                id: drawer_id.clone(),
+            let request = DistillRequest {
+                statement,
                 content,
+                tier,
+                supporting_refs,
                 wing,
-                room: Some(room),
-                source_file: Some(knowledge_source_file(&domain, &field, &tier, &statement)),
-                source_type: SourceType::Manual,
-                added_at: current_timestamp(),
-                chunk_index: Some(0),
-                normalize_version: CURRENT_NORMALIZE_VERSION,
-                importance,
-                memory_kind: MemoryKind::Knowledge,
+                room,
                 domain,
                 field,
-                anchor_kind: anchor.anchor_kind,
-                anchor_id: anchor.anchor_id,
-                parent_anchor_id: anchor.parent_anchor_id,
-                provenance: None,
-                statement: Some(statement),
-                tier: Some(tier),
-                status: Some(status),
-                supporting_refs: supporting_refs.clone(),
-                counterexample_refs: counterexample_refs.clone(),
-                teaching_refs: teaching_refs.clone(),
-                verification_refs: Vec::new(),
+                cwd,
                 scope_constraints,
+                counterexample_refs,
+                teaching_refs,
                 trigger_hints,
+                importance,
+                dry_run,
             };
-            db.insert_drawer(&drawer)
-                .context("failed to insert distilled knowledge drawer")?;
-            db.insert_vector(&drawer_id, &vector)
-                .context("failed to insert distilled knowledge vector")?;
-            append_audit_entry(
-                db,
-                "knowledge_distill",
-                &serde_json::json!({
-                    "drawer_id": drawer_id,
-                    "statement": drawer.statement,
-                    "tier": drawer.tier.as_ref().map(knowledge_tier_slug),
-                    "status": drawer.status.as_ref().map(knowledge_status_slug),
-                    "supporting_refs": supporting_refs,
-                    "counterexample_refs": counterexample_refs,
-                    "teaching_refs": teaching_refs,
-                }),
-            )
-            .context("failed to append audit log")?;
-            println!("drawer_id={drawer_id} created=true");
+            let outcome = match prepare_distill(db, request)? {
+                DistillPlan::Done(outcome) => outcome,
+                DistillPlan::Create(prepared) => {
+                    let embedder = build_embedder(config).await?;
+                    let vector = embedder
+                        .embed(&[prepared.content.as_str()])
+                        .await
+                        .context("failed to embed distilled knowledge")?
+                        .into_iter()
+                        .next()
+                        .context("embedder returned no vector")?;
+                    commit_distill(db, *prepared, &vector)?
+                }
+            };
+
+            if outcome.dry_run {
+                println!("dry_run=true drawer_id={}", outcome.drawer_id);
+                return Ok(());
+            }
+
+            println!(
+                "drawer_id={} created={}",
+                outcome.drawer_id, outcome.created
+            );
         }
         KnowledgeCommands::Promote {
             drawer_id,
@@ -1477,14 +1392,6 @@ async fn knowledge_command(
     Ok(())
 }
 
-fn trim_required(value: &str, field: &str) -> Result<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        bail!("{field} must not be empty");
-    }
-    Ok(trimmed.to_string())
-}
-
 fn normalized_nonempty_strings(values: &[String]) -> Vec<String> {
     values
         .iter()
@@ -1493,15 +1400,6 @@ fn normalized_nonempty_strings(values: &[String]) -> Vec<String> {
             (!trimmed.is_empty()).then(|| trimmed.to_string())
         })
         .collect()
-}
-
-fn parse_distill_tier(value: &str) -> Result<KnowledgeTier> {
-    match value.trim() {
-        "dao_ren" => Ok(KnowledgeTier::DaoRen),
-        "qi" => Ok(KnowledgeTier::Qi),
-        "dao_tian" | "shu" => bail!("distill only allows candidate dao_ren or qi"),
-        other => bail!("unsupported knowledge tier: {other}"),
-    }
 }
 
 fn build_trigger_hints(
@@ -1520,40 +1418,6 @@ fn build_trigger_hints(
         workflow_bias,
         tool_needs,
     })
-}
-
-fn distill_anchor(domain: &MemoryDomain, cwd: Option<&Path>) -> Result<anchor::DerivedAnchor> {
-    if matches!(domain, MemoryDomain::Global) {
-        return Ok(anchor::DerivedAnchor {
-            anchor_kind: AnchorKind::Global,
-            anchor_id: "global://default".to_string(),
-            parent_anchor_id: None,
-        });
-    }
-    let cwd = match cwd {
-        Some(path) => path.to_path_buf(),
-        None => env::current_dir().context("failed to read current directory")?,
-    };
-    anchor::derive_anchor_from_cwd(Some(&cwd)).context("failed to derive distill anchor")
-}
-
-fn validate_distill_refs(db: &Database, field: &str, refs: &[String]) -> Result<()> {
-    if field == "supporting_refs" && refs.is_empty() {
-        bail!("supporting_refs must not be empty");
-    }
-    for drawer_id in refs {
-        if !drawer_id.starts_with("drawer_") {
-            bail!("{field} must contain drawer ids");
-        }
-        let drawer = db
-            .get_drawer(drawer_id)
-            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
-            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
-        if drawer.memory_kind != MemoryKind::Evidence {
-            bail!("{field} must point to evidence drawers");
-        }
-    }
-    Ok(())
 }
 
 fn load_lifecycle_knowledge_drawer(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -24,6 +24,9 @@ use crate::ingest::{
     },
     normalize::CURRENT_NORMALIZE_VERSION,
 };
+use crate::knowledge_distill::{
+    DistillPlan, DistillRequest as CoreDistillRequest, commit_distill, prepare_distill,
+};
 use crate::knowledge_gate::evaluate_gate_by_id;
 use crate::search::{SearchFilters, SearchOptions, resolve_route, search_with_vector_options};
 use anyhow::Context;
@@ -38,11 +41,11 @@ use serde_json::Value;
 use super::tools::{
     ContextRequest, ContextResponse, CoworkPushRequest, CoworkPushResponse, DeleteRequest,
     DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, IngestRequest,
-    IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeGateRequest, KnowledgeGateResponse,
-    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest,
-    SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest,
-    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
-    TunnelsResponse,
+    IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeDistillRequest,
+    KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, PeekMessageDto,
+    PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest, SearchResponse,
+    SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse,
+    TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -126,6 +129,17 @@ impl MempalMcpServer {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         self.mempal_knowledge_gate(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn knowledge_distill_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<KnowledgeDistillResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_knowledge_distill(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -673,6 +687,58 @@ impl MempalMcpServer {
         .map_err(context_error)?;
 
         Ok(Json(ContextResponse::from(pack)))
+    }
+
+    #[tool(
+        name = "mempal_knowledge_distill",
+        description = "Create candidate knowledge from existing evidence drawer refs. Deterministic Stage-1 distill: writes memory_kind=knowledge/status=candidate for tier dao_ren or qi, validates refs are evidence drawers, and never calls an LLM, promotes, or creates Phase-2 knowledge cards."
+    )]
+    async fn mempal_knowledge_distill(
+        &self,
+        Parameters(request): Parameters<KnowledgeDistillRequest>,
+    ) -> std::result::Result<Json<KnowledgeDistillResponse>, ErrorData> {
+        let dry_run = request.dry_run.unwrap_or(false);
+        let core_request = CoreDistillRequest {
+            statement: request.statement,
+            content: request.content,
+            tier: request.tier,
+            supporting_refs: request.supporting_refs,
+            wing: request.wing.unwrap_or_else(|| "mempal".to_string()),
+            room: request.room.unwrap_or_else(|| "knowledge".to_string()),
+            domain: request.domain.unwrap_or_else(|| "project".to_string()),
+            field: request
+                .field
+                .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
+            cwd: request.cwd.map(PathBuf::from),
+            scope_constraints: request.scope_constraints,
+            counterexample_refs: request.counterexample_refs.unwrap_or_default(),
+            teaching_refs: request.teaching_refs.unwrap_or_default(),
+            trigger_hints: request.trigger_hints.as_ref().map(trigger_hints_from_dto),
+            importance: request.importance.unwrap_or(3),
+            dry_run,
+        };
+        let plan = {
+            let db = self.open_db()?;
+            prepare_distill(&db, core_request).map_err(knowledge_distill_error)?
+        };
+        let prepared = match plan {
+            DistillPlan::Done(outcome) => return Ok(Json(KnowledgeDistillResponse::from(outcome))),
+            DistillPlan::Create(prepared) => prepared,
+        };
+
+        let embedder = self.embedder_factory.build().await.map_err(|error| {
+            ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
+        })?;
+        let vector = embedder
+            .embed(&[prepared.content.as_str()])
+            .await
+            .map_err(|error| ErrorData::internal_error(format!("embedding failed: {error}"), None))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| ErrorData::internal_error("embedder returned no vector", None))?;
+        let db = self.open_db()?;
+        let outcome = commit_distill(&db, *prepared, &vector).map_err(knowledge_distill_error)?;
+        Ok(Json(KnowledgeDistillResponse::from(outcome)))
     }
 
     #[tool(
@@ -1398,6 +1464,18 @@ fn knowledge_gate_error(error: anyhow::Error) -> ErrorData {
     ErrorData::invalid_params(error.to_string(), None)
 }
 
+fn knowledge_distill_error(error: anyhow::Error) -> ErrorData {
+    let message = error.to_string();
+    if message.contains("failed to embed")
+        || message.contains("failed to insert")
+        || message.contains("failed to append audit")
+        || message.contains("embedder required")
+    {
+        return ErrorData::internal_error(message, None);
+    }
+    ErrorData::invalid_params(message, None)
+}
+
 fn context_error(error: crate::context::ContextError) -> ErrorData {
     match error {
         crate::context::ContextError::DeriveAnchor(_) => {
@@ -1517,6 +1595,7 @@ mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
+    use rusqlite::params;
     use tempfile::TempDir;
 
     use super::*;
@@ -1675,6 +1754,22 @@ mod tests {
         fs::read_to_string(audit_path)
             .map(|content| content.lines().count())
             .unwrap_or(0)
+    }
+
+    fn vector_row_count(db: &Database, id: &str) -> i64 {
+        db.conn()
+            .query_row(
+                "SELECT COUNT(*) FROM drawer_vectors WHERE id = ?1",
+                params![id],
+                |row| row.get(0),
+            )
+            .expect("count vector rows")
+    }
+
+    fn total_vector_count(db: &Database) -> i64 {
+        db.conn()
+            .query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| row.get(0))
+            .expect("count vector rows")
     }
 
     fn insert_triple(
@@ -2025,6 +2120,294 @@ mod tests {
                 .unwrap_or_default()
                 .contains("dao_tian -> dao_ren -> shu -> qi")
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_distill_creates_candidate_knowledge() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "evidence first observation",
+            "mempal",
+            Some("distill"),
+            "/tmp/evidence.md",
+            2,
+        );
+
+        let response = server
+            .knowledge_distill_json_for_test(serde_json::json!({
+                "statement": "Prefer evidence first",
+                "content": "Use cited evidence before asserting project facts.",
+                "tier": "dao_ren",
+                "supporting_refs": ["drawer_evidence"]
+            }))
+            .await
+            .expect("distill should succeed");
+        assert!(response.created);
+        assert!(!response.dry_run);
+        assert!(response.drawer_id.starts_with("drawer_"));
+
+        let db = Database::open(&db_path).expect("open db");
+        let drawer = db
+            .get_drawer(&response.drawer_id)
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(drawer.memory_kind, MemoryKind::Knowledge);
+        assert_eq!(drawer.tier, Some(KnowledgeTier::DaoRen));
+        assert_eq!(drawer.status, Some(KnowledgeStatus::Candidate));
+        assert_eq!(drawer.supporting_refs, vec!["drawer_evidence"]);
+
+        let context = server
+            .context_json_for_test(serde_json::json!({
+                "query": "evidence first",
+                "cwd": db_path.parent().expect("db parent").to_string_lossy()
+            }))
+            .await
+            .expect("context should succeed");
+        let context_ids: Vec<_> = context
+            .sections
+            .into_iter()
+            .flat_map(|section| section.items)
+            .map(|item| item.drawer_id)
+            .collect();
+        assert!(!context_ids.contains(&response.drawer_id));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_distill_dry_run_no_write() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "dry run evidence",
+            "mempal",
+            Some("distill"),
+            "/tmp/evidence.md",
+            2,
+        );
+        let db = Database::open(&db_path).expect("open db");
+        let drawer_count_before = db.drawer_count().expect("drawer count");
+        let vector_count_before = total_vector_count(&db);
+        let schema_before = db.schema_version().expect("schema");
+        let audit_before = audit_line_count(&db_path);
+
+        let request = serde_json::json!({
+            "statement": "Dry run candidate",
+            "content": "This should not be written.",
+            "tier": "qi",
+            "supporting_refs": ["drawer_evidence"],
+            "dry_run": true
+        });
+        let first = server
+            .knowledge_distill_json_for_test(request.clone())
+            .await
+            .expect("first dry-run should succeed");
+        let second = server
+            .knowledge_distill_json_for_test(request)
+            .await
+            .expect("second dry-run should succeed");
+
+        assert_eq!(first.drawer_id, second.drawer_id);
+        assert!(!first.created);
+        assert!(first.dry_run);
+        assert!(!second.created);
+        assert!(second.dry_run);
+        assert_eq!(
+            db.drawer_count().expect("drawer count"),
+            drawer_count_before
+        );
+        assert_eq!(total_vector_count(&db), vector_count_before);
+        assert_eq!(db.schema_version().expect("schema"), schema_before);
+        assert_eq!(audit_line_count(&db_path), audit_before);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_distill_rejects_dao_tian_candidate() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "dao tian evidence",
+            "mempal",
+            Some("distill"),
+            "/tmp/evidence.md",
+            2,
+        );
+
+        let error = server
+            .knowledge_distill_json_for_test(serde_json::json!({
+                "statement": "Universal law",
+                "content": "This should not be candidate dao_tian.",
+                "tier": "dao_tian",
+                "supporting_refs": ["drawer_evidence"]
+            }))
+            .await
+            .expect_err("dao_tian candidate should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("distill only allows candidate dao_ren or qi"),
+            "error={error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_distill_rejects_missing_supporting_refs() {
+        let (_tempdir, db_path, server) = setup_server();
+        let missing = server
+            .knowledge_distill_json_for_test(serde_json::json!({
+                "statement": "Missing refs",
+                "content": "This should fail before writing.",
+                "tier": "qi",
+                "supporting_refs": []
+            }))
+            .await
+            .expect_err("missing refs should be rejected");
+        assert!(
+            missing.to_string().contains("supporting_refs"),
+            "error={missing}"
+        );
+
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "support evidence",
+            "mempal",
+            Some("distill"),
+            "/tmp/evidence.md",
+            2,
+        );
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_ref_knowledge",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Candidate,
+            "Tool candidate.",
+            "Knowledge ref content",
+            KnowledgeRefs {
+                supporting: vec!["drawer_evidence".to_string()],
+                ..KnowledgeRefs::default()
+            },
+        );
+
+        let wrong_kind = server
+            .knowledge_distill_json_for_test(serde_json::json!({
+                "statement": "Wrong ref kind",
+                "content": "This should fail before writing.",
+                "tier": "qi",
+                "supporting_refs": ["drawer_ref_knowledge"]
+            }))
+            .await
+            .expect_err("knowledge refs should be rejected");
+        assert!(
+            wrong_kind
+                .to_string()
+                .contains("supporting_refs must point to evidence drawers"),
+            "error={wrong_kind}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_distill_stores_trigger_hints() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "trigger hint evidence",
+            "mempal",
+            Some("distill"),
+            "/tmp/evidence.md",
+            2,
+        );
+
+        let response = server
+            .knowledge_distill_json_for_test(serde_json::json!({
+                "statement": "Reproduce before patching",
+                "content": "Reproduce failures before changing code.",
+                "tier": "qi",
+                "supporting_refs": ["drawer_evidence"],
+                "trigger_hints": {
+                    "intent_tags": ["debugging"],
+                    "workflow_bias": ["reproduce-first"],
+                    "tool_needs": ["cargo-test"]
+                }
+            }))
+            .await
+            .expect("distill should succeed");
+        let db = Database::open(&db_path).expect("open db");
+        let drawer = db
+            .get_drawer(&response.drawer_id)
+            .expect("load drawer")
+            .expect("drawer exists");
+        let hints = drawer.trigger_hints.expect("trigger hints");
+        assert_eq!(hints.intent_tags, vec!["debugging"]);
+        assert_eq!(hints.workflow_bias, vec!["reproduce-first"]);
+        assert_eq!(hints.tool_needs, vec!["cargo-test"]);
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL.contains("trigger_hints as bias metadata only")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_distill_existing_drawer_no_duplicate_or_audit() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "idempotent evidence",
+            "mempal",
+            Some("distill"),
+            "/tmp/evidence.md",
+            2,
+        );
+        let request = serde_json::json!({
+            "statement": "Idempotent distill",
+            "content": "Equivalent requests should not duplicate drawers.",
+            "tier": "dao_ren",
+            "supporting_refs": ["drawer_evidence"]
+        });
+        let first = server
+            .knowledge_distill_json_for_test(request.clone())
+            .await
+            .expect("first distill should create");
+        assert!(first.created);
+        let db = Database::open(&db_path).expect("open db");
+        let drawer_count_before_second = db.drawer_count().expect("drawer count");
+        let vector_count_before_second = total_vector_count(&db);
+        let audit_before_second = audit_line_count(&db_path);
+
+        let second = server
+            .knowledge_distill_json_for_test(request)
+            .await
+            .expect("second distill should be idempotent");
+        assert_eq!(second.drawer_id, first.drawer_id);
+        assert!(!second.created);
+        assert_eq!(
+            db.drawer_count().expect("drawer count"),
+            drawer_count_before_second
+        );
+        assert_eq!(total_vector_count(&db), vector_count_before_second);
+        assert_eq!(audit_line_count(&db_path), audit_before_second);
+        assert_eq!(vector_row_count(&db, &first.drawer_id), 1);
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_mempal_knowledge_distill() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let distill_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_knowledge_distill")
+            .expect("mempal_knowledge_distill tool exists");
+        assert!(
+            distill_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("candidate knowledge from existing evidence")
+        );
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_distill"));
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3,6 +3,7 @@ use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
     NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry, TunnelEndpoint,
 };
+use crate::knowledge_distill::DistillOutcome;
 use crate::knowledge_gate::GateReport;
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
@@ -81,6 +82,42 @@ pub struct KnowledgeGateRequest {
     pub target_status: Option<String>,
     pub reviewer: Option<String>,
     pub allow_counterexamples: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct KnowledgeDistillRequest {
+    pub statement: String,
+    pub content: String,
+    pub tier: String,
+    pub supporting_refs: Vec<String>,
+    pub counterexample_refs: Option<Vec<String>>,
+    pub teaching_refs: Option<Vec<String>>,
+    pub domain: Option<String>,
+    pub field: Option<String>,
+    pub wing: Option<String>,
+    pub room: Option<String>,
+    pub scope_constraints: Option<String>,
+    pub trigger_hints: Option<TriggerHintsDto>,
+    pub cwd: Option<String>,
+    pub importance: Option<i32>,
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeDistillResponse {
+    pub drawer_id: String,
+    pub created: bool,
+    pub dry_run: bool,
+}
+
+impl From<DistillOutcome> for KnowledgeDistillResponse {
+    fn from(outcome: DistillOutcome) -> Self {
+        Self {
+            drawer_id: outcome.drawer_id,
+            created: outcome.created,
+            dry_run: outcome.dry_run,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]


### PR DESCRIPTION
## Summary
- add shared deterministic knowledge distill core used by CLI and MCP
- add read/write mempal_knowledge_distill MCP tool for candidate dao_ren/qi knowledge from evidence refs
- update MEMORY_PROTOCOL, usage docs, MIND-MODEL, AGENTS/CLAUDE, and P22 spec/plan

## Verification
- agent-spec parse specs/p22-mcp-knowledge-distill.spec.md
- agent-spec lint specs/p22-mcp-knowledge-distill.spec.md --min-score 0.7
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test mcp::server::tests::test_mcp_knowledge_distill -- --nocapture
- cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_mempal_knowledge_distill -- --nocapture
- cargo test --test knowledge_lifecycle test_cli_knowledge_distill -- --nocapture
- cargo test