### PR TITLE
P24: add explicit anchor publication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P23）
+### 已完成的 Spec（P0-P24）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -70,6 +70,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p21-mcp-knowledge-gate.spec.md` | 完成 | `mempal_knowledge_gate` MCP 工具：向 agent runtime 暴露 P20 read-only promotion gate |
 | `specs/p22-mcp-knowledge-distill.spec.md` | 完成 | `mempal_knowledge_distill` MCP 工具：从 evidence refs 创建 candidate knowledge drawer |
 | `specs/p23-mcp-knowledge-lifecycle.spec.md` | 完成 | `mempal_knowledge_promote` / `mempal_knowledge_demote` MCP 工具：gate-enforced promotion + evidence-backed demotion |
+| `specs/p24-anchor-publication.spec.md` | 完成 | `mempal knowledge publish-anchor` CLI：显式 outward anchor publication（worktree -> repo -> global） |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -102,6 +103,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md` — P21 MCP knowledge gate（已完成）
 - `docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md` — P22 MCP knowledge distill（已完成）
 - `docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md` — P23 MCP knowledge lifecycle（已完成）
+- `docs/plans/2026-04-26-p24-anchor-publication-implementation.md` — P24 anchor publication CLI（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P23）
+### 已完成的 Spec（P0-P24）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -68,6 +68,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p21-mcp-knowledge-gate.spec.md` | 完成 | `mempal_knowledge_gate` MCP 工具：向 agent runtime 暴露 P20 read-only promotion gate |
 | `specs/p22-mcp-knowledge-distill.spec.md` | 完成 | `mempal_knowledge_distill` MCP 工具：从 evidence refs 创建 candidate knowledge drawer |
 | `specs/p23-mcp-knowledge-lifecycle.spec.md` | 完成 | `mempal_knowledge_promote` / `mempal_knowledge_demote` MCP 工具：gate-enforced promotion + evidence-backed demotion |
+| `specs/p24-anchor-publication.spec.md` | 完成 | `mempal knowledge publish-anchor` CLI：显式 outward anchor publication（worktree -> repo -> global） |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -100,6 +101,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-25-p21-mcp-knowledge-gate-implementation.md` — P21 MCP knowledge gate（已完成）
 - `docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md` — P22 MCP knowledge distill（已完成）
 - `docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md` — P23 MCP knowledge lifecycle（已完成）
+- `docs/plans/2026-04-26-p24-anchor-publication-implementation.md` — P24 anchor publication CLI（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -826,6 +826,7 @@ Implemented Phase-1 runtime surface:
 - promotion gate CLI provides a read-only advisory report before promotion, using deterministic evidence-count policy without mutating status, refs, vectors, schema, or audit history
 - `mempal_knowledge_gate` exposes the same read-only promotion gate to MCP-connected agents, so runtime agents can check readiness without shelling out or mutating lifecycle state
 - `mempal_knowledge_promote` and `mempal_knowledge_demote` expose lifecycle mutation to MCP-connected agents; promotion is gate-enforced after appending supplied verification refs, while demotion requires counterexample evidence
+- `mempal knowledge publish-anchor` implements explicit outward anchor publication for active knowledge (`worktree -> repo -> global`) as a metadata-only operation separate from tier/status promotion
 - lifecycle updates are metadata-only in Stage 1; they do not rewrite content, re-embed vectors, or create Phase-2 knowledge cards
 
 ### Phase 2: Knowledge Card Extraction

--- a/docs/plans/2026-04-26-p24-anchor-publication-implementation.md
+++ b/docs/plans/2026-04-26-p24-anchor-publication-implementation.md
@@ -1,0 +1,21 @@
+# P24 Anchor Publication Implementation Plan
+
+## Goal
+
+Add explicit Stage-1 knowledge anchor publication so stable knowledge can move outward across persistence scopes without changing its tier/status lifecycle.
+
+## Implementation Steps
+
+1. Add `Database::update_knowledge_anchor` for metadata-only anchor updates.
+2. Add `knowledge_anchor` shared logic for validation, target anchor resolution, update, and audit writing.
+3. Add CLI command `mempal knowledge publish-anchor`.
+4. Add integration tests for worktree-to-repo, repo-to-global, invalid chains, invalid targets, and schema stability.
+5. Update docs, repo instructions, and mind-model implementation surface.
+
+## Non-Goals
+
+- No schema migration.
+- No drawer clone/copy.
+- No vector or FTS content rewrite.
+- No MCP/REST endpoint.
+- No automatic publication from promote, gate, or distill.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -226,6 +226,20 @@ the audit log. P21 exposes the same policy to MCP agents as
 mempal knowledge gate drawer_knowledge --format json
 ```
 
