### PR TITLE
P25: expose anchor publication over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P24）
+### 已完成的 Spec（P0-P25）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -71,6 +71,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p22-mcp-knowledge-distill.spec.md` | 完成 | `mempal_knowledge_distill` MCP 工具：从 evidence refs 创建 candidate knowledge drawer |
 | `specs/p23-mcp-knowledge-lifecycle.spec.md` | 完成 | `mempal_knowledge_promote` / `mempal_knowledge_demote` MCP 工具：gate-enforced promotion + evidence-backed demotion |
 | `specs/p24-anchor-publication.spec.md` | 完成 | `mempal knowledge publish-anchor` CLI：显式 outward anchor publication（worktree -> repo -> global） |
+| `specs/p25-mcp-anchor-publication.spec.md` | 完成 | `mempal_knowledge_publish_anchor` MCP 工具：显式 outward anchor publication |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -104,6 +105,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md` — P22 MCP knowledge distill（已完成）
 - `docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md` — P23 MCP knowledge lifecycle（已完成）
 - `docs/plans/2026-04-26-p24-anchor-publication-implementation.md` — P24 anchor publication CLI（已完成）
+- `docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md` — P25 MCP anchor publication（已完成）
 
 ### Spec 使用方式
 
@@ -124,7 +126,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，14 条规则
 
-## MCP 工具（15 个）
+## MCP 工具（16 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -135,6 +137,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
+| `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P24）
+### 已完成的 Spec（P0-P25）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -69,6 +69,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p22-mcp-knowledge-distill.spec.md` | 完成 | `mempal_knowledge_distill` MCP 工具：从 evidence refs 创建 candidate knowledge drawer |
 | `specs/p23-mcp-knowledge-lifecycle.spec.md` | 完成 | `mempal_knowledge_promote` / `mempal_knowledge_demote` MCP 工具：gate-enforced promotion + evidence-backed demotion |
 | `specs/p24-anchor-publication.spec.md` | 完成 | `mempal knowledge publish-anchor` CLI：显式 outward anchor publication（worktree -> repo -> global） |
+| `specs/p25-mcp-anchor-publication.spec.md` | 完成 | `mempal_knowledge_publish_anchor` MCP 工具：显式 outward anchor publication |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -102,6 +103,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-25-p22-mcp-knowledge-distill-implementation.md` — P22 MCP knowledge distill（已完成）
 - `docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md` — P23 MCP knowledge lifecycle（已完成）
 - `docs/plans/2026-04-26-p24-anchor-publication-implementation.md` — P24 anchor publication CLI（已完成）
+- `docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md` — P25 MCP anchor publication（已完成）
 
 ### Spec 使用方式
 
@@ -122,7 +124,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，14 条规则
 
-## MCP 工具（15 个）
+## MCP 工具（16 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -133,6 +135,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
+| `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -827,6 +827,7 @@ Implemented Phase-1 runtime surface:
 - `mempal_knowledge_gate` exposes the same read-only promotion gate to MCP-connected agents, so runtime agents can check readiness without shelling out or mutating lifecycle state
 - `mempal_knowledge_promote` and `mempal_knowledge_demote` expose lifecycle mutation to MCP-connected agents; promotion is gate-enforced after appending supplied verification refs, while demotion requires counterexample evidence
 - `mempal knowledge publish-anchor` implements explicit outward anchor publication for active knowledge (`worktree -> repo -> global`) as a metadata-only operation separate from tier/status promotion
+- `mempal_knowledge_publish_anchor` exposes the same outward anchor publication operation to MCP-connected agents without changing content, vectors, tier, or status
 - lifecycle updates are metadata-only in Stage 1; they do not rewrite content, re-embed vectors, or create Phase-2 knowledge cards
 
 ### Phase 2: Knowledge Card Extraction

