### PR TITLE
feat: add dao tian context budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P25）
+### 已完成的 Spec（P0-P26）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -72,6 +72,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p23-mcp-knowledge-lifecycle.spec.md` | 完成 | `mempal_knowledge_promote` / `mempal_knowledge_demote` MCP 工具：gate-enforced promotion + evidence-backed demotion |
 | `specs/p24-anchor-publication.spec.md` | 完成 | `mempal knowledge publish-anchor` CLI：显式 outward anchor publication（worktree -> repo -> global） |
 | `specs/p25-mcp-anchor-publication.spec.md` | 完成 | `mempal_knowledge_publish_anchor` MCP 工具：显式 outward anchor publication |
+| `specs/p26-dao-tian-runtime-budget.spec.md` | 完成 | `mempal context` / `mempal_context` 默认最多注入 1 条 `dao_tian`，支持显式禁用或提高预算 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -106,6 +107,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md` — P23 MCP knowledge lifecycle（已完成）
 - `docs/plans/2026-04-26-p24-anchor-publication-implementation.md` — P24 anchor publication CLI（已完成）
 - `docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md` — P25 MCP anchor publication（已完成）
+- `docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md` — P26 dao_tian runtime budget（已完成）
 
 ### Spec 使用方式
 
@@ -124,7 +126,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，14 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
 
 ## MCP 工具（16 个）
 
@@ -132,7 +134,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
-| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16） |
+| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P25）
+### 已完成的 Spec（P0-P26）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -70,6 +70,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p23-mcp-knowledge-lifecycle.spec.md` | 完成 | `mempal_knowledge_promote` / `mempal_knowledge_demote` MCP 工具：gate-enforced promotion + evidence-backed demotion |
 | `specs/p24-anchor-publication.spec.md` | 完成 | `mempal knowledge publish-anchor` CLI：显式 outward anchor publication（worktree -> repo -> global） |
 | `specs/p25-mcp-anchor-publication.spec.md` | 完成 | `mempal_knowledge_publish_anchor` MCP 工具：显式 outward anchor publication |
+| `specs/p26-dao-tian-runtime-budget.spec.md` | 完成 | `mempal context` / `mempal_context` 默认最多注入 1 条 `dao_tian`，支持显式禁用或提高预算 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -104,6 +105,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p23-mcp-knowledge-lifecycle-implementation.md` — P23 MCP knowledge lifecycle（已完成）
 - `docs/plans/2026-04-26-p24-anchor-publication-implementation.md` — P24 anchor publication CLI（已完成）
 - `docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md` — P25 MCP anchor publication（已完成）
+- `docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md` — P26 dao_tian runtime budget（已完成）
 
 ### Spec 使用方式
 
@@ -122,7 +124,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，14 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
 
 ## MCP 工具（16 个）
 
@@ -130,7 +132,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
-| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16） |
+| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -813,6 +813,9 @@ Implemented Phase-1 runtime surface:
 - `mempal context <query>` assembles a runtime context pack from typed drawers
 - `mempal_context` exposes the same pack to MCP-connected agents
 - knowledge sections are ordered as `dao_tian -> dao_ren -> shu -> qi`
+- `dao_tian` is sparse by default in runtime context: `mempal context` and
+  `mempal_context` inject at most 1 `dao_tian` item unless the caller explicitly
+  sets `--dao-tian-limit` / `dao_tian_limit`; `0` disables `dao_tian`
 - evidence remains opt-in via `--include-evidence`
 - same-tier items prefer `worktree`, then current `repo`, then `repo://legacy`, then `global`
 - `global` anchor candidates use `domain=global`, preserving the invariant that global anchors do not hold project-local domain memory
@@ -897,12 +900,11 @@ This design does not assume:
 
 The following remain open and should be resolved in later design work:
 