+P24 adds explicit anchor publication. This is separate from tier/status
+promotion: it only moves an already active knowledge drawer outward across
+anchor scope, without rewriting content or vectors.
+
+```bash
+mempal knowledge publish-anchor drawer_knowledge \
+  --to repo \
+  --reason "stable across this repository"
+```
+
+Supported publication chain is `worktree -> repo -> global`. Publishing to
+`global` requires `domain=global` and an explicit `--target-anchor-id
+global://...`.
+
 For `dao_tian -> canonical`, provide a reviewer for the advisory gate:
 
 ```bash

--- a/specs/p24-anchor-publication.spec.md
+++ b/specs/p24-anchor-publication.spec.md
@@ -1,0 +1,144 @@
+spec: task
+name: "P24: explicit knowledge anchor publication CLI"
+inherits: project
+tags: [memory, knowledge, anchor, lifecycle, cli]
+---
+
+## Intent
+
+P12 introduced `global/repo/worktree` anchors and P14-P23 made typed knowledge usable at runtime, but anchor-scope publication still exists only as a design rule. P24 adds the smallest explicit CLI operation for publishing an existing knowledge drawer outward across anchor scopes while preserving Stage-1 drawer storage and avoiding automatic policy decisions.
+
+## Decisions
+
+- Add CLI command `mempal knowledge publish-anchor <drawer_id>`.
+- Request flags:
+  - required `--to repo|global`
+  - required `--reason <text>`
+  - optional `--reviewer <text>`
+  - optional `--target-anchor-id <anchor_id>`
+  - optional `--cwd <path>`
+- The command only accepts `memory_kind=knowledge`.
+- The command only accepts active knowledge statuses: `promoted|canonical`.
+- The command is metadata-only:
+  - updates `anchor_kind`, `anchor_id`, and `parent_anchor_id`
+  - does not change content, statement, tier, status, refs, vectors, FTS content, source_file, or schema
+- Publication chain is explicit and outward-only:
+  - `worktree -> repo`
+  - `repo -> global`
+  - `worktree -> global` is rejected
+  - same-anchor publication is rejected
+  - inward publication is rejected
+- For `--to repo`:
+  - if `--target-anchor-id` is supplied, it must be a valid `repo://...` anchor id
+  - otherwise, a worktree drawer must have `parent_anchor_id`
+  - otherwise, `--cwd` may be used to derive the current repo anchor
+- For `--to global`:
+  - `--target-anchor-id` is required and must be a valid `global://...` anchor id
+  - the drawer must already have `domain=global`, preserving the P12 invariant that global anchors require global domain
+- Successful publication appends a `knowledge_publish_anchor` audit entry with drawer id, old/new anchor, reason, and reviewer.
+- The command prints a deterministic one-line summary: `published <drawer_id>: <old_kind>:<old_id> -> <new_kind>:<new_id>`.
+- This task does not add MCP or REST publication endpoints.
+
+## Boundaries
+
+### Allowed Changes
+
+- `src/core/db.rs`
+- `src/knowledge_anchor.rs`
+- `src/lib.rs`
+- `src/main.rs`
+- `tests/knowledge_lifecycle.rs`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `specs/p24-anchor-publication.spec.md`
+- `docs/plans/**`
+
+### Forbidden
+
+- Do not add tables, columns, triggers, or migrations.
+- Do not add Phase-2 `knowledge_cards`.
+- Do not duplicate or clone drawers.
+- Do not update vectors or re-embed content.
+- Do not change `mempal_context` ordering.
+- Do not add MCP or REST publication endpoints.
+- Do not auto-publish as part of promote/distill/gate.
+- Do not introduce new dependencies.
+
+## Acceptance Criteria
+
+Scenario: CLI publishes worktree knowledge to parent repo anchor
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_publish_anchor_worktree_to_repo
+  Given a promoted knowledge drawer has `anchor_kind="worktree"` and `parent_anchor_id="repo://parent"`
+  When running `mempal knowledge publish-anchor <id> --to repo --reason "share stable rule"`
+  Then the command exits successfully
+  And stdout says `published <id>: worktree:<old_id> -> repo:repo://parent`
+  And the stored drawer has `anchor_kind="repo"`, `anchor_id="repo://parent"`, and `parent_anchor_id=NULL`
+  And content, statement, status, refs, and vector row remain unchanged
+  And one `knowledge_publish_anchor` audit entry is appended
+
+Scenario: CLI publishes global-domain repo knowledge to explicit global anchor
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_publish_anchor_repo_to_global
+  Given a canonical knowledge drawer has `domain="global"` and `anchor_kind="repo"`
+  When running `mempal knowledge publish-anchor <id> --to global --target-anchor-id global://epistemics --reason "global law" --reviewer human`
+  Then the command exits successfully
+  And the stored drawer has `anchor_kind="global"` and `anchor_id="global://epistemics"`
+  And the audit entry includes reviewer `human`
+
+Scenario: CLI rejects worktree directly to global
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_publish_anchor_rejects_worktree_to_global
+  Given a promoted knowledge drawer has `anchor_kind="worktree"`
+  When running `mempal knowledge publish-anchor <id> --to global --target-anchor-id global://x --reason "skip"`
+  Then the command fails
+  And stderr mentions `worktree -> global publication is not allowed`
+  And the stored drawer anchor remains unchanged
+
+Scenario: CLI rejects inactive or evidence targets
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_publish_anchor_rejects_inactive_or_evidence
+  Given an evidence drawer exists
+  When running `mempal knowledge publish-anchor <evidence_id> --to repo --reason "bad"`
+  Then the command fails
+  And stderr mentions `knowledge anchor publication requires a knowledge drawer`
+  Given a candidate knowledge drawer exists
+  When running `mempal knowledge publish-anchor <candidate_id> --to repo --reason "bad"`
+  Then the command fails
+  And stderr mentions `publish-anchor requires promoted or canonical knowledge`
+
+Scenario: CLI rejects invalid target anchors
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_publish_anchor_rejects_invalid_target_anchor
+  Given a promoted repo knowledge drawer exists
+  When running `mempal knowledge publish-anchor <id> --to global --reason "missing target"`
+  Then the command fails
+  And stderr mentions `--target-anchor-id is required for global publication`
+  When running `mempal knowledge publish-anchor <id> --to repo --target-anchor-id global://wrong --reason "bad"`
+  Then the command fails
+  And stderr mentions `expected prefix repo://`
+
+Scenario: publish-anchor does not bump schema
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_publish_anchor_does_not_bump_schema
+  Given a promoted worktree knowledge drawer with a parent repo anchor
+  And the current schema version is recorded
+  When running `mempal knowledge publish-anchor <id> --to repo --reason "stable"`
+  Then schema version remains unchanged
+  And no new table is created
+
+## Out of Scope
+
+- MCP `mempal_knowledge_publish_anchor`.
+- REST publication endpoint.
+- Automatic publication after promotion.
+- LLM or evaluator scoring.
+- Phase-2 knowledge card publication.

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -700,6 +700,33 @@ impl Database {
         Ok(affected > 0)
     }
 