--- a/docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md
+++ b/docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md
@@ -1,0 +1,21 @@
+# P25 MCP Anchor Publication Implementation Plan
+
+## Goal
+
+Expose P24 explicit knowledge anchor publication to MCP-connected agents without changing the underlying Stage-1 drawer model.
+
+## Implementation Steps
+
+1. Add MCP DTOs for `mempal_knowledge_publish_anchor`.
+2. Add MCP server handler that reuses `publish_anchor`.
+3. Map publication validation errors to invalid params and write failures to internal errors.
+4. Add MCP integration tests for worktree-to-repo, repo-to-global, invalid chain, invalid targets, and tool registry/protocol coverage.
+5. Update protocol, docs, repo instructions, and mind-model implemented surface.
+
+## Non-Goals
+
+- No REST endpoint.
+- No schema migration.
+- No drawer clone/copy.
+- No vector rewrite or re-embedding.
+- No automatic publication from lifecycle actions.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -238,7 +238,8 @@ mempal knowledge publish-anchor drawer_knowledge \
 
 Supported publication chain is `worktree -> repo -> global`. Publishing to
 `global` requires `domain=global` and an explicit `--target-anchor-id
-global://...`.
+global://...`. P25 exposes the same metadata-only operation to MCP agents as
+`mempal_knowledge_publish_anchor`.
 
 For `dao_tian -> canonical`, provide a reviewer for the advisory gate:
 
@@ -539,7 +540,7 @@ mempal serve --mcp
 
 If `mempal` was built without the `rest` feature, plain `mempal serve` behaves the same way.
 
-The MCP server exposes fifteen tools:
+The MCP server exposes sixteen tools:
 
 - `mempal_status` — state + protocol + AAAK spec
 - `mempal_search` — hybrid search (BM25 + vector + RRF) with tunnel hints and AAAK-derived structured signals (`entities` / `topics` / `flags` / `emotions` / `importance_stars`)
@@ -548,6 +549,7 @@ The MCP server exposes fifteen tools:
 - `mempal_knowledge_gate` — read-only promotion readiness check for knowledge drawers; returns the same deterministic gate report as `mempal knowledge gate --format json`
 - `mempal_knowledge_promote` — gate-enforced lifecycle promotion with supplied verification refs
 - `mempal_knowledge_demote` — demote or retire knowledge with counterexample evidence refs
+- `mempal_knowledge_publish_anchor` — metadata-only outward anchor publication for active knowledge
 - `mempal_ingest` — store memories with optional importance (0-5) and dry_run
 - `mempal_delete` — soft-delete with audit
 - `mempal_taxonomy` — list or edit routing keywords