-1. How many `dao_tian` items should be allowed in default runtime context?
-2. What exact promotion thresholds should be used for `dao_ren` and `dao_tian`?
-3. Should `dao_tian` always require human review, or can a high-grade evaluator canonize it?
-4. How should `field` taxonomy be managed?
-5. How should wake-up assembly decide when to inject `dao_tian` versus only `dao_ren`?
-6. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
+1. What exact promotion thresholds should be used for `dao_ren` and `dao_tian`?
+2. Should `dao_tian` always require human review, or can a high-grade evaluator canonize it?
+3. How should `field` taxonomy be managed?
+4. Should `wake-up` eventually consume typed `dao_tian` / `dao_ren`, or should that remain exclusive to `mempal context`?
+5. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
 
 ## Current Recommendation
 

--- a/docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md
+++ b/docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md
@@ -1,0 +1,27 @@
+# P26 Dao Tian Runtime Budget Implementation Plan
+
+**Goal:** Add a conservative runtime budget for `dao_tian` context injection so universal principles remain sparse by default while still allowing explicit caller override.
+
+**Architecture:** Keep `src/context.rs` as the single source of assembly behavior. Add `dao_tian_limit` to the core request, expose it through CLI and MCP, and document the default policy in protocol and design docs. No schema, ranking, lifecycle, or wake-up changes.
+
+## Steps
+
+- [x] Validate task contract with `agent-spec parse/lint`.
+- [x] Add `dao_tian_limit` to `ContextRequest` and enforce it only for the `dao_tian` tier.
+- [x] Add CLI flag `--dao-tian-limit`, defaulting to 1.
+- [x] Add MCP request field `dao_tian_limit`, defaulting to 1.
+- [x] Add core, CLI, and MCP tests for default cap, disable, raised limit, and global `max_items` cap.
+- [x] Update protocol, usage docs, mind-model design status, and repo instructions.
+- [x] Run formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p26-dao-tian-runtime-budget.spec.md
+agent-spec lint specs/p26-dao-tian-runtime-budget.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,7 +95,7 @@ Use this when you already know the concepts and just need the right command quic
 | `mempal init <DIR> [--dry-run]` | infer a `wing` and seed initial taxonomy rooms from a project tree |
 | `mempal ingest --wing <WING> <DIR> [--dry-run]` | chunk, embed, and store a project tree |
 | `mempal search <QUERY> [--wing W] [--room R] [--json]` | hybrid search (BM25 + vector + RRF) with tunnel hints |
-| `mempal context <QUERY> [--format json] [--include-evidence]` | assemble mind-model runtime context (`dao_tian -> dao_ren -> shu -> qi`) |
+| `mempal context <QUERY> [--format json] [--include-evidence] [--dao-tian-limit N]` | assemble mind-model runtime context (`dao_tian -> dao_ren -> shu -> qi`); default `dao_tian` budget is 1 |
 | `mempal knowledge distill --statement ... --content ... --tier dao_ren --supporting-ref <ID>` | create candidate knowledge from evidence refs |
 | `mempal knowledge gate <ID> [--format json]` | evaluate whether knowledge satisfies promotion gate policy without mutating it |
 | `mempal knowledge promote <ID> --status promoted --verification-ref <ID> --reason ...` | promote bootstrap knowledge into active runtime use |
@@ -544,7 +544,7 @@ The MCP server exposes sixteen tools:
 
 - `mempal_status` — state + protocol + AAAK spec
 - `mempal_search` — hybrid search (BM25 + vector + RRF) with tunnel hints and AAAK-derived structured signals (`entities` / `topics` / `flags` / `emotions` / `importance_stars`)
-- `mempal_context` — mind-model runtime context pack (`dao_tian -> dao_ren -> shu -> qi`, evidence opt-in); guides workflow / skill / tool choice but never executes skills
+- `mempal_context` — mind-model runtime context pack (`dao_tian -> dao_ren -> shu -> qi`, evidence opt-in, `dao_tian_limit` default 1); guides workflow / skill / tool choice but never executes skills
 - `mempal_knowledge_distill` — create candidate `dao_ren` / `qi` knowledge from existing evidence refs; deterministic and never auto-promotes
 - `mempal_knowledge_gate` — read-only promotion readiness check for knowledge drawers; returns the same deterministic gate report as `mempal knowledge gate --format json`
 - `mempal_knowledge_promote` — gate-enforced lifecycle promotion with supplied verification refs