+    pub fn update_knowledge_anchor(
+        &self,
+        drawer_id: &str,
+        anchor_kind: &AnchorKind,
+        anchor_id: &str,
+        parent_anchor_id: Option<&str>,
+    ) -> Result<bool, DbError> {
+        let affected = self.conn.execute(
+            r#"
+            UPDATE drawers
+            SET anchor_kind = ?2,
+                anchor_id = ?3,
+                parent_anchor_id = ?4
+            WHERE id = ?1
+              AND deleted_at IS NULL
+              AND memory_kind = 'knowledge'
+            "#,
+            params![
+                drawer_id,
+                anchor_kind_as_str(anchor_kind),
+                anchor_id,
+                parent_anchor_id,
+            ],
+        )?;
+        Ok(affected > 0)
+    }
+
     pub fn neighbor_chunks(
         &self,
         source_file: &str,

--- a/src/knowledge_anchor.rs
+++ b/src/knowledge_anchor.rs
@@ -1,0 +1,195 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+use crate::core::{
+    anchor::{self, DerivedAnchor},
+    db::Database,
+    types::{AnchorKind, Drawer, KnowledgeStatus, MemoryDomain, MemoryKind},
+    utils::current_timestamp,
+};
+
+#[derive(Debug, Clone)]
+pub struct PublishAnchorRequest {
+    pub drawer_id: String,
+    pub to: String,
+    pub target_anchor_id: Option<String>,
+    pub cwd: Option<PathBuf>,
+    pub reason: String,
+    pub reviewer: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PublishAnchorOutcome {
+    pub drawer_id: String,
+    pub old_anchor_kind: String,
+    pub old_anchor_id: String,
+    pub old_parent_anchor_id: Option<String>,
+    pub new_anchor_kind: String,
+    pub new_anchor_id: String,
+    pub new_parent_anchor_id: Option<String>,
+}
+
+pub fn publish_anchor(
+    db: &Database,
+    request: PublishAnchorRequest,
+) -> Result<PublishAnchorOutcome> {
+    let drawer = load_publishable_knowledge(db, &request.drawer_id)?;
+    let target = resolve_target_anchor(&drawer, &request)?;
+    if drawer.anchor_kind == target.anchor_kind && drawer.anchor_id == target.anchor_id {
+        bail!("same-anchor publication is not allowed");
+    }
+    validate_publication_chain(&drawer, &target)?;
+    anchor::validate_anchor_domain(&drawer.domain, &target.anchor_kind)
+        .map_err(|message| anyhow::anyhow!(message))?;
+    anchor::validate_explicit_anchor(&target.anchor_kind, &target.anchor_id)?;
+
+    db.update_knowledge_anchor(
+        &request.drawer_id,
+        &target.anchor_kind,
+        &target.anchor_id,
+        target.parent_anchor_id.as_deref(),
+    )
+    .context("failed to update knowledge anchor")?;
+    append_audit_entry(
+        db,
+        "knowledge_publish_anchor",
+        &serde_json::json!({
+            "drawer_id": request.drawer_id,
+            "old_anchor_kind": anchor_kind_slug(&drawer.anchor_kind),
+            "old_anchor_id": drawer.anchor_id,
+            "old_parent_anchor_id": drawer.parent_anchor_id,
+            "new_anchor_kind": anchor_kind_slug(&target.anchor_kind),
+            "new_anchor_id": target.anchor_id,
+            "new_parent_anchor_id": target.parent_anchor_id,
+            "reason": request.reason,
+            "reviewer": request.reviewer,
+        }),
+    )
+    .context("failed to append audit log")?;
+
+    Ok(PublishAnchorOutcome {
+        drawer_id: drawer.id,
+        old_anchor_kind: anchor_kind_slug(&drawer.anchor_kind).to_string(),
+        old_anchor_id: drawer.anchor_id,
+        old_parent_anchor_id: drawer.parent_anchor_id,
+        new_anchor_kind: anchor_kind_slug(&target.anchor_kind).to_string(),
+        new_anchor_id: target.anchor_id,
+        new_parent_anchor_id: target.parent_anchor_id,
+    })
+}
+
+fn load_publishable_knowledge(db: &Database, drawer_id: &str) -> Result<Drawer> {
+    let drawer = db
+        .get_drawer(drawer_id)
+        .context("failed to look up drawer")?
+        .with_context(|| format!("drawer not found: {drawer_id}"))?;
+    if drawer.memory_kind != MemoryKind::Knowledge {
+        bail!("knowledge anchor publication requires a knowledge drawer");
+    }
+    match drawer.status {
+        Some(KnowledgeStatus::Promoted | KnowledgeStatus::Canonical) => Ok(drawer),
+        _ => bail!("publish-anchor requires promoted or canonical knowledge"),
+    }
+}
+
+fn resolve_target_anchor(drawer: &Drawer, request: &PublishAnchorRequest) -> Result<DerivedAnchor> {
+    match request.to.trim() {
+        "repo" => resolve_repo_target(drawer, request),
+        "global" => resolve_global_target(drawer, request),
+        other => bail!("unsupported publish target: {other}"),
+    }
+}
+
+fn resolve_repo_target(drawer: &Drawer, request: &PublishAnchorRequest) -> Result<DerivedAnchor> {
+    if let Some(anchor_id) = request.target_anchor_id.as_deref() {
+        anchor::validate_explicit_anchor(&AnchorKind::Repo, anchor_id)?;
+        return Ok(DerivedAnchor {
+            anchor_kind: AnchorKind::Repo,
+            anchor_id: anchor_id.to_string(),
+            parent_anchor_id: None,
+        });
+    }
+    if let Some(parent_anchor_id) = drawer.parent_anchor_id.as_deref() {
+        anchor::validate_explicit_anchor(&AnchorKind::Repo, parent_anchor_id)?;
+        return Ok(DerivedAnchor {
+            anchor_kind: AnchorKind::Repo,
+            anchor_id: parent_anchor_id.to_string(),
+            parent_anchor_id: None,
+        });
+    }
+    if let Some(cwd) = request.cwd.as_deref() {
+        let derived = anchor::derive_anchor_from_cwd(Some(Path::new(cwd)))?;
+        if let Some(parent_anchor_id) = derived.parent_anchor_id {
+            return Ok(DerivedAnchor {
+                anchor_kind: AnchorKind::Repo,
+                anchor_id: parent_anchor_id,
+                parent_anchor_id: None,
+            });
+        }
+    }
+    bail!("repo publication requires --target-anchor-id, parent_anchor_id, or --cwd with a repo")
+}
+
+fn resolve_global_target(drawer: &Drawer, request: &PublishAnchorRequest) -> Result<DerivedAnchor> {
+    if drawer.domain != MemoryDomain::Global {
+        bail!("global anchor requires domain=global");
+    }
+    let anchor_id = request
+        .target_anchor_id
+        .as_deref()
+        .context("--target-anchor-id is required for global publication")?;
+    anchor::validate_explicit_anchor(&AnchorKind::Global, anchor_id)?;
+    Ok(DerivedAnchor {
+        anchor_kind: AnchorKind::Global,
+        anchor_id: anchor_id.to_string(),
+        parent_anchor_id: None,
+    })
+}
+
+fn validate_publication_chain(drawer: &Drawer, target: &DerivedAnchor) -> Result<()> {
+    match (&drawer.anchor_kind, &target.anchor_kind) {
+        (AnchorKind::Worktree, AnchorKind::Repo) => Ok(()),
+        (AnchorKind::Repo, AnchorKind::Global) => Ok(()),
+        (AnchorKind::Worktree, AnchorKind::Global) => {
+            bail!("worktree -> global publication is not allowed")
+        }
+        (AnchorKind::Global, _) => bail!("inward publication from global is not allowed"),
+        (AnchorKind::Repo, AnchorKind::Worktree) | (AnchorKind::Worktree, AnchorKind::Worktree) => {
+            bail!("inward publication is not allowed")
+        }
+        (AnchorKind::Repo, AnchorKind::Repo) => bail!("same-anchor publication is not allowed"),
+    }
+}
+
+fn append_audit_entry(db: &Database, command: &str, details: &serde_json::Value) -> Result<()> {
+    let audit_path = db
+        .path()
+        .parent()
+        .map(|parent| parent.join("audit.jsonl"))
+        .unwrap_or_else(|| PathBuf::from("audit.jsonl"));
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&audit_path)
+        .with_context(|| format!("failed to open audit log {}", audit_path.display()))?;
+    let entry = serde_json::json!({
+        "timestamp": current_timestamp(),
+        "command": command,
+        "details": details,
+    });
+    writeln!(file, "{entry}")
+        .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
+    Ok(())
+}
+
+fn anchor_kind_slug(value: &AnchorKind) -> &'static str {
+    match value {
+        AnchorKind::Global => "global",
+        AnchorKind::Repo => "repo",
+        AnchorKind::Worktree => "worktree",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cowork;
 pub mod embed;
 pub mod factcheck;
 pub mod ingest;
+pub mod knowledge_anchor;
 pub mod knowledge_distill;
 pub mod knowledge_gate;
 pub mod knowledge_lifecycle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use mempal::ingest::{
     IngestOptions, IngestStats, ingest_dir_with_options, ingest_file_with_options,
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
+use mempal::knowledge_anchor::{PublishAnchorRequest, publish_anchor};
 use mempal::knowledge_distill::{DistillPlan, DistillRequest, commit_distill, prepare_distill};
 use mempal::knowledge_gate::{GateReport, evaluate_gate_by_id};
 use mempal::knowledge_lifecycle::{
@@ -320,6 +321,19 @@ enum KnowledgeCommands {
         allow_counterexamples: bool,
         #[arg(long, default_value = "plain")]
         format: String,
+    },
+    PublishAnchor {
+        drawer_id: String,
+        #[arg(long)]
+        to: String,
+        #[arg(long = "target-anchor-id")]
+        target_anchor_id: Option<String>,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+        #[arg(long)]
+        reason: String,
+        #[arg(long)]
+        reviewer: Option<String>,
     },
 }
 
@@ -1332,6 +1346,34 @@ async fn knowledge_command(
                 ),
                 other => bail!("unsupported gate format: {other}"),
             }
+        }
+        KnowledgeCommands::PublishAnchor {
+            drawer_id,
+            to,
+            target_anchor_id,
+            cwd,
+            reason,
+            reviewer,
+        } => {
+            let outcome = publish_anchor(
+                db,
+                PublishAnchorRequest {
+                    drawer_id: drawer_id.clone(),
+                    to,
+                    target_anchor_id,
+                    cwd,
+                    reason,
+                    reviewer,
+                },
+            )?;
+            println!(
+                "published {}: {}:{} -> {}:{}",
+                drawer_id,
+                outcome.old_anchor_kind,
+                outcome.old_anchor_id,
+                outcome.new_anchor_kind,
+                outcome.new_anchor_id
+            );
         }
     }
 

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -198,6 +198,53 @@ fn insert_knowledge_with_refs(
         .expect("insert knowledge vector");
 }
 
