### PR TITLE
P23: expose knowledge lifecycle over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P22）
+### 已完成的 Spec（P0-P23）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -69,6 +69,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p20-promotion-gate-policy.spec.md` | 完成 | read-only promotion gate policy：`mempal knowledge gate` 评估 knowledge drawer 是否满足最小提升门槛 |
 | `specs/p21-mcp-knowledge-gate.spec.md` | 完成 | `mempal_knowledge_gate` MCP 工具：向 agent runtime 暴露 P20 read-only promotion gate |
 | `specs/p22-mcp-knowledge-distill.spec.md` | 完成 | `mempal_knowledge_distill` MCP 工具：从 evidence refs 创建 candidate knowledge drawer |
+| `specs/p23-mcp-knowledge-lifecycle.spec.md` | 完成 | `mempal_knowledge_promote` / `mempal_knowledge_demote` MCP 工具：gate-enforced promotion + evidence-backed demotion |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -100,6 +101,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md` — P20 promotion gate policy（已完成）
 - `docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md` — P21 MCP knowledge gate（已完成）
 - `docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md` — P22 MCP knowledge distill（已完成）
+- `docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md` — P23 MCP knowledge lifecycle（已完成）
 
 ### Spec 使用方式
 
@@ -118,9 +120,9 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，13 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，14 条规则
 
-## MCP 工具（13 个）
+## MCP 工具（15 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -129,6 +131,8 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
+| `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |
+| `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P22）
+### 已完成的 Spec（P0-P23）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -67,6 +67,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p20-promotion-gate-policy.spec.md` | 完成 | read-only promotion gate policy：`mempal knowledge gate` 评估 knowledge drawer 是否满足最小提升门槛 |
 | `specs/p21-mcp-knowledge-gate.spec.md` | 完成 | `mempal_knowledge_gate` MCP 工具：向 agent runtime 暴露 P20 read-only promotion gate |
 | `specs/p22-mcp-knowledge-distill.spec.md` | 完成 | `mempal_knowledge_distill` MCP 工具：从 evidence refs 创建 candidate knowledge drawer |