--- a/specs/p25-mcp-anchor-publication.spec.md
+++ b/specs/p25-mcp-anchor-publication.spec.md
@@ -1,0 +1,113 @@
+spec: task
+name: "P25: MCP knowledge anchor publication"
+inherits: project
+tags: [memory, knowledge, anchor, lifecycle, mcp]
+---
+
+## Intent
+
+P24 added CLI-only explicit anchor publication for active knowledge drawers, but MCP-connected agents still cannot publish stable worktree knowledge outward without shelling out. P25 exposes the same metadata-only operation as an MCP tool while reusing the P24 implementation and preserving the Stage-1 no-schema-change model.
+
+## Decisions
+
+- Add one MCP tool named `mempal_knowledge_publish_anchor`.
+- The MCP tool reuses `publish_anchor`; CLI and MCP publication rules must not drift.
+- Request fields are `drawer_id`, `to`, `reason`, optional `reviewer`, optional `target_anchor_id`, and optional `cwd`.
+- Response fields are `drawer_id`, `old_anchor_kind`, `old_anchor_id`, `old_parent_anchor_id`, `new_anchor_kind`, `new_anchor_id`, and `new_parent_anchor_id`.
+- The tool only accepts active knowledge drawers with status `promoted|canonical`.
+- The tool preserves P24 outward-only publication chain:
+  - `worktree -> repo`
+  - `repo -> global`
+  - reject `worktree -> global`
+  - reject same-anchor and inward publication
+- The tool is metadata-only:
+  - updates `anchor_kind`, `anchor_id`, and `parent_anchor_id`
+  - does not mutate content, statement, tier, status, refs, vectors, FTS content, source_file, triples, tunnels, schema, or Phase-2 objects
+- Successful publication appends the same `knowledge_publish_anchor` audit entry as CLI.
+- Invalid target drawer, inactive status, invalid chain, invalid target anchor, and invalid global-domain attempts return MCP invalid params errors.
+- Database/audit write failures return MCP internal errors.
+- `MEMORY_PROTOCOL`, docs, and repo instructions list the new MCP tool and state that anchor publication is separate from tier/status promotion.
+
+## Boundaries
+
+### Allowed Changes
+
+- `src/knowledge_anchor.rs`
+- `src/mcp/tools.rs`
+- `src/mcp/server.rs`
+- `src/core/protocol.rs`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/usage.md`
+- `docs/MIND-MODEL-DESIGN.md`
+- `specs/p25-mcp-anchor-publication.spec.md`
+- `docs/plans/**`
+
+### Forbidden
+
+- Do not add tables, columns, triggers, or migrations.
+- Do not add REST publication endpoints.
+- Do not change CLI `publish-anchor` behavior.
+- Do not duplicate or clone drawers.
+- Do not update vectors or re-embed content.
+- Do not auto-publish from promote, distill, or gate.
+- Do not introduce new dependencies.
+
+## Acceptance Criteria
+
+Scenario: MCP publishes worktree knowledge to repo anchor
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_publish_anchor_worktree_to_repo
+  Given a promoted knowledge drawer has `anchor_kind="worktree"` and `parent_anchor_id="repo://parent"`
+  When an MCP client calls `mempal_knowledge_publish_anchor` with `to="repo"` and a reason
+  Then the response reports old anchor `worktree` and new anchor `repo://parent`
+  And the stored drawer has `anchor_kind="repo"`, `anchor_id="repo://parent"`, and `parent_anchor_id=NULL`
+  And content, statement, status, refs, schema, and vector row remain unchanged
+  And one `knowledge_publish_anchor` audit entry is appended
+
+Scenario: MCP publishes repo knowledge to explicit global anchor
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_publish_anchor_repo_to_global
+  Given a canonical knowledge drawer has `domain="global"` and `anchor_kind="repo"`
+  When an MCP client calls `mempal_knowledge_publish_anchor` with `to="global"` and `target_anchor_id="global://epistemics"`
+  Then the response reports `new_anchor_kind="global"` and `new_anchor_id="global://epistemics"`
+  And the audit entry includes the supplied reviewer
+
+Scenario: MCP rejects invalid publication without mutation
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_publish_anchor_rejects_invalid_chain_without_mutation
+  Given a promoted knowledge drawer has `anchor_kind="worktree"`
+  When an MCP client calls `mempal_knowledge_publish_anchor` with `to="global"` and `target_anchor_id="global://x"`
+  Then the call fails with invalid params
+  And the error mentions `worktree -> global publication is not allowed`
+  And drawer anchor, schema, vector row, and audit log remain unchanged
+
+Scenario: MCP rejects inactive or evidence targets
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_publish_anchor_rejects_inactive_or_evidence
+  Given one evidence drawer id and one candidate knowledge drawer id
+  When an MCP client calls `mempal_knowledge_publish_anchor` for the evidence drawer
+  Then the call fails with invalid params and mentions `knowledge drawer`
+  When an MCP client calls `mempal_knowledge_publish_anchor` for the candidate drawer
+  Then the call fails with invalid params and mentions `promoted or canonical`
+
+Scenario: MCP tool registry and protocol include anchor publication
+  Test:
+    Package: mempal
+    Filter: test_mcp_tool_registry_and_protocol_include_knowledge_publish_anchor
+  Given the MCP tool registry and `MEMORY_PROTOCOL`
+  When they are inspected
+  Then the registry contains `mempal_knowledge_publish_anchor`
+  And the description mentions outward anchor publication
+  And `MEMORY_PROTOCOL` says anchor publication is separate from tier/status promotion
+
+## Out of Scope
+
+- REST publication endpoint.
+- Automatic publication.
+- LLM or evaluator scoring.
+- Phase-2 knowledge cards.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -179,6 +179,13 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    when counterexample evidence shows promoted knowledge is contradicted,
    obsolete, superseded, out of scope, or unsafe.
 
+15. PUBLISH KNOWLEDGE OUTWARD ACROSS ANCHORS
+   Anchor publication is separate from tier/status promotion. Use
+   mempal_knowledge_publish_anchor only for active knowledge that should move
+   outward in persistence scope: worktree -> repo or repo -> global. The tool
+   updates only anchor metadata and audit history; it does not rewrite content,
+   re-embed vectors, or change knowledge tier/status.
+
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
@@ -187,6 +194,7 @@ TOOLS:
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
+  mempal_knowledge_publish_anchor — metadata-only outward anchor publication
   mempal_ingest        — save a new drawer (wing required, room optional, importance 0-5)
   mempal_delete        — soft-delete a drawer by ID
   mempal_taxonomy      — list or edit routing keywords
@@ -384,6 +392,22 @@ mod tests {
         assert!(
             MEMORY_PROTOCOL.contains("MCP promotion is gate-enforced"),
             "MEMORY_PROTOCOL must state MCP promotion is gate-enforced"
+        );
+    }
+
+    #[test]
+    fn contains_knowledge_anchor_publication_guidance() {
+        assert!(
+            MEMORY_PROTOCOL.contains("15. PUBLISH KNOWLEDGE OUTWARD ACROSS ANCHORS"),
+            "MEMORY_PROTOCOL must include Rule 15 anchor publication guidance"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("mempal_knowledge_publish_anchor"),
+            "MEMORY_PROTOCOL must mention MCP anchor publication tool"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("Anchor publication is separate from tier/status promotion"),
+            "MEMORY_PROTOCOL must keep anchor publication separate from tier/status promotion"
         );
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -24,6 +24,7 @@ use crate::ingest::{
     },
     normalize::CURRENT_NORMALIZE_VERSION,
 };
+use crate::knowledge_anchor::{PublishAnchorRequest as CorePublishAnchorRequest, publish_anchor};
 use crate::knowledge_distill::{
     DistillPlan, DistillRequest as CoreDistillRequest, commit_distill, prepare_distill,
 };
@@ -48,10 +49,10 @@ use super::tools::{
     IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeDemoteRequest,
     KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
     KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePromoteRequest, KnowledgePromoteResponse,
-    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest,
-    SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest,
-    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
-    TunnelsResponse,
+    KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse, PeekMessageDto,
+    PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest, SearchResponse,
+    SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse,
+    TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -168,6 +169,17 @@ impl MempalMcpServer {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         self.mempal_knowledge_demote(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn knowledge_publish_anchor_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<KnowledgePublishAnchorResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_knowledge_publish_anchor(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -838,6 +850,31 @@ impl MempalMcpServer {
         .map_err(knowledge_lifecycle_error)?;
 
         Ok(Json(KnowledgeDemoteResponse::from(outcome)))
+    }
+
+    #[tool(
+        name = "mempal_knowledge_publish_anchor",
+        description = "Publish active knowledge outward across anchor scope. Metadata-only operation for worktree -> repo or repo -> global publication; updates anchor fields and audit log without touching content, vectors, schema, or tier/status lifecycle."
+    )]
+    async fn mempal_knowledge_publish_anchor(
+        &self,
+        Parameters(request): Parameters<KnowledgePublishAnchorRequest>,
+    ) -> std::result::Result<Json<KnowledgePublishAnchorResponse>, ErrorData> {
+        let db = self.open_db()?;
+        let outcome = publish_anchor(
+            &db,
+            CorePublishAnchorRequest {
+                drawer_id: request.drawer_id,
+                to: request.to,
+                target_anchor_id: request.target_anchor_id,
+                cwd: request.cwd.map(PathBuf::from),
+                reason: request.reason,
+                reviewer: request.reviewer,
+            },
+        )
+        .map_err(knowledge_anchor_error)?;
+
+        Ok(Json(KnowledgePublishAnchorResponse::from(outcome)))
     }
 
     #[tool(
@@ -1566,6 +1603,18 @@ fn knowledge_lifecycle_error(error: anyhow::Error) -> ErrorData {
     ErrorData::invalid_params(message, None)
 }
 
+fn knowledge_anchor_error(error: anyhow::Error) -> ErrorData {
+    let message = error.to_string();
+    if message.contains("failed to update")
+        || message.contains("failed to append audit")
+        || message.contains("failed to open audit")
+        || message.contains("failed to write audit")
+    {
+        return ErrorData::internal_error(message, None);
+    }
+    ErrorData::invalid_params(message, None)
+}
+
 fn context_error(error: crate::context::ContextError) -> ErrorData {
     match error {
         crate::context::ContextError::DeriveAnchor(_) => {
@@ -1709,6 +1758,13 @@ mod tests {
         verification: Vec<String>,
     }
 
+    struct KnowledgeAnchorArgs<'a> {
+        domain: MemoryDomain,
+        anchor_kind: AnchorKind,
+        anchor_id: &'a str,
+        parent_anchor_id: Option<&'a str>,
+    }
+
     #[async_trait]
     impl crate::embed::EmbedderFactory for StubEmbedderFactory {
         async fn build(&self) -> crate::embed::Result<Box<dyn Embedder>> {
@@ -1836,6 +1892,47 @@ mod tests {
             .expect("insert vector");
     }
 
+    fn insert_knowledge_drawer_with_anchor(
+        db_path: &Path,
+        id: &str,
+        status: KnowledgeStatus,
+        anchor_args: KnowledgeAnchorArgs<'_>,
+    ) {
+        let db = Database::open(db_path).expect("open db");
+        let drawer = Drawer {
+            id: id.to_string(),
+            content: format!("{id} content"),
+            wing: "mempal".to_string(),
+            room: Some("context".to_string()),
+            source_file: Some(format!("knowledge://project/context/{id}")),
+            source_type: SourceType::Manual,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            normalize_version: 1,
+            importance: 3,
+            memory_kind: MemoryKind::Knowledge,
+            domain: anchor_args.domain,
+            field: anchor::DEFAULT_FIELD.to_string(),
+            anchor_kind: anchor_args.anchor_kind,
+            anchor_id: anchor_args.anchor_id.to_string(),
+            parent_anchor_id: anchor_args.parent_anchor_id.map(str::to_string),
+            provenance: None,
+            statement: Some(format!("{id} statement")),
+            tier: Some(KnowledgeTier::Shu),
+            status: Some(status),
+            supporting_refs: vec!["drawer_supporting_ev".to_string()],
+            counterexample_refs: Vec::new(),
+            teaching_refs: Vec::new(),
+            verification_refs: Vec::new(),
+            scope_constraints: None,
+            trigger_hints: None,
+        };
+        db.insert_drawer(&drawer)
+            .expect("insert anchored knowledge drawer");
+        db.insert_vector(id, &[0.1, 0.2, 0.3])
+            .expect("insert anchored knowledge vector");
+    }
+
     fn audit_line_count(db_path: &Path) -> usize {
         let audit_path = db_path
             .parent()
@@ -1844,6 +1941,15 @@ mod tests {
         fs::read_to_string(audit_path)
             .map(|content| content.lines().count())
             .unwrap_or(0)
+    }
+
+    fn last_audit_entry(db_path: &Path) -> serde_json::Value {
+        let audit_path = db_path
+            .parent()
+            .expect("db path has parent")
+            .join("audit.jsonl");
+        let content = fs::read_to_string(audit_path).expect("read audit log");
+        serde_json::from_str(content.lines().last().expect("last audit line")).expect("audit json")
     }
 
     fn vector_row_count(db: &Database, id: &str) -> i64 {
@@ -3154,6 +3260,236 @@ mod tests {
         );
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_promote"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("MCP promotion is gate-enforced"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_publish_anchor_worktree_to_repo() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer_with_anchor(
+            &db_path,
+            "drawer_publish_worktree",
+            KnowledgeStatus::Promoted,
+            KnowledgeAnchorArgs {
+                domain: MemoryDomain::Project,
+                anchor_kind: AnchorKind::Worktree,
+                anchor_id: "worktree:///tmp/mcp-publish-worktree",
+                parent_anchor_id: Some("repo://parent"),
+            },
+        );
+        let db = Database::open(&db_path).expect("open db");
+        let before = db
+            .get_drawer("drawer_publish_worktree")
+            .expect("load drawer")
+            .expect("drawer exists");
+        let schema_before = db.schema_version().expect("schema");
+        let vector_count_before = vector_row_count(&db, "drawer_publish_worktree");
+        let audit_before = audit_line_count(&db_path);
+
+        let response = server
+            .knowledge_publish_anchor_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_publish_worktree",
+                "to": "repo",
+                "reason": "share stable MCP rule"
+            }))
+            .await
+            .expect("publish should pass");
+
+        assert_eq!(response.old_anchor_kind, "worktree");
+        assert_eq!(
+            response.old_anchor_id,
+            "worktree:///tmp/mcp-publish-worktree"
+        );
+        assert_eq!(response.new_anchor_kind, "repo");
+        assert_eq!(response.new_anchor_id, "repo://parent");
+        assert_eq!(response.new_parent_anchor_id, None);
+        let after = db
+            .get_drawer("drawer_publish_worktree")
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(after.anchor_kind, AnchorKind::Repo);
+        assert_eq!(after.anchor_id, "repo://parent");
+        assert_eq!(after.parent_anchor_id, None);
+        assert_eq!(after.content, before.content);
+        assert_eq!(after.statement, before.statement);
+        assert_eq!(after.status, before.status);
+        assert_eq!(after.supporting_refs, before.supporting_refs);
+        assert_eq!(db.schema_version().expect("schema"), schema_before);
+        assert_eq!(
+            vector_row_count(&db, "drawer_publish_worktree"),
+            vector_count_before
+        );
+        assert_eq!(audit_line_count(&db_path), audit_before + 1);
+        assert_eq!(
+            last_audit_entry(&db_path)["command"],
+            "knowledge_publish_anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_publish_anchor_repo_to_global() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer_with_anchor(
+            &db_path,
+            "drawer_publish_global",
+            KnowledgeStatus::Canonical,
+            KnowledgeAnchorArgs {
+                domain: MemoryDomain::Global,
+                anchor_kind: AnchorKind::Repo,
+                anchor_id: "repo://global-ready",
+                parent_anchor_id: None,
+            },
+        );
+
+        let response = server
+            .knowledge_publish_anchor_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_publish_global",
+                "to": "global",
+                "target_anchor_id": "global://epistemics",
+                "reason": "global law",
+                "reviewer": "human"
+            }))
+            .await
+            .expect("publish should pass");
+
+        assert_eq!(response.new_anchor_kind, "global");
+        assert_eq!(response.new_anchor_id, "global://epistemics");
+        let db = Database::open(&db_path).expect("open db");
+        let drawer = db
+            .get_drawer("drawer_publish_global")
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(drawer.anchor_kind, AnchorKind::Global);
+        assert_eq!(drawer.anchor_id, "global://epistemics");
+        assert_eq!(last_audit_entry(&db_path)["details"]["reviewer"], "human");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_publish_anchor_rejects_invalid_chain_without_mutation() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer_with_anchor(
+            &db_path,
+            "drawer_publish_invalid_chain",
+            KnowledgeStatus::Promoted,
+            KnowledgeAnchorArgs {
+                domain: MemoryDomain::Global,
+                anchor_kind: AnchorKind::Worktree,
+                anchor_id: "worktree:///tmp/mcp-publish-invalid",
+                parent_anchor_id: Some("repo://parent"),
+            },
+        );
+        let db = Database::open(&db_path).expect("open db");
+        let before = db
+            .get_drawer("drawer_publish_invalid_chain")
+            .expect("load drawer")
+            .expect("drawer exists");
+        let schema_before = db.schema_version().expect("schema");
+        let vector_count_before = vector_row_count(&db, "drawer_publish_invalid_chain");
+        let audit_before = audit_line_count(&db_path);
+
+        let error = server
+            .knowledge_publish_anchor_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_publish_invalid_chain",
+                "to": "global",
+                "target_anchor_id": "global://x",
+                "reason": "skip chain"
+            }))
+            .await
+            .expect_err("invalid chain should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("worktree -> global publication is not allowed"),
+            "error={error}"
+        );
+        let after = db
+            .get_drawer("drawer_publish_invalid_chain")
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(after.anchor_kind, before.anchor_kind);
+        assert_eq!(after.anchor_id, before.anchor_id);
+        assert_eq!(after.parent_anchor_id, before.parent_anchor_id);
+        assert_eq!(db.schema_version().expect("schema"), schema_before);
+        assert_eq!(
+            vector_row_count(&db, "drawer_publish_invalid_chain"),
+            vector_count_before
+        );
+        assert_eq!(audit_line_count(&db_path), audit_before);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_publish_anchor_rejects_inactive_or_evidence() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_publish_evidence",
+            "evidence",
+            "mempal",
+            Some("publish"),
+            "/tmp/publish-evidence.md",
+            2,
+        );
+        insert_knowledge_drawer_with_anchor(
+            &db_path,
+            "drawer_publish_candidate",
+            KnowledgeStatus::Candidate,
+            KnowledgeAnchorArgs {
+                domain: MemoryDomain::Project,
+                anchor_kind: AnchorKind::Worktree,
+                anchor_id: "worktree:///tmp/mcp-publish-candidate",
+                parent_anchor_id: Some("repo://parent"),
+            },
+        );
+
+        let evidence_error = server
+            .knowledge_publish_anchor_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_publish_evidence",
+                "to": "repo",
+                "reason": "bad"
+            }))
+            .await
+            .expect_err("evidence should be rejected");
+        assert!(
+            evidence_error.to_string().contains("knowledge drawer"),
+            "error={evidence_error}"
+        );
+
+        let candidate_error = server
+            .knowledge_publish_anchor_json_for_test(serde_json::json!({
+                "drawer_id": "drawer_publish_candidate",
+                "to": "repo",
+                "reason": "bad"
+            }))
+            .await
+            .expect_err("candidate should be rejected");
+        assert!(
+            candidate_error
+                .to_string()
+                .contains("promoted or canonical"),
+            "error={candidate_error}"
+        );
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_knowledge_publish_anchor() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let publish_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_knowledge_publish_anchor")
+            .expect("mempal_knowledge_publish_anchor tool exists");
+        assert!(
+            publish_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("outward across anchor scope")
+        );
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_publish_anchor"));
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL
+                .contains("Anchor publication is separate from tier/status promotion")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3,6 +3,7 @@ use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
     NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry, TunnelEndpoint,
 };
+use crate::knowledge_anchor::PublishAnchorOutcome;
 use crate::knowledge_distill::DistillOutcome;
 use crate::knowledge_gate::GateReport;
 use crate::knowledge_lifecycle::{DemoteOutcome, PromoteOutcome};
@@ -176,6 +177,41 @@ impl From<DemoteOutcome> for KnowledgeDemoteResponse {
             old_status: outcome.old_status,
             new_status: outcome.new_status,
             counterexample_refs: outcome.counterexample_refs,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct KnowledgePublishAnchorRequest {
+    pub drawer_id: String,
+    pub to: String,
+    pub target_anchor_id: Option<String>,
+    pub cwd: Option<String>,
+    pub reason: String,
+    pub reviewer: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgePublishAnchorResponse {
+    pub drawer_id: String,
+    pub old_anchor_kind: String,
+    pub old_anchor_id: String,
+    pub old_parent_anchor_id: Option<String>,
+    pub new_anchor_kind: String,
+    pub new_anchor_id: String,
+    pub new_parent_anchor_id: Option<String>,
+}
+
+impl From<PublishAnchorOutcome> for KnowledgePublishAnchorResponse {
+    fn from(outcome: PublishAnchorOutcome) -> Self {
+        Self {
+            drawer_id: outcome.drawer_id,
+            old_anchor_kind: outcome.old_anchor_kind,
+            old_anchor_id: outcome.old_anchor_id,
+            old_parent_anchor_id: outcome.old_parent_anchor_id,
+            new_anchor_kind: outcome.new_anchor_kind,
+            new_anchor_id: outcome.new_anchor_id,
+            new_parent_anchor_id: outcome.new_parent_anchor_id,
         }
     }
 }


### PR DESCRIPTION
## Summary

- add mempal_knowledge_publish_anchor MCP tool
- reuse P24 publish_anchor implementation for CLI/MCP parity
- return old/new anchor metadata and preserve metadata-only publication guarantees
- update MEMORY_PROTOCOL, usage docs, repo instructions, and mind-model design

## Verification

- agent-spec parse specs/p25-mcp-anchor-publication.spec.md
- agent-spec lint specs/p25-mcp-anchor-publication.spec.md --min-score 0.7
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