+struct KnowledgeAnchorArgs<'a> {
+    domain: MemoryDomain,
+    anchor_kind: AnchorKind,
+    anchor_id: &'a str,
+    parent_anchor_id: Option<&'a str>,
+}
+
+fn insert_knowledge_with_anchor(
+    db: &Database,
+    id: &str,
+    status: KnowledgeStatus,
+    anchor: KnowledgeAnchorArgs<'_>,
+) {
+    let drawer = Drawer {
+        id: id.to_string(),
+        content: format!("{id} content"),
+        wing: "mempal".to_string(),
+        room: Some("lifecycle".to_string()),
+        source_file: Some(format!("knowledge://project/lifecycle/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 4,
+        memory_kind: MemoryKind::Knowledge,
+        domain: anchor.domain,
+        field: anchor::DEFAULT_FIELD.to_string(),
+        anchor_kind: anchor.anchor_kind,
+        anchor_id: anchor.anchor_id.to_string(),
+        parent_anchor_id: anchor.parent_anchor_id.map(str::to_string),
+        provenance: None,
+        statement: Some(format!("{id} statement")),
+        tier: Some(KnowledgeTier::Shu),
+        status: Some(status),
+        supporting_refs: vec!["drawer_supporting".to_string()],
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    };
+    db.insert_drawer(&drawer)
+        .expect("insert anchored knowledge");
+    db.insert_vector(id, &vector())
+        .expect("insert anchored knowledge vector");
+}
+
 async fn default_context_ids(db: &Database, cwd: &Path, query: &str) -> Vec<String> {
     let pack = assemble_context(
         db,
@@ -245,8 +292,335 @@ fn audit_line_count(home: &Path) -> usize {
         .unwrap_or(0)
 }
 
+fn last_audit_entry(home: &Path) -> Value {
+    let audit_path = home.join(".mempal").join("audit.jsonl");
+    let content = fs::read_to_string(audit_path).expect("read audit log");
+    serde_json::from_str(content.lines().last().expect("last audit line")).expect("audit json")
+}
+
+fn table_count(db: &Database) -> i64 {
+    db.conn()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("table count")
+}
+
 fn gate_json(output: &Output) -> Value {
     serde_json::from_slice(&output.stdout).expect("gate json")
+}
+
+#[test]
+fn test_cli_knowledge_publish_anchor_worktree_to_repo() {
+    let (home, db) = setup_home();
+    insert_knowledge_with_anchor(
+        &db,
+        "drawer_publish_worktree",
+        KnowledgeStatus::Promoted,
+        KnowledgeAnchorArgs {
+            domain: MemoryDomain::Project,
+            anchor_kind: AnchorKind::Worktree,
+            anchor_id: "worktree:///tmp/publish-worktree",
+            parent_anchor_id: Some("repo://parent"),
+        },
+    );
+    let before = db
+        .get_drawer("drawer_publish_worktree")
+        .expect("load drawer")
+        .expect("drawer exists");
+    let vector_count_before = vector_row_count(&db, "drawer_publish_worktree");
+    let audit_before = audit_line_count(home.path());
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "publish-anchor",
+            "drawer_publish_worktree",
+            "--to",
+            "repo",
+            "--reason",
+            "share stable rule",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(
+            "published drawer_publish_worktree: worktree:worktree:///tmp/publish-worktree -> repo:repo://parent"
+        ),
+        "stdout={stdout}"
+    );
+    let after = db
+        .get_drawer("drawer_publish_worktree")
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(after.anchor_kind, AnchorKind::Repo);
+    assert_eq!(after.anchor_id, "repo://parent");
+    assert_eq!(after.parent_anchor_id, None);
+    assert_eq!(after.content, before.content);
+    assert_eq!(after.statement, before.statement);
+    assert_eq!(after.status, before.status);
+    assert_eq!(after.supporting_refs, before.supporting_refs);
+    assert_eq!(
+        vector_row_count(&db, "drawer_publish_worktree"),
+        vector_count_before
+    );
+    assert_eq!(audit_line_count(home.path()), audit_before + 1);
+    assert_eq!(
+        last_audit_entry(home.path())["command"],
+        "knowledge_publish_anchor"
+    );
+}
+
+#[test]
+fn test_cli_knowledge_publish_anchor_repo_to_global() {
+    let (home, db) = setup_home();
+    insert_knowledge_with_anchor(
+        &db,
+        "drawer_publish_global",
+        KnowledgeStatus::Canonical,
+        KnowledgeAnchorArgs {
+            domain: MemoryDomain::Global,
+            anchor_kind: AnchorKind::Repo,
+            anchor_id: "repo://global-ready",
+            parent_anchor_id: None,
+        },
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "publish-anchor",
+            "drawer_publish_global",
+            "--to",
+            "global",
+            "--target-anchor-id",
+            "global://epistemics",
+            "--reason",
+            "global law",
+            "--reviewer",
+            "human",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let drawer = db
+        .get_drawer("drawer_publish_global")
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.anchor_kind, AnchorKind::Global);
+    assert_eq!(drawer.anchor_id, "global://epistemics");
+    let audit = last_audit_entry(home.path());
+    assert_eq!(audit["command"], "knowledge_publish_anchor");
+    assert_eq!(audit["details"]["reviewer"], "human");
+}
+
+#[test]
+fn test_cli_knowledge_publish_anchor_rejects_worktree_to_global() {
+    let (home, db) = setup_home();
+    insert_knowledge_with_anchor(
+        &db,
+        "drawer_publish_skip",
+        KnowledgeStatus::Promoted,
+        KnowledgeAnchorArgs {
+            domain: MemoryDomain::Global,
+            anchor_kind: AnchorKind::Worktree,
+            anchor_id: "worktree:///tmp/publish-skip",
+            parent_anchor_id: Some("repo://parent"),
+        },
+    );
+    let before = db
+        .get_drawer("drawer_publish_skip")
+        .expect("load drawer")
+        .expect("drawer exists");
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "publish-anchor",
+            "drawer_publish_skip",
+            "--to",
+            "global",
+            "--target-anchor-id",
+            "global://x",
+            "--reason",
+            "skip",
+        ],
+    );
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("worktree -> global publication is not allowed")
+    );
+    let after = db
+        .get_drawer("drawer_publish_skip")
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(after.anchor_kind, before.anchor_kind);
+    assert_eq!(after.anchor_id, before.anchor_id);
+    assert_eq!(after.parent_anchor_id, before.parent_anchor_id);
+}
+
+#[test]
+fn test_cli_knowledge_publish_anchor_rejects_inactive_or_evidence() {
+    let (home, db) = setup_home();
+    insert_evidence(
+        &db,
+        "drawer_publish_evidence",
+        "evidence cannot be published",
+    );
+    insert_knowledge_with_anchor(
+        &db,
+        "drawer_publish_candidate",
+        KnowledgeStatus::Candidate,
+        KnowledgeAnchorArgs {
+            domain: MemoryDomain::Project,
+            anchor_kind: AnchorKind::Worktree,
+            anchor_id: "worktree:///tmp/publish-candidate",
+            parent_anchor_id: Some("repo://parent"),
+        },
+    );
+
+    let evidence_output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "publish-anchor",
+            "drawer_publish_evidence",
+            "--to",
+            "repo",
+            "--reason",
+            "bad",
+        ],
+    );
+    assert!(!evidence_output.status.success());
+    assert!(
+        String::from_utf8_lossy(&evidence_output.stderr)
+            .contains("knowledge anchor publication requires a knowledge drawer")
+    );
+
+    let candidate_output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "publish-anchor",
+            "drawer_publish_candidate",
+            "--to",
+            "repo",
+            "--reason",
+            "bad",
+        ],
+    );
+    assert!(!candidate_output.status.success());
+    assert!(
+        String::from_utf8_lossy(&candidate_output.stderr)
+            .contains("publish-anchor requires promoted or canonical knowledge")
+    );
+}
+
+#[test]
+fn test_cli_knowledge_publish_anchor_rejects_invalid_target_anchor() {
+    let (home, db) = setup_home();
+    insert_knowledge_with_anchor(
+        &db,
+        "drawer_publish_invalid_target",
+        KnowledgeStatus::Promoted,
+        KnowledgeAnchorArgs {
+            domain: MemoryDomain::Global,
+            anchor_kind: AnchorKind::Repo,
+            anchor_id: "repo://invalid-target",
+            parent_anchor_id: None,
+        },
+    );
+
+    let missing_global = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "publish-anchor",
+            "drawer_publish_invalid_target",
+            "--to",
+            "global",
+            "--reason",
+            "missing target",
+        ],
+    );
+    assert!(!missing_global.status.success());
+    assert!(
+        String::from_utf8_lossy(&missing_global.stderr)
+            .contains("--target-anchor-id is required for global publication")
+    );
+
+    let wrong_prefix = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "publish-anchor",
+            "drawer_publish_invalid_target",
+            "--to",
+            "repo",
+            "--target-anchor-id",
+            "global://wrong",
+            "--reason",
+            "bad",
+        ],
+    );
+    assert!(!wrong_prefix.status.success());
+    assert!(String::from_utf8_lossy(&wrong_prefix.stderr).contains("expected prefix repo://"));
+}
+
+#[test]
+fn test_cli_knowledge_publish_anchor_does_not_bump_schema() {
+    let (home, db) = setup_home();
+    insert_knowledge_with_anchor(
+        &db,
+        "drawer_publish_schema",
+        KnowledgeStatus::Promoted,
+        KnowledgeAnchorArgs {
+            domain: MemoryDomain::Project,
+            anchor_kind: AnchorKind::Worktree,
+            anchor_id: "worktree:///tmp/publish-schema",
+            parent_anchor_id: Some("repo://parent"),
+        },
+    );
+    let schema_before = db.schema_version().expect("schema");
+    let table_count_before = table_count(&db);
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge",
+            "publish-anchor",
+            "drawer_publish_schema",
+            "--to",
+            "repo",
+            "--reason",
+            "stable",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(db.schema_version().expect("schema"), schema_before);
+    assert_eq!(table_count(&db), table_count_before);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add  for explicit outward anchor publication
- support worktree -> repo and repo -> global while rejecting worktree -> global/inward/same-anchor publication
- update only anchor metadata and audit log; preserve content, statement, refs, vectors, source_file, and schema
- document P24 in specs, plans, usage, repo instructions, and mind-model design

## Verification

- agent-spec parse specs/p24-anchor-publication.spec.md
- agent-spec lint specs/p24-anchor-publication.spec.md --min-score 0.7
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