--- a/specs/p26-dao-tian-runtime-budget.spec.md
+++ b/specs/p26-dao-tian-runtime-budget.spec.md
@@ -1,0 +1,97 @@
+spec: task
+name: "P26: dao_tian runtime context budget"
+inherits: project
+tags: [memory, context, mind-model, runtime, mcp]
+---
+
+## Intent
+
+`dao_tian` 是跨领域高层原则，数量应该极少，且不应在每次 runtime context
+assembly 中压过领域规则和可执行方法。P14/P15 已经实现
+`dao_tian -> dao_ren -> shu -> qi` 的固定排序，但还没有单独限制
+`dao_tian` 的默认注入数量。
+
+本任务给 `mempal context` 和 `mempal_context` 增加保守的 `dao_tian`
+运行时预算：默认最多 1 条，可由调用方显式禁用或提高；总输出仍受
+`max_items` 控制。
+
+## Decisions
+
+- `mempal context` 新增 `--dao-tian-limit <N>`。
+- `mempal_context` 新增可选参数 `dao_tian_limit`。
+- 默认 `dao_tian_limit=1`。
+- `dao_tian_limit=0` 表示不输出 `dao_tian` section。
+- `dao_tian_limit=N` 表示 `dao_tian` section 最多输出 N 条 active knowledge items。
+- `max_items` 仍是全局总预算；`dao_tian_limit` 不能让总条目数超过 `max_items`。
+- 非 `dao_tian` tiers 继续共享剩余 `max_items` 预算，不新增单独 tier limit。
+- Section order 仍为 `dao_tian -> dao_ren -> shu -> qi -> evidence`。
+- 如果 `dao_tian_limit=0` 或没有匹配项，则不输出空的 `dao_tian` section。
+- `dao_tian_limit=0` 是合法值；`max_items=0` 仍必须拒绝。
+
+## Acceptance Criteria
+
+Scenario: default context caps dao_tian to one item
+  Test:
+    Package: mempal
+    Filter: test_context_default_caps_dao_tian_to_one
+  Given 数据库中存在两条 active `dao_tian` knowledge drawers 和一条 active `dao_ren`
+  When 调用 core context assembler 且使用默认 `dao_tian_limit`
+  Then `dao_tian` section 最多包含 1 条 item
+  And `dao_ren` 仍可使用剩余总预算进入 context
+
+Scenario: CLI can disable dao_tian injection
+  Test:
+    Package: mempal
+    Filter: test_cli_context_dao_tian_limit_zero_omits_section
+  Given 数据库中存在 active `dao_tian` 和 active `dao_ren`
+  When 执行 `mempal context "debug" --dao-tian-limit 0 --format json`
+  Then JSON response 不包含 `dao_tian` section
+  And response 仍可包含 `dao_ren` section
+
+Scenario: CLI can raise dao_tian budget
+  Test:
+    Package: mempal
+    Filter: test_cli_context_dao_tian_limit_two_allows_two_items
+  Given 数据库中存在两条 active `dao_tian`
+  When 执行 `mempal context "debug" --dao-tian-limit 2 --format json`
+  Then `dao_tian` section 包含 2 条 item
+
+Scenario: MCP can disable dao_tian injection
+  Test:
+    Package: mempal
+    Filter: test_mcp_context_dao_tian_limit_zero_omits_section
+  Given 数据库中存在 active `dao_tian` 和 active `shu`
+  When MCP 客户端调用 `mempal_context(query="debug", dao_tian_limit=0)`
+  Then response 不包含 `dao_tian` section
+  And response 仍可包含 `shu` section
+
+Scenario: max_items remains the global cap
+  Test:
+    Package: mempal
+    Filter: test_context_max_items_still_caps_raised_dao_tian_limit
+  Given 数据库中存在多条 active `dao_tian`
+  When 调用 context assembler，设置 `max_items=1` 且 `dao_tian_limit=2`
+  Then 总输出 item 数最多为 1
+
+Scenario: max_items zero remains invalid
+  Test:
+    Package: mempal
+    Filter: test_context_rejects_invalid_max_items
+  Given 任意数据库状态
+  When 执行 `mempal context "debug" --max-items 0`
+  Then command fails with a `max-items` validation error
+
+## Out of Scope
+
+- Do not change database schema.
+- Do not change search ranking, vector embeddings, or RRF behavior.
+- Do not add per-tier budgets for `dao_ren`, `shu`, or `qi`.
+- Do not implement automatic `dao_tian` relevance evaluation.
+- Do not make wake-up use `dao_tian`; this task only affects `mempal context` and `mempal_context`.
+- Do not execute skills or tools based on `dao_tian`.
+
+## Constraints
+
+- Keep `src/context.rs` as the source of truth for budget enforcement.
+- Keep CLI and MCP defaults aligned.
+- Update protocol and docs so agents know `dao_tian` is sparse by default.

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,6 +42,7 @@ pub struct ContextRequest {
     pub cwd: PathBuf,
     pub include_evidence: bool,
     pub max_items: usize,
+    pub dao_tian_limit: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -138,13 +139,21 @@ pub fn assemble_context_with_vector(
         if remaining == 0 {
             break;
         }
+        let mut tier_remaining = if matches!(tier, KnowledgeTier::DaoTian) {
+            request.dao_tian_limit.min(remaining)
+        } else {
+            remaining
+        };
+        if tier_remaining == 0 {
+            continue;
+        }
         let mut items = Vec::new();
         for anchor in &anchors {
-            if remaining == 0 {
+            if remaining == 0 || tier_remaining == 0 {
                 break;
             }
             for status in active_statuses() {
-                if remaining == 0 {
+                if remaining == 0 || tier_remaining == 0 {
                     break;
                 }
                 let mut results = search_context_candidates(
@@ -157,12 +166,12 @@ pub fn assemble_context_with_vector(
                         memory_kind: MemoryKind::Knowledge,
                         tier: Some(tier.clone()),
                         status: Some(status.clone()),
-                        top_k: remaining,
+                        top_k: tier_remaining,
                     },
                 )?;
                 results.retain(|result| result.anchor_id == anchor.anchor_id);
                 for result in results {
-                    if remaining == 0 {
+                    if remaining == 0 || tier_remaining == 0 {
                         break;
                     }
                     if !seen.insert(result.drawer_id.clone()) {
@@ -170,6 +179,7 @@ pub fn assemble_context_with_vector(
                     }
                     items.push(context_item_from_result(db, result)?);
                     remaining -= 1;
+                    tier_remaining -= 1;
                 }
             }
         }

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -47,6 +47,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    before choosing a workflow or skill when the user asks "how should we
    approach this?" or when a task benefits from high-level principles plus
    concrete tool bindings.
+   dao_tian is intentionally sparse in runtime context: by default at most one
+   dao_tian item is injected. Set dao_tian_limit=0 when universal principles
+   are not needed, or raise it only when explicitly reasoning about
+   cross-domain fundamentals. max_items remains the total output budget.
 
    Skill-selection discipline:
    - Read dao_tian first for cross-domain principles.
@@ -344,6 +348,20 @@ mod tests {
             MEMORY_PROTOCOL.contains("Use\n   mempal_search to verify project facts"),
             "MEMORY_PROTOCOL must keep fact verification and citations on mempal_search"
         );
+    }
+
+    #[test]
+    fn contains_dao_tian_runtime_budget_guidance() {
+        for phrase in [
+            "by default at most one\n   dao_tian item",
+            "Set dao_tian_limit=0",
+            "max_items remains the total output budget",
+        ] {
+            assert!(
+                MEMORY_PROTOCOL.contains(phrase),
+                "MEMORY_PROTOCOL must include dao_tian budget phrase: {phrase}"
+            );
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,8 @@ enum Commands {
         include_evidence: bool,
         #[arg(long, default_value_t = 12)]
         max_items: usize,
+        #[arg(long = "dao-tian-limit", default_value_t = 1)]
+        dao_tian_limit: usize,
     },
     WakeUp {
         #[arg(long)]
@@ -493,6 +495,7 @@ async fn run() -> Result<()> {
             format,
             include_evidence,
             max_items,
+            dao_tian_limit,
         } => {
             context_command(
                 &db,
@@ -505,6 +508,7 @@ async fn run() -> Result<()> {
                     format,
                     include_evidence,
                     max_items,
+                    dao_tian_limit,
                 },
             )
             .await
@@ -556,6 +560,7 @@ struct ContextCommandArgs {
     format: String,
     include_evidence: bool,
     max_items: usize,
+    dao_tian_limit: usize,
 }
 
 async fn bench_command(config: &Config, command: BenchCommands) -> Result<()> {
@@ -773,6 +778,7 @@ async fn context_command(db: &Database, config: &Config, args: ContextCommandArg
             cwd,
             include_evidence: args.include_evidence,
             max_items: args.max_items,
+            dao_tian_limit: args.dao_tian_limit,
         },
     )
     .await?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -680,6 +680,7 @@ impl MempalMcpServer {
                 None,
             ));
         }
+        let dao_tian_limit = request.dao_tian_limit.unwrap_or(1);
 
         let domain = parse_domain(request.domain.as_deref())?.unwrap_or(MemoryDomain::Project);
         let cwd = match request.cwd.as_deref() {
@@ -721,6 +722,7 @@ impl MempalMcpServer {
                 cwd,
                 include_evidence: request.include_evidence.unwrap_or(false),
                 max_items,
+                dao_tian_limit,
             },
             &query_vector,
         )
@@ -2234,6 +2236,42 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["qi", "evidence"]);
         assert_eq!(response.sections[1].items[0].drawer_id, "drawer_evidence");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_dao_tian_limit_zero_omits_section() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_dao_tian",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Evidence precedes assertion.",
+            "debug universal principle",
+        );
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_shu",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Reproduce before patching.",
+            "debug workflow rule",
+        );
+
+        let response = server
+            .context_json_for_test(serde_json::json!({
+                "query": "debug",
+                "dao_tian_limit": 0
+            }))
+            .await
+            .expect("context should succeed");
+        let names = response
+            .sections
+            .iter()
+            .map(|section| section.name.as_str())
+            .collect::<Vec<_>>();
+        assert!(!names.contains(&"dao_tian"));
+        assert!(names.contains(&"shu"));
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -67,6 +67,9 @@ pub struct ContextRequest {
     pub cwd: Option<String>,
     pub include_evidence: Option<bool>,
     pub max_items: Option<usize>,
+    /// Maximum number of `dao_tian` items to include. Defaults to 1; 0 disables
+    /// the `dao_tian` section while preserving lower-tier context.
+    pub dao_tian_limit: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -70,6 +70,7 @@ fn default_request(query: &str, cwd: &Path) -> ContextRequest {
         cwd: cwd.to_path_buf(),
         include_evidence: false,
         max_items: 12,
+        dao_tian_limit: 1,
     }
 }
 
@@ -314,6 +315,87 @@ async fn test_context_groups_knowledge_by_tier_order() {
 }
 
 #[tokio::test]
+async fn test_context_default_caps_dao_tian_to_one() {
+    let (tmp, db) = new_db();
+    for item in [
+        knowledge_drawer(
+            "drawer_dao_tian_one",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Evidence precedes assertion.",
+            "debug universal principle one",
+        ),
+        knowledge_drawer(
+            "drawer_dao_tian_two",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Claims need source-backed verification.",
+            "debug universal principle two",
+        ),
+        knowledge_drawer(
+            "drawer_dao_ren",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Promoted,
+            "Software changes need executable feedback.",
+            "debug domain principle",
+        ),
+    ] {
+        insert_fixture(&db, &item);
+    }
+
+    let pack = assemble_context(&db, &embedder(), default_request("debug", tmp.path()))
+        .await
+        .expect("assemble context");
+    let dao_tian = pack
+        .sections
+        .iter()
+        .find(|section| section.name == "dao_tian")
+        .expect("dao_tian section");
+    assert_eq!(dao_tian.items.len(), 1);
+    assert!(
+        pack.sections
+            .iter()
+            .any(|section| section.name == "dao_ren")
+    );
+}
+
+#[tokio::test]
+async fn test_context_max_items_still_caps_raised_dao_tian_limit() {
+    let (tmp, db) = new_db();
+    for item in [
+        knowledge_drawer(
+            "drawer_dao_tian_one",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Evidence precedes assertion.",
+            "debug universal principle one",
+        ),
+        knowledge_drawer(
+            "drawer_dao_tian_two",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Claims need source-backed verification.",
+            "debug universal principle two",
+        ),
+    ] {
+        insert_fixture(&db, &item);
+    }
+
+    let mut request = default_request("debug", tmp.path());
+    request.max_items = 1;
+    request.dao_tian_limit = 2;
+    let pack = assemble_context(&db, &embedder(), request)
+        .await
+        .expect("assemble context");
+    let item_count: usize = pack
+        .sections
+        .iter()
+        .map(|section| section.items.len())
+        .sum();
+    assert_eq!(item_count, 1);
+}
+
+#[tokio::test]
 async fn test_context_prefers_worktree_anchor_before_repo_and_global() {
     let (tmp, db) = new_db();
     let repo_path = tmp.path().join("repo");
@@ -515,6 +597,71 @@ fn test_context_json_output_exposes_stable_pack_shape() {
     assert_eq!(item["anchor_kind"], "repo");
     assert!(item["anchor_id"].is_string());
     assert_eq!(item["trigger_hints"]["intent_tags"][0], "debugging");
+}
+
+#[test]
+fn test_cli_context_dao_tian_limit_zero_omits_section() {
+    let (tmp, db) = setup_cli_home();
+    for item in [
+        knowledge_drawer(
+            "drawer_dao_tian",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Evidence precedes assertion.",
+            "debug universal principle",
+        ),
+        knowledge_drawer(
+            "drawer_dao_ren",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Promoted,
+            "Software changes need executable feedback.",
+            "debug domain principle",
+        ),
+    ] {
+        insert_fixture(&db, &item);
+    }
+
+    let value = run_context_json(tmp.path(), "debug", &["--dao-tian-limit", "0"]);
+    let names: Vec<_> = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .map(|section| section["name"].as_str().expect("section name"))
+        .collect();
+    assert!(!names.contains(&"dao_tian"));
+    assert!(names.contains(&"dao_ren"));
+}
+
+#[test]
+fn test_cli_context_dao_tian_limit_two_allows_two_items() {
+    let (tmp, db) = setup_cli_home();
+    for item in [
+        knowledge_drawer(
+            "drawer_dao_tian_one",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Evidence precedes assertion.",
+            "debug universal principle one",
+        ),
+        knowledge_drawer(
+            "drawer_dao_tian_two",
+            KnowledgeTier::DaoTian,
+            KnowledgeStatus::Canonical,
+            "Claims need source-backed verification.",
+            "debug universal principle two",
+        ),
+    ] {
+        insert_fixture(&db, &item);
+    }
+
+    let value = run_context_json(tmp.path(), "debug", &["--dao-tian-limit", "2"]);
+    let dao_tian = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .find(|section| section["name"] == "dao_tian")
+        .expect("dao_tian section");
+    assert_eq!(dao_tian["items"].as_array().expect("items").len(), 2);
 }
 
 #[tokio::test]

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -256,6 +256,7 @@ async fn default_context_ids(db: &Database, cwd: &Path, query: &str) -> Vec<Stri
             cwd: cwd.to_path_buf(),
             include_evidence: false,
             max_items: 12,
+            dao_tian_limit: 1,
         },
     )
     .await


### PR DESCRIPTION
## Summary

- Add P26 spec and implementation plan for dao_tian runtime context budget.
- Add core ContextRequest.dao_tian_limit and enforce it only for dao_tian.
- Expose CLI --dao-tian-limit and MCP dao_tian_limit, both defaulting to 1.
- Update protocol, usage docs, MIND-MODEL-DESIGN, AGENTS, and CLAUDE.

## Verification

- agent-spec parse specs/p26-dao-tian-runtime-budget.spec.md
- agent-spec lint specs/p26-dao-tian-runtime-budget.spec.md --min-score 0.7
- cargo fmt --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