+| `specs/p23-mcp-knowledge-lifecycle.spec.md` | 完成 | `mempal_knowledge_promote` / `mempal_knowledge_demote` MCP 工具：gate-enforced promotion + evidence-backed demotion |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -98,6 +99,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-25-p20-promotion-gate-policy-implementation.md` — P20 promotion gate policy（已完成）
 - `docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md` — P21 MCP knowledge gate（已完成）
 - `docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md` — P22 MCP knowledge distill（已完成）
+- `docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md` — P23 MCP knowledge lifecycle（已完成）
 
 ### Spec 使用方式
 
@@ -116,9 +118,9 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，13 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，14 条规则
 
-## MCP 工具（13 个）
+## MCP 工具（15 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -127,6 +129,8 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
+| `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |
+| `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -825,6 +825,7 @@ Implemented Phase-1 runtime surface:
 - lifecycle verification / counterexample refs are hardened to require existing evidence drawers, preserving the rule that promotion and demotion are justified by evidence rather than arbitrary ids or other knowledge claims
 - promotion gate CLI provides a read-only advisory report before promotion, using deterministic evidence-count policy without mutating status, refs, vectors, schema, or audit history
 - `mempal_knowledge_gate` exposes the same read-only promotion gate to MCP-connected agents, so runtime agents can check readiness without shelling out or mutating lifecycle state
+- `mempal_knowledge_promote` and `mempal_knowledge_demote` expose lifecycle mutation to MCP-connected agents; promotion is gate-enforced after appending supplied verification refs, while demotion requires counterexample evidence
 - lifecycle updates are metadata-only in Stage 1; they do not rewrite content, re-embed vectors, or create Phase-2 knowledge cards
 
 ### Phase 2: Knowledge Card Extraction

--- a/docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md
+++ b/docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md
@@ -1,0 +1,26 @@
+# P23 MCP Knowledge Lifecycle Implementation Plan
+
+## Goal
+
+Expose the Stage-1 knowledge lifecycle to MCP agents without weakening the governance model:
+
+- `mempal_knowledge_promote` mutates status only after a deterministic gate pass.
+- `mempal_knowledge_demote` requires counterexample evidence and a bounded reason type.
+- CLI and MCP share one lifecycle implementation.
+
+## Implementation Steps
+
+1. Add a shared `knowledge_lifecycle` module for promote/demote validation, ref de-duplication, lifecycle updates, and audit writing.
+2. Extend `knowledge_gate` with a reusable evaluator for an effective in-memory drawer so promotion can gate after appending request verification refs.
+3. Refactor CLI lifecycle commands to call the shared implementation.
+4. Add MCP request/response DTOs and tools for promote/demote.
+5. Update protocol/docs/specs to describe gate-enforced MCP promotion.
+6. Verify with focused MCP lifecycle tests, spec lint, cargo check, clippy, and full tests.
+
+## Non-Goals
+
+- No schema migration.
+- No automatic distill-to-promote.
+- No LLM evaluator or research integration.
+- No REST lifecycle endpoint.
+- No Phase-2 lifecycle event tables.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,7 +201,10 @@ ids or other knowledge drawers:
 
 P18 adds deterministic CLI distill. P22 exposes the same operation to MCP agents
 as `mempal_knowledge_distill`: create candidate `dao_ren` / `qi` knowledge from
-existing evidence refs without LLM summarization or auto-promotion.
+existing evidence refs without LLM summarization or auto-promotion. P23 exposes
+the lifecycle mutation side as `mempal_knowledge_promote` and
+`mempal_knowledge_demote`: MCP promotion is gate-enforced, and demotion requires
+counterexample evidence.
 
 Equivalent MCP distill request:
 
@@ -522,13 +525,15 @@ mempal serve --mcp
 
 If `mempal` was built without the `rest` feature, plain `mempal serve` behaves the same way.
 
-The MCP server exposes thirteen tools:
+The MCP server exposes fifteen tools:
 
 - `mempal_status` — state + protocol + AAAK spec
 - `mempal_search` — hybrid search (BM25 + vector + RRF) with tunnel hints and AAAK-derived structured signals (`entities` / `topics` / `flags` / `emotions` / `importance_stars`)
 - `mempal_context` — mind-model runtime context pack (`dao_tian -> dao_ren -> shu -> qi`, evidence opt-in); guides workflow / skill / tool choice but never executes skills
 - `mempal_knowledge_distill` — create candidate `dao_ren` / `qi` knowledge from existing evidence refs; deterministic and never auto-promotes
 - `mempal_knowledge_gate` — read-only promotion readiness check for knowledge drawers; returns the same deterministic gate report as `mempal knowledge gate --format json`
+- `mempal_knowledge_promote` — gate-enforced lifecycle promotion with supplied verification refs
+- `mempal_knowledge_demote` — demote or retire knowledge with counterexample evidence refs
 - `mempal_ingest` — store memories with optional importance (0-5) and dry_run
 - `mempal_delete` — soft-delete with audit
 - `mempal_taxonomy` — list or edit routing keywords

--- a/specs/p23-mcp-knowledge-lifecycle.spec.md
+++ b/specs/p23-mcp-knowledge-lifecycle.spec.md
@@ -1,0 +1,138 @@
+spec: task
+name: "P23: MCP knowledge lifecycle mutation tools"
+inherits: project
+tags: [memory, knowledge, lifecycle, gate, mcp]
+---
+
+## Intent
+
+P21 exposes promotion gate checks to MCP agents and P22 lets agents distill candidate knowledge from evidence, but the final lifecycle mutation still requires shelling out to the CLI. P23 exposes the P17 promote/demote lifecycle through MCP while preserving the P20 gate discipline: MCP promotion must pass the deterministic gate before mutating a drawer.
+
+## Decisions
+
+- Add MCP tools `mempal_knowledge_promote` and `mempal_knowledge_demote`.
+- CLI and MCP lifecycle mutations must reuse one shared implementation; they must not drift.
+- `mempal_knowledge_promote` request fields:
+  - `drawer_id`
+  - `status`, limited to `promoted|canonical`
+  - `verification_refs`, one or more evidence drawer ids
+  - `reason`
+  - optional `reviewer`
+  - optional `allow_counterexamples`, default `false`
+- MCP promote appends verification refs with stable de-duplication before evaluating the promotion gate.
+- MCP promote must run the same deterministic gate policy as P20 against the effective post-ref drawer before mutation.
+- If the promotion gate rejects, MCP promote returns invalid params and must not update status, refs, vectors, schema, or audit log.
+- `mempal_knowledge_demote` request fields:
+  - `drawer_id`
+  - `status`, limited to `demoted|retired`
+  - `evidence_refs`, one or more evidence drawer ids
+  - `reason`
+  - `reason_type`, limited to `contradicted|obsolete|superseded|out_of_scope|unsafe`
+- MCP demote appends evidence refs to `counterexample_refs` with stable de-duplication.
+- Lifecycle tools only accept `memory_kind=knowledge`.
+- All lifecycle refs must be existing evidence drawer ids.
+- Lifecycle tools do not change content, statement, tier, anchor metadata, vectors, FTS, triples, tunnels, or schema.
+- Successful lifecycle mutations append audit entries matching the CLI command names: `knowledge_promote` and `knowledge_demote`.
+- `MEMORY_PROTOCOL`, docs, and repo instructions list both lifecycle MCP tools and state that promotion is gate-enforced.
+
+## Boundaries
+
+### Allowed Changes
+
+- `src/knowledge_lifecycle.rs`
+- `src/knowledge_gate.rs`
+- `src/lib.rs`
+- `src/main.rs`
+- `src/mcp/tools.rs`
+- `src/mcp/server.rs`
+- `src/core/protocol.rs`
+- `tests/**`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/plans/**`
+
+### Forbidden
+
+- Do not add tables, columns, triggers, or migrations.
+- Do not add Phase-2 `knowledge_cards`.
+- Do not add automatic promotion from distill.
+- Do not change context assembly ordering or active-status rules.
+- Do not change `mempal_knowledge_gate` response shape.
+- Do not re-embed or rewrite vectors.
+- Do not call LLMs, external research tools, or network services.
+- Do not introduce new dependencies.
+
+## Acceptance Criteria
+
+Scenario: MCP promote updates status after gate pass
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_promote_updates_status_after_gate_pass
+  Given one candidate `dao_ren` knowledge drawer with two supporting evidence refs
+  And one verification evidence drawer exists
+  When an MCP client calls `mempal_knowledge_promote` with `status="promoted"` and that verification ref
+  Then the response reports old status `candidate` and new status `promoted`
+  And the stored drawer status is `promoted`
+  And `verification_refs` contains the supplied ref
+  And one `knowledge_promote` audit entry is appended
+
+Scenario: MCP promote rejects gate failure without mutation
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_promote_rejects_gate_failure_without_mutation
+  Given one candidate `dao_ren` knowledge drawer with only one supporting evidence ref
+  And one verification evidence drawer exists
+  When an MCP client calls `mempal_knowledge_promote`
+  Then the call fails with invalid params
+  And the error mentions promotion gate failed
+  And drawer status, refs, schema, vector rows, and audit log remain unchanged
+
+Scenario: MCP demote updates status and counterexample refs
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_demote_updates_status_and_counterexample_refs
+  Given one promoted `shu` knowledge drawer
+  And one counterexample evidence drawer exists
+  When an MCP client calls `mempal_knowledge_demote` with `status="demoted"` and `reason_type="contradicted"`
+  Then the response reports old status `promoted` and new status `demoted`
+  And the stored drawer status is `demoted`
+  And `counterexample_refs` contains the supplied evidence ref
+  And one `knowledge_demote` audit entry is appended
+
+Scenario: MCP lifecycle rejects evidence drawer targets
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_lifecycle_rejects_evidence_drawer_targets
+  Given one evidence drawer id
+  When an MCP client calls promote or demote for that drawer
+  Then the call fails with invalid params
+  And the error mentions lifecycle requires a knowledge drawer
+
+Scenario: MCP lifecycle validates refs are evidence drawers
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_lifecycle_validates_refs_are_evidence_drawers
+  Given one knowledge drawer id
+  And a lifecycle ref points to another knowledge drawer
+  When an MCP client calls promote or demote with that ref
+  Then the call fails with invalid params
+  And the error mentions lifecycle refs must point to evidence drawers
+
+Scenario: MCP tool registry and protocol include lifecycle tools
+  Test:
+    Package: mempal
+    Filter: test_mcp_tool_registry_and_protocol_include_knowledge_lifecycle_tools
+  Given the MCP tool registry and `MEMORY_PROTOCOL`
+  When they are inspected
+  Then the registry contains `mempal_knowledge_promote` and `mempal_knowledge_demote`
+  And `MEMORY_PROTOCOL` says MCP promotion is gate-enforced
+
+## Out of Scope
+
+- Automatic distill-to-promote.
+- LLM or evaluator scoring.
+- REST lifecycle endpoints.
+- Anchor publication APIs.
+- Phase-2 lifecycle event tables.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -171,12 +171,22 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    content, tier, and evidence refs explicitly. The tool only creates
    candidate dao_ren or qi knowledge and never promotes it automatically.
 
+14. MUTATE KNOWLEDGE LIFECYCLE WITH EVIDENCE
+   Use mempal_knowledge_promote only after you have evidence refs that satisfy
+   the promotion gate. MCP promotion is gate-enforced: the tool appends the
+   supplied verification refs to the effective drawer, runs the deterministic
+   gate, and mutates status only if allowed=true. Use mempal_knowledge_demote
+   when counterexample evidence shows promoted knowledge is contradicted,
+   obsolete, superseded, out of scope, or unsafe.
+
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
   mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi)
   mempal_knowledge_distill — create candidate knowledge from evidence refs
   mempal_knowledge_gate — read-only knowledge promotion readiness check
+  mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
+  mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_ingest        — save a new drawer (wing required, room optional, importance 0-5)
   mempal_delete        — soft-delete a drawer by ID
   mempal_taxonomy      — list or edit routing keywords
@@ -357,6 +367,23 @@ mod tests {
         assert!(
             MEMORY_PROTOCOL.contains("never promotes it automatically"),
             "MEMORY_PROTOCOL must state that distill never auto-promotes"
+        );
+    }
+
+    #[test]
+    fn contains_knowledge_lifecycle_mcp_guidance() {
+        assert!(
+            MEMORY_PROTOCOL.contains("14. MUTATE KNOWLEDGE LIFECYCLE WITH EVIDENCE"),
+            "MEMORY_PROTOCOL must include Rule 14 lifecycle guidance"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("mempal_knowledge_promote")
+                && MEMORY_PROTOCOL.contains("mempal_knowledge_demote"),
+            "MEMORY_PROTOCOL must mention MCP lifecycle tools"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("MCP promotion is gate-enforced"),
+            "MEMORY_PROTOCOL must state MCP promotion is gate-enforced"
         );
     }
 

--- a/src/knowledge_gate.rs
+++ b/src/knowledge_gate.rs
@@ -52,6 +52,24 @@ pub fn evaluate_gate_by_id(
     evaluate_gate(db, &drawer, &target_status, reviewer, allow_counterexamples)
 }
 
+pub fn evaluate_gate_for_drawer(
+    db: &Database,
+    drawer: &Drawer,
+    target_status: &KnowledgeStatus,
+    reviewer: Option<&str>,
+    allow_counterexamples: bool,
+) -> Result<GateReport> {
+    if drawer.memory_kind != MemoryKind::Knowledge {
+        bail!("knowledge gate requires a knowledge drawer");
+    }
+    let tier = drawer
+        .tier
+        .as_ref()
+        .context("knowledge gate requires tier metadata")?;
+    validate_tier_status(tier, target_status)?;
+    evaluate_gate(db, drawer, target_status, reviewer, allow_counterexamples)
+}
+
 fn load_gate_knowledge_drawer(db: &Database, drawer_id: &str) -> Result<Drawer> {
     let drawer = db
         .get_drawer(drawer_id)

--- a/src/knowledge_lifecycle.rs
+++ b/src/knowledge_lifecycle.rs
@@ -1,0 +1,286 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+use crate::core::{
+    db::Database,
+    types::{Drawer, KnowledgeStatus, KnowledgeTier, MemoryKind},
+    utils::current_timestamp,
+};
+use crate::knowledge_gate::{GateReport, evaluate_gate_for_drawer};
+
+#[derive(Debug, Clone)]
+pub struct PromoteRequest {
+    pub drawer_id: String,
+    pub status: String,
+    pub verification_refs: Vec<String>,
+    pub reason: String,
+    pub reviewer: Option<String>,
+    pub allow_counterexamples: bool,
+    pub enforce_gate: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DemoteRequest {
+    pub drawer_id: String,
+    pub status: String,
+    pub evidence_refs: Vec<String>,
+    pub reason: String,
+    pub reason_type: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PromoteOutcome {
+    pub drawer_id: String,
+    pub old_status: String,
+    pub new_status: String,
+    pub verification_refs: Vec<String>,
+    pub gate: Option<GateReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DemoteOutcome {
+    pub drawer_id: String,
+    pub old_status: String,
+    pub new_status: String,
+    pub counterexample_refs: Vec<String>,
+}
+
+pub fn promote_knowledge(db: &Database, request: PromoteRequest) -> Result<PromoteOutcome> {
+    let target_status = parse_lifecycle_status(&request.status)?;
+    if !matches!(
+        target_status,
+        KnowledgeStatus::Promoted | KnowledgeStatus::Canonical
+    ) {
+        bail!("promote status must be promoted or canonical");
+    }
+    let mut drawer = load_lifecycle_knowledge_drawer(db, &request.drawer_id)?;
+    validate_tier_status(
+        drawer.tier.as_ref().expect("knowledge drawer has tier"),
+        &target_status,
+    )?;
+    validate_lifecycle_refs(db, &request.verification_refs)?;
+
+    let old_status = drawer.status.clone().expect("knowledge drawer has status");
+    append_unique_refs(&mut drawer.verification_refs, &request.verification_refs);
+    let gate = if request.enforce_gate {
+        let gate = evaluate_gate_for_drawer(
+            db,
+            &drawer,
+            &target_status,
+            request.reviewer.as_deref(),
+            request.allow_counterexamples,
+        )?;
+        if !gate.allowed {
+            bail!("promotion gate failed: {}", gate.reasons.join("; "));
+        }
+        Some(gate)
+    } else {
+        None
+    };
+
+    db.update_knowledge_lifecycle(
+        &request.drawer_id,
+        &target_status,
+        &drawer.verification_refs,
+        &drawer.counterexample_refs,
+    )
+    .context("failed to update knowledge lifecycle")?;
+    append_audit_entry(
+        db,
+        "knowledge_promote",
+        &serde_json::json!({
+            "drawer_id": request.drawer_id,
+            "old_status": knowledge_status_slug(&old_status),
+            "new_status": knowledge_status_slug(&target_status),
+            "verification_refs": request.verification_refs,
+            "reason": request.reason,
+            "reviewer": request.reviewer,
+        }),
+    )
+    .context("failed to append audit log")?;
+
+    Ok(PromoteOutcome {
+        drawer_id: drawer.id,
+        old_status: knowledge_status_slug(&old_status).to_string(),
+        new_status: knowledge_status_slug(&target_status).to_string(),
+        verification_refs: drawer.verification_refs,
+        gate,
+    })
+}
+
+pub fn demote_knowledge(db: &Database, request: DemoteRequest) -> Result<DemoteOutcome> {
+    let target_status = parse_lifecycle_status(&request.status)?;
+    if !matches!(
+        target_status,
+        KnowledgeStatus::Demoted | KnowledgeStatus::Retired
+    ) {
+        bail!("demote status must be demoted or retired");
+    }
+    validate_demote_reason_type(&request.reason_type)?;
+    let mut drawer = load_lifecycle_knowledge_drawer(db, &request.drawer_id)?;
+    validate_tier_status(
+        drawer.tier.as_ref().expect("knowledge drawer has tier"),
+        &target_status,
+    )?;
+    validate_lifecycle_refs(db, &request.evidence_refs)?;
+
+    let old_status = drawer.status.clone().expect("knowledge drawer has status");
+    append_unique_refs(&mut drawer.counterexample_refs, &request.evidence_refs);
+    db.update_knowledge_lifecycle(
+        &request.drawer_id,
+        &target_status,
+        &drawer.verification_refs,
+        &drawer.counterexample_refs,
+    )
+    .context("failed to update knowledge lifecycle")?;
+    append_audit_entry(
+        db,
+        "knowledge_demote",
+        &serde_json::json!({
+            "drawer_id": request.drawer_id,
+            "old_status": knowledge_status_slug(&old_status),
+            "new_status": knowledge_status_slug(&target_status),
+            "evidence_refs": request.evidence_refs,
+            "reason": request.reason,
+            "reason_type": request.reason_type,
+        }),
+    )
+    .context("failed to append audit log")?;
+
+    Ok(DemoteOutcome {
+        drawer_id: drawer.id,
+        old_status: knowledge_status_slug(&old_status).to_string(),
+        new_status: knowledge_status_slug(&target_status).to_string(),
+        counterexample_refs: drawer.counterexample_refs,
+    })
+}
+
+fn load_lifecycle_knowledge_drawer(db: &Database, drawer_id: &str) -> Result<Drawer> {
+    let drawer = db
+        .get_drawer(drawer_id)
+        .context("failed to look up drawer")?
+        .with_context(|| format!("drawer not found: {drawer_id}"))?;
+    if drawer.memory_kind != MemoryKind::Knowledge {
+        bail!("knowledge lifecycle requires a knowledge drawer");
+    }
+    if drawer.tier.is_none() || drawer.status.is_none() {
+        bail!("knowledge lifecycle requires tier and status metadata");
+    }
+    Ok(drawer)
+}
+
+fn parse_lifecycle_status(value: &str) -> Result<KnowledgeStatus> {
+    match value.trim() {
+        "candidate" => Ok(KnowledgeStatus::Candidate),
+        "promoted" => Ok(KnowledgeStatus::Promoted),
+        "canonical" => Ok(KnowledgeStatus::Canonical),
+        "demoted" => Ok(KnowledgeStatus::Demoted),
+        "retired" => Ok(KnowledgeStatus::Retired),
+        other => bail!("unsupported knowledge status: {other}"),
+    }
+}
+
+fn validate_tier_status(tier: &KnowledgeTier, status: &KnowledgeStatus) -> Result<()> {
+    let allowed = match tier {
+        KnowledgeTier::DaoTian => &[KnowledgeStatus::Canonical, KnowledgeStatus::Demoted][..],
+        KnowledgeTier::DaoRen => &[
+            KnowledgeStatus::Candidate,
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+        KnowledgeTier::Shu => &[
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+        KnowledgeTier::Qi => &[
+            KnowledgeStatus::Candidate,
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+    };
+
+    if allowed.contains(status) {
+        return Ok(());
+    }
+
+    match tier {
+        KnowledgeTier::DaoTian => bail!("dao_tian only allows canonical or demoted"),
+        KnowledgeTier::DaoRen => {
+            bail!("dao_ren only allows candidate, promoted, demoted, or retired")
+        }
+        KnowledgeTier::Shu => bail!("shu only allows promoted, demoted, or retired"),
+        KnowledgeTier::Qi => bail!("qi only allows candidate, promoted, demoted, or retired"),
+    }
+}
+
+fn validate_demote_reason_type(value: &str) -> Result<()> {
+    match value.trim() {
+        "contradicted" | "obsolete" | "superseded" | "out_of_scope" | "unsafe" => Ok(()),
+        other => bail!("unsupported demote reason_type: {other}"),
+    }
+}
+
+fn validate_lifecycle_refs(db: &Database, refs: &[String]) -> Result<()> {
+    if refs.is_empty() {
+        bail!("at least one lifecycle evidence ref is required");
+    }
+    for drawer_id in refs {
+        if !drawer_id.starts_with("drawer_") {
+            bail!("lifecycle refs must contain drawer ids");
+        }
+        let drawer = db
+            .get_drawer(drawer_id)
+            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
+            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
+        if drawer.memory_kind != MemoryKind::Evidence {
+            bail!("lifecycle refs must point to evidence drawers");
+        }
+    }
+    Ok(())
+}
+
+fn append_unique_refs(target: &mut Vec<String>, refs: &[String]) {
+    for item in refs {
+        if !target.iter().any(|existing| existing == item) {
+            target.push(item.clone());
+        }
+    }
+}
+
+fn append_audit_entry(db: &Database, command: &str, details: &serde_json::Value) -> Result<()> {
+    let audit_path = db
+        .path()
+        .parent()
+        .map(|parent| parent.join("audit.jsonl"))
+        .unwrap_or_else(|| PathBuf::from("audit.jsonl"));
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&audit_path)
+        .with_context(|| format!("failed to open audit log {}", audit_path.display()))?;
+    let entry = serde_json::json!({
+        "timestamp": current_timestamp(),
+        "command": command,
+        "details": details,
+    });
+    writeln!(file, "{entry}")
+        .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
+    Ok(())
+}
+
+fn knowledge_status_slug(value: &KnowledgeStatus) -> &'static str {
+    match value {
+        KnowledgeStatus::Candidate => "candidate",
+        KnowledgeStatus::Promoted => "promoted",
+        KnowledgeStatus::Canonical => "canonical",
+        KnowledgeStatus::Demoted => "demoted",
+        KnowledgeStatus::Retired => "retired",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,6 @@ pub mod factcheck;
 pub mod ingest;
 pub mod knowledge_distill;
 pub mod knowledge_gate;
+pub mod knowledge_lifecycle;
 pub mod mcp;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,9 @@ use mempal::ingest::{
 };
 use mempal::knowledge_distill::{DistillPlan, DistillRequest, commit_distill, prepare_distill};
 use mempal::knowledge_gate::{GateReport, evaluate_gate_by_id};
+use mempal::knowledge_lifecycle::{
+    DemoteRequest, PromoteRequest, demote_knowledge, promote_knowledge,
+};
 use mempal::mcp::MempalMcpServer;
 use mempal::search::{SearchFilters, SearchOptions, search_with_options};
 use serde::Serialize;
@@ -1267,48 +1270,21 @@ async fn knowledge_command(
             reason,
             reviewer,
         } => {
-            let target_status = parse_lifecycle_status(&status)?;
-            if !matches!(
-                target_status,
-                KnowledgeStatus::Promoted | KnowledgeStatus::Canonical
-            ) {
-                bail!("promote status must be promoted or canonical");
-            }
-            let drawer = load_lifecycle_knowledge_drawer(db, &drawer_id)?;
-            validate_tier_status(
-                drawer.tier.as_ref().expect("knowledge drawer has tier"),
-                &target_status,
-            )?;
-            validate_lifecycle_refs(db, &verification_refs)?;
-
-            let old_status = drawer.status.clone().expect("knowledge drawer has status");
-            let mut updated_verification_refs = drawer.verification_refs.clone();
-            append_unique_refs(&mut updated_verification_refs, &verification_refs);
-            db.update_knowledge_lifecycle(
-                &drawer_id,
-                &target_status,
-                &updated_verification_refs,
-                &drawer.counterexample_refs,
-            )
-            .context("failed to update knowledge lifecycle")?;
-            append_audit_entry(
+            let outcome = promote_knowledge(
                 db,
-                "knowledge_promote",
-                &serde_json::json!({
-                    "drawer_id": drawer_id,
-                    "old_status": knowledge_status_slug(&old_status),
-                    "new_status": knowledge_status_slug(&target_status),
-                    "verification_refs": verification_refs,
-                    "reason": reason,
-                    "reviewer": reviewer,
-                }),
-            )
-            .context("failed to append audit log")?;
+                PromoteRequest {
+                    drawer_id: drawer_id.clone(),
+                    status,
+                    verification_refs,
+                    reason,
+                    reviewer,
+                    allow_counterexamples: false,
+                    enforce_gate: false,
+                },
+            )?;
             println!(
                 "promoted {}: {} -> {}",
-                drawer_id,
-                knowledge_status_slug(&old_status),
-                knowledge_status_slug(&target_status)
+                drawer_id, outcome.old_status, outcome.new_status
             );
         }
         KnowledgeCommands::Demote {
@@ -1318,49 +1294,19 @@ async fn knowledge_command(
             reason,
             reason_type,
         } => {
-            let target_status = parse_lifecycle_status(&status)?;
-            if !matches!(
-                target_status,
-                KnowledgeStatus::Demoted | KnowledgeStatus::Retired
-            ) {
-                bail!("demote status must be demoted or retired");
-            }
-            validate_demote_reason_type(&reason_type)?;
-            let drawer = load_lifecycle_knowledge_drawer(db, &drawer_id)?;
-            validate_tier_status(
-                drawer.tier.as_ref().expect("knowledge drawer has tier"),
-                &target_status,
-            )?;
-            validate_lifecycle_refs(db, &evidence_refs)?;
-
-            let old_status = drawer.status.clone().expect("knowledge drawer has status");
-            let mut updated_counterexample_refs = drawer.counterexample_refs.clone();
-            append_unique_refs(&mut updated_counterexample_refs, &evidence_refs);
-            db.update_knowledge_lifecycle(
-                &drawer_id,
-                &target_status,
-                &drawer.verification_refs,
-                &updated_counterexample_refs,
-            )
-            .context("failed to update knowledge lifecycle")?;
-            append_audit_entry(
+            let outcome = demote_knowledge(
                 db,
-                "knowledge_demote",
-                &serde_json::json!({
-                    "drawer_id": drawer_id,
-                    "old_status": knowledge_status_slug(&old_status),
-                    "new_status": knowledge_status_slug(&target_status),
-                    "evidence_refs": evidence_refs,
-                    "reason": reason,
-                    "reason_type": reason_type,
-                }),
-            )
-            .context("failed to append audit log")?;
+                DemoteRequest {
+                    drawer_id: drawer_id.clone(),
+                    status,
+                    evidence_refs,
+                    reason,
+                    reason_type,
+                },
+            )?;
             println!(
                 "demoted {}: {} -> {}",
-                drawer_id,
-                knowledge_status_slug(&old_status),
-                knowledge_status_slug(&target_status)
+                drawer_id, outcome.old_status, outcome.new_status
             );
         }
         KnowledgeCommands::Gate {
@@ -1420,70 +1366,6 @@ fn build_trigger_hints(
     })
 }
 
-fn load_lifecycle_knowledge_drawer(
-    db: &Database,
-    drawer_id: &str,
-) -> Result<mempal::core::types::Drawer> {
-    let drawer = db
-        .get_drawer(drawer_id)
-        .context("failed to look up drawer")?
-        .with_context(|| format!("drawer not found: {drawer_id}"))?;
-    if drawer.memory_kind != MemoryKind::Knowledge {
-        bail!("knowledge lifecycle requires a knowledge drawer");
-    }
-    if drawer.tier.is_none() || drawer.status.is_none() {
-        bail!("knowledge lifecycle requires tier and status metadata");
-    }
-    Ok(drawer)
-}
-
-fn parse_lifecycle_status(value: &str) -> Result<KnowledgeStatus> {
-    match value {
-        "candidate" => Ok(KnowledgeStatus::Candidate),
-        "promoted" => Ok(KnowledgeStatus::Promoted),
-        "canonical" => Ok(KnowledgeStatus::Canonical),
-        "demoted" => Ok(KnowledgeStatus::Demoted),
-        "retired" => Ok(KnowledgeStatus::Retired),
-        other => bail!("unsupported knowledge status: {other}"),
-    }
-}
-
-fn validate_tier_status(tier: &KnowledgeTier, status: &KnowledgeStatus) -> Result<()> {
-    let allowed = match tier {
-        KnowledgeTier::DaoTian => &[KnowledgeStatus::Canonical, KnowledgeStatus::Demoted][..],
-        KnowledgeTier::DaoRen => &[
-            KnowledgeStatus::Candidate,
-            KnowledgeStatus::Promoted,
-            KnowledgeStatus::Demoted,
-            KnowledgeStatus::Retired,
-        ][..],
-        KnowledgeTier::Shu => &[
-            KnowledgeStatus::Promoted,
-            KnowledgeStatus::Demoted,
-            KnowledgeStatus::Retired,
-        ][..],
-        KnowledgeTier::Qi => &[
-            KnowledgeStatus::Candidate,
-            KnowledgeStatus::Promoted,
-            KnowledgeStatus::Demoted,
-            KnowledgeStatus::Retired,
-        ][..],
-    };
-
-    if allowed.contains(status) {
-        return Ok(());
-    }
-
-    match tier {
-        KnowledgeTier::DaoTian => bail!("dao_tian only allows canonical or demoted"),
-        KnowledgeTier::DaoRen => {
-            bail!("dao_ren only allows candidate, promoted, demoted, or retired")
-        }
-        KnowledgeTier::Shu => bail!("shu only allows promoted, demoted, or retired"),
-        KnowledgeTier::Qi => bail!("qi only allows candidate, promoted, demoted, or retired"),
-    }
-}
-
 fn print_gate_report(report: &GateReport) {
     println!("drawer_id={}", report.drawer_id);
     println!("tier={}", report.tier);
@@ -1507,40 +1389,6 @@ fn print_gate_report(report: &GateReport) {
     );
     for reason in &report.reasons {
         println!("reason={reason}");
-    }
-}
-
-fn validate_demote_reason_type(value: &str) -> Result<()> {
-    match value {
-        "contradicted" | "obsolete" | "superseded" | "out_of_scope" | "unsafe" => Ok(()),
-        other => bail!("unsupported demote reason_type: {other}"),
-    }
-}
-
-fn validate_lifecycle_refs(db: &Database, refs: &[String]) -> Result<()> {
-    if refs.is_empty() {
-        bail!("at least one lifecycle evidence ref is required");
-    }
-    for drawer_id in refs {
-        if !drawer_id.starts_with("drawer_") {
-            bail!("lifecycle refs must contain drawer ids");
-        }
-        let drawer = db
-            .get_drawer(drawer_id)
-            .with_context(|| format!("failed to load ref drawer {drawer_id}"))?
-            .with_context(|| format!("ref drawer not found: {drawer_id}"))?;
-        if drawer.memory_kind != MemoryKind::Evidence {
-            bail!("lifecycle refs must point to evidence drawers");
-        }
-    }
-    Ok(())
-}
-
-fn append_unique_refs(target: &mut Vec<String>, refs: &[String]) {
-    for item in refs {
-        if !target.iter().any(|existing| existing == item) {
-            target.push(item.clone());
-        }
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -28,6 +28,10 @@ use crate::knowledge_distill::{
     DistillPlan, DistillRequest as CoreDistillRequest, commit_distill, prepare_distill,
 };
 use crate::knowledge_gate::evaluate_gate_by_id;
+use crate::knowledge_lifecycle::{
+    DemoteRequest as CoreDemoteRequest, PromoteRequest as CorePromoteRequest, demote_knowledge,
+    promote_knowledge,
+};
 use crate::search::{SearchFilters, SearchOptions, resolve_route, search_with_vector_options};
 use anyhow::Context;
 use rmcp::{
@@ -41,11 +45,13 @@ use serde_json::Value;
 use super::tools::{
     ContextRequest, ContextResponse, CoworkPushRequest, CoworkPushResponse, DeleteRequest,
     DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, IngestRequest,
-    IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeDistillRequest,
-    KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, PeekMessageDto,
-    PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest, SearchResponse,
-    SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse,
-    TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
+    IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeDemoteRequest,
+    KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
+    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePromoteRequest, KnowledgePromoteResponse,
+    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest,
+    SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest,
+    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
+    TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -140,6 +146,28 @@ impl MempalMcpServer {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         self.mempal_knowledge_distill(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn knowledge_promote_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<KnowledgePromoteResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_knowledge_promote(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn knowledge_demote_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<KnowledgeDemoteResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_knowledge_demote(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -760,6 +788,56 @@ impl MempalMcpServer {
         .map_err(knowledge_gate_error)?;
 
         Ok(Json(KnowledgeGateResponse::from(report)))
+    }
+
+    #[tool(
+        name = "mempal_knowledge_promote",
+        description = "Promote a knowledge drawer after a deterministic gate pass. Appends verification evidence refs, evaluates promotion readiness, then updates lifecycle status and audit log only if the gate allows it."
+    )]
+    async fn mempal_knowledge_promote(
+        &self,
+        Parameters(request): Parameters<KnowledgePromoteRequest>,
+    ) -> std::result::Result<Json<KnowledgePromoteResponse>, ErrorData> {
+        let db = self.open_db()?;
+        let outcome = promote_knowledge(
+            &db,
+            CorePromoteRequest {
+                drawer_id: request.drawer_id,
+                status: request.status,
+                verification_refs: request.verification_refs,
+                reason: request.reason,
+                reviewer: request.reviewer,
+                allow_counterexamples: request.allow_counterexamples.unwrap_or(false),
+                enforce_gate: true,
+            },
+        )
+        .map_err(knowledge_lifecycle_error)?;
+
+        Ok(Json(KnowledgePromoteResponse::from(outcome)))
+    }
+
+    #[tool(
+        name = "mempal_knowledge_demote",
+        description = "Demote or retire a knowledge drawer with counterexample evidence. Appends evidence refs to counterexample_refs, updates lifecycle status, and writes an audit entry without touching vectors or schema."
+    )]
+    async fn mempal_knowledge_demote(
+        &self,
+        Parameters(request): Parameters<KnowledgeDemoteRequest>,
+    ) -> std::result::Result<Json<KnowledgeDemoteResponse>, ErrorData> {
+        let db = self.open_db()?;
+        let outcome = demote_knowledge(
+            &db,
+            CoreDemoteRequest {
+                drawer_id: request.drawer_id,
+                status: request.status,
+                evidence_refs: request.evidence_refs,
+                reason: request.reason,
+                reason_type: request.reason_type,
+            },
+        )
+        .map_err(knowledge_lifecycle_error)?;
+
+        Ok(Json(KnowledgeDemoteResponse::from(outcome)))
     }
 
     #[tool(
@@ -1470,6 +1548,18 @@ fn knowledge_distill_error(error: anyhow::Error) -> ErrorData {
         || message.contains("failed to insert")
         || message.contains("failed to append audit")
         || message.contains("embedder required")
+    {
+        return ErrorData::internal_error(message, None);
+    }
+    ErrorData::invalid_params(message, None)
+}
+
+fn knowledge_lifecycle_error(error: anyhow::Error) -> ErrorData {
+    let message = error.to_string();
+    if message.contains("failed to update")
+        || message.contains("failed to append audit")
+        || message.contains("failed to open audit")
+        || message.contains("failed to write audit")
     {
         return ErrorData::internal_error(message, None);
     }
@@ -2759,6 +2849,311 @@ mod tests {
                 .contains("Read-only promotion readiness")
         );
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_gate"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_promote_updates_status_after_gate_pass() {
+        let (_tempdir, db_path, server) = setup_server();
+        for id in ["drawer_support_1", "drawer_support_2", "drawer_verify_1"] {
+            insert_drawer(
+                &db_path,
+                id,
+                id,
+                "mempal",
+                Some("lifecycle"),
+                &format!("/tmp/{id}.md"),
+                2,
+            );
+        }
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_lifecycle_promote",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Candidate,
+            "Gate-passed knowledge can be promoted.",
+            "Knowledge content",
+            KnowledgeRefs {
+                supporting: vec![
+                    "drawer_support_1".to_string(),
+                    "drawer_support_2".to_string(),
+                ],
+                ..KnowledgeRefs::default()
+            },
+        );
+        let audit_before = audit_line_count(&db_path);
+
+        let response = server
+            .knowledge_promote_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_lifecycle_promote",
+                "status": "promoted",
+                "verification_refs": ["drawer_verify_1"],
+                "reason": "validated by MCP lifecycle test",
+                "reviewer": "test"
+            }))
+            .await
+            .expect("promote should pass");
+
+        assert_eq!(response.old_status, "candidate");
+        assert_eq!(response.new_status, "promoted");
+        let gate = response.gate.expect("MCP promote returns gate report");
+        assert!(gate.allowed, "reasons={:?}", gate.reasons);
+        assert_eq!(response.verification_refs, vec!["drawer_verify_1"]);
+        let db = Database::open(&db_path).expect("open db");
+        let drawer = db
+            .get_drawer("drawer_lifecycle_promote")
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(drawer.status, Some(KnowledgeStatus::Promoted));
+        assert_eq!(drawer.verification_refs, vec!["drawer_verify_1"]);
+        assert_eq!(audit_line_count(&db_path), audit_before + 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_promote_rejects_gate_failure_without_mutation() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_support_1",
+            "support 1",
+            "mempal",
+            Some("lifecycle"),
+            "/tmp/support-1.md",
+            2,
+        );
+        insert_drawer(
+            &db_path,
+            "drawer_verify_1",
+            "verify 1",
+            "mempal",
+            Some("lifecycle"),
+            "/tmp/verify-1.md",
+            2,
+        );
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_lifecycle_gate_fail",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Candidate,
+            "Insufficiently supported knowledge cannot be promoted.",
+            "Knowledge content",
+            KnowledgeRefs {
+                supporting: vec!["drawer_support_1".to_string()],
+                ..KnowledgeRefs::default()
+            },
+        );
+        let db = Database::open(&db_path).expect("open db");
+        let schema_before = db.schema_version().expect("schema");
+        let vector_count_before = vector_row_count(&db, "drawer_lifecycle_gate_fail");
+        let audit_before = audit_line_count(&db_path);
+
+        let error = server
+            .knowledge_promote_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_lifecycle_gate_fail",
+                "status": "promoted",
+                "verification_refs": ["drawer_verify_1"],
+                "reason": "should fail gate"
+            }))
+            .await
+            .expect_err("promote should fail gate");
+
+        assert!(
+            error.to_string().contains("promotion gate failed"),
+            "error={error}"
+        );
+        let drawer = db
+            .get_drawer("drawer_lifecycle_gate_fail")
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(drawer.status, Some(KnowledgeStatus::Candidate));
+        assert!(drawer.verification_refs.is_empty());
+        assert_eq!(db.schema_version().expect("schema"), schema_before);
+        assert_eq!(
+            vector_row_count(&db, "drawer_lifecycle_gate_fail"),
+            vector_count_before
+        );
+        assert_eq!(audit_line_count(&db_path), audit_before);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_demote_updates_status_and_counterexample_refs() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_counterexample_1",
+            "counterexample 1",
+            "mempal",
+            Some("lifecycle"),
+            "/tmp/counterexample-1.md",
+            2,
+        );
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_lifecycle_demote",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "A workflow can be demoted.",
+            "Knowledge content",
+            KnowledgeRefs::default(),
+        );
+        let audit_before = audit_line_count(&db_path);
+
+        let response = server
+            .knowledge_demote_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_lifecycle_demote",
+                "status": "demoted",
+                "evidence_refs": ["drawer_counterexample_1"],
+                "reason": "contradicted by MCP lifecycle test",
+                "reason_type": "contradicted"
+            }))
+            .await
+            .expect("demote should pass");
+
+        assert_eq!(response.old_status, "promoted");
+        assert_eq!(response.new_status, "demoted");
+        assert_eq!(
+            response.counterexample_refs,
+            vec!["drawer_counterexample_1"]
+        );
+        let db = Database::open(&db_path).expect("open db");
+        let drawer = db
+            .get_drawer("drawer_lifecycle_demote")
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(drawer.status, Some(KnowledgeStatus::Demoted));
+        assert_eq!(drawer.counterexample_refs, vec!["drawer_counterexample_1"]);
+        assert_eq!(audit_line_count(&db_path), audit_before + 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_lifecycle_rejects_evidence_drawer_targets() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_evidence_target",
+            "evidence target",
+            "mempal",
+            Some("lifecycle"),
+            "/tmp/evidence-target.md",
+            2,
+        );
+        let promote_error = server
+            .knowledge_promote_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_evidence_target",
+                "status": "promoted",
+                "verification_refs": ["drawer_evidence_target"],
+                "reason": "bad target"
+            }))
+            .await
+            .expect_err("evidence target should be rejected");
+        assert!(
+            promote_error
+                .to_string()
+                .contains("knowledge lifecycle requires a knowledge drawer"),
+            "error={promote_error}"
+        );
+
+        let demote_error = server
+            .knowledge_demote_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_evidence_target",
+                "status": "demoted",
+                "evidence_refs": ["drawer_evidence_target"],
+                "reason": "bad target",
+                "reason_type": "contradicted"
+            }))
+            .await
+            .expect_err("evidence target should be rejected");
+        assert!(
+            demote_error
+                .to_string()
+                .contains("knowledge lifecycle requires a knowledge drawer"),
+            "error={demote_error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_lifecycle_validates_refs_are_evidence_drawers() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_lifecycle_target",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Candidate,
+            "Knowledge target.",
+            "Knowledge content",
+            KnowledgeRefs::default(),
+        );
+        insert_knowledge_drawer_with_refs(
+            &db_path,
+            "drawer_wrong_ref_kind",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Candidate,
+            "Wrong ref kind.",
+            "Knowledge content",
+            KnowledgeRefs::default(),
+        );
+
+        let promote_error = server
+            .knowledge_promote_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_lifecycle_target",
+                "status": "promoted",
+                "verification_refs": ["drawer_wrong_ref_kind"],
+                "reason": "bad ref"
+            }))
+            .await
+            .expect_err("knowledge ref should be rejected");
+        assert!(
+            promote_error
+                .to_string()
+                .contains("lifecycle refs must point to evidence drawers"),
+            "error={promote_error}"
+        );
+
+        let demote_error = server
+            .knowledge_demote_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_lifecycle_target",
+                "status": "demoted",
+                "evidence_refs": ["drawer_wrong_ref_kind"],
+                "reason": "bad ref",
+                "reason_type": "contradicted"
+            }))
+            .await
+            .expect_err("knowledge ref should be rejected");
+        assert!(
+            demote_error
+                .to_string()
+                .contains("lifecycle refs must point to evidence drawers"),
+            "error={demote_error}"
+        );
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_knowledge_lifecycle_tools() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let promote_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_knowledge_promote")
+            .expect("mempal_knowledge_promote tool exists");
+        assert!(
+            promote_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("gate pass")
+        );
+        let demote_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_knowledge_demote")
+            .expect("mempal_knowledge_demote tool exists");
+        assert!(
+            demote_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("counterexample evidence")
+        );
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_promote"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("MCP promotion is gate-enforced"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -5,6 +5,7 @@ use crate::core::types::{
 };
 use crate::knowledge_distill::DistillOutcome;
 use crate::knowledge_gate::GateReport;
+use crate::knowledge_lifecycle::{DemoteOutcome, PromoteOutcome};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 
@@ -116,6 +117,65 @@ impl From<DistillOutcome> for KnowledgeDistillResponse {
             drawer_id: outcome.drawer_id,
             created: outcome.created,
             dry_run: outcome.dry_run,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct KnowledgePromoteRequest {
+    pub drawer_id: String,
+    pub status: String,
+    pub verification_refs: Vec<String>,
+    pub reason: String,
+    pub reviewer: Option<String>,
+    pub allow_counterexamples: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgePromoteResponse {
+    pub drawer_id: String,
+    pub old_status: String,
+    pub new_status: String,
+    pub verification_refs: Vec<String>,
+    pub gate: Option<KnowledgeGateResponse>,
+}
+
+impl From<PromoteOutcome> for KnowledgePromoteResponse {
+    fn from(outcome: PromoteOutcome) -> Self {
+        Self {
+            drawer_id: outcome.drawer_id,
+            old_status: outcome.old_status,
+            new_status: outcome.new_status,
+            verification_refs: outcome.verification_refs,
+            gate: outcome.gate.map(KnowledgeGateResponse::from),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct KnowledgeDemoteRequest {
+    pub drawer_id: String,
+    pub status: String,
+    pub evidence_refs: Vec<String>,
+    pub reason: String,
+    pub reason_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeDemoteResponse {
+    pub drawer_id: String,
+    pub old_status: String,
+    pub new_status: String,
+    pub counterexample_refs: Vec<String>,
+}
+
+impl From<DemoteOutcome> for KnowledgeDemoteResponse {
+    fn from(outcome: DemoteOutcome) -> Self {
+        Self {
+            drawer_id: outcome.drawer_id,
+            old_status: outcome.old_status,
+            new_status: outcome.new_status,
+            counterexample_refs: outcome.counterexample_refs,
         }
     }
 }


### PR DESCRIPTION
## Summary

- add shared knowledge lifecycle implementation for promote/demote
- expose mempal_knowledge_promote and mempal_knowledge_demote MCP tools
- enforce promotion gate for MCP promote after appending supplied verification refs
- keep CLI lifecycle behavior compatible with P17 while sharing validation/update/audit logic
- update protocol, specs, docs, and repo instructions for P23

## Verification

- agent-spec parse specs/p23-mcp-knowledge-lifecycle.spec.md
- agent-spec lint specs/p23-mcp-knowledge-lifecycle.spec.md --min-score 0.7
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
