### PR TITLE
feat: expose knowledge promotion policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P26）
+### 已完成的 Spec（P0-P27）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -73,6 +73,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p24-anchor-publication.spec.md` | 完成 | `mempal knowledge publish-anchor` CLI：显式 outward anchor publication（worktree -> repo -> global） |
 | `specs/p25-mcp-anchor-publication.spec.md` | 完成 | `mempal_knowledge_publish_anchor` MCP 工具：显式 outward anchor publication |
 | `specs/p26-dao-tian-runtime-budget.spec.md` | 完成 | `mempal context` / `mempal_context` 默认最多注入 1 条 `dao_tian`，支持显式禁用或提高预算 |
+| `specs/p27-knowledge-policy-surface.spec.md` | 完成 | `mempal knowledge policy` / `mempal_knowledge_policy`：只读 Stage-1 promotion policy 阈值表 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -108,6 +109,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p24-anchor-publication-implementation.md` — P24 anchor publication CLI（已完成）
 - `docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md` — P25 MCP anchor publication（已完成）
 - `docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md` — P26 dao_tian runtime budget（已完成）
+- `docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md` — P27 knowledge policy surface（已完成）
 
 ### Spec 使用方式
 
@@ -128,7 +130,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
 
-## MCP 工具（16 个）
+## MCP 工具（17 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -136,6 +138,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
+| `mempal_knowledge_policy` | read-only Stage-1 promotion policy：列出 `dao_tian/dao_ren/shu/qi` 提升阈值（P27） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P26）
+### 已完成的 Spec（P0-P27）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -71,6 +71,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p24-anchor-publication.spec.md` | 完成 | `mempal knowledge publish-anchor` CLI：显式 outward anchor publication（worktree -> repo -> global） |
 | `specs/p25-mcp-anchor-publication.spec.md` | 完成 | `mempal_knowledge_publish_anchor` MCP 工具：显式 outward anchor publication |
 | `specs/p26-dao-tian-runtime-budget.spec.md` | 完成 | `mempal context` / `mempal_context` 默认最多注入 1 条 `dao_tian`，支持显式禁用或提高预算 |
+| `specs/p27-knowledge-policy-surface.spec.md` | 完成 | `mempal knowledge policy` / `mempal_knowledge_policy`：只读 Stage-1 promotion policy 阈值表 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -106,6 +107,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p24-anchor-publication-implementation.md` — P24 anchor publication CLI（已完成）
 - `docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md` — P25 MCP anchor publication（已完成）
 - `docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md` — P26 dao_tian runtime budget（已完成）
+- `docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md` — P27 knowledge policy surface（已完成）
 
 ### Spec 使用方式
 
@@ -126,7 +128,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
 
-## MCP 工具（16 个）
+## MCP 工具（17 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -134,6 +136,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
+| `mempal_knowledge_policy` | read-only Stage-1 promotion policy：列出 `dao_tian/dao_ren/shu/qi` 提升阈值（P27） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |
 | `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -828,6 +828,13 @@ Implemented Phase-1 runtime surface:
 - lifecycle verification / counterexample refs are hardened to require existing evidence drawers, preserving the rule that promotion and demotion are justified by evidence rather than arbitrary ids or other knowledge claims
 - promotion gate CLI provides a read-only advisory report before promotion, using deterministic evidence-count policy without mutating status, refs, vectors, schema, or audit history
 - `mempal_knowledge_gate` exposes the same read-only promotion gate to MCP-connected agents, so runtime agents can check readiness without shelling out or mutating lifecycle state
+- Stage-1 promotion policy is inspectable without a concrete drawer through `mempal knowledge policy` and `mempal_knowledge_policy`
+- current Stage-1 thresholds are:
+  - `dao_tian -> canonical`: 3 supporting refs, 2 verification refs, 1 teaching ref, human reviewer required, counterexamples block
+  - `dao_ren -> promoted`: 2 supporting refs, 1 verification ref, counterexamples block
+  - `shu -> promoted`: 1 supporting ref, 1 verification ref, counterexamples block
+  - `qi -> promoted`: 1 supporting ref, 1 verification ref, counterexamples block
+- `dao_tian -> canonical` always requires a human reviewer in Stage 1; evaluator-only canonization is intentionally out of scope
 - `mempal_knowledge_promote` and `mempal_knowledge_demote` expose lifecycle mutation to MCP-connected agents; promotion is gate-enforced after appending supplied verification refs, while demotion requires counterexample evidence
 - `mempal knowledge publish-anchor` implements explicit outward anchor publication for active knowledge (`worktree -> repo -> global`) as a metadata-only operation separate from tier/status promotion
 - `mempal_knowledge_publish_anchor` exposes the same outward anchor publication operation to MCP-connected agents without changing content, vectors, tier, or status
@@ -900,11 +907,9 @@ This design does not assume:
 
 The following remain open and should be resolved in later design work:
 
-1. What exact promotion thresholds should be used for `dao_ren` and `dao_tian`?
-2. Should `dao_tian` always require human review, or can a high-grade evaluator canonize it?
-3. How should `field` taxonomy be managed?
-4. Should `wake-up` eventually consume typed `dao_tian` / `dao_ren`, or should that remain exclusive to `mempal context`?
-5. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
+1. How should `field` taxonomy be managed?
+2. Should `wake-up` eventually consume typed `dao_tian` / `dao_ren`, or should that remain exclusive to `mempal context`?
+3. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
 
 ## Current Recommendation
 

--- a/docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md
+++ b/docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md
@@ -1,0 +1,27 @@
+# P27 Knowledge Policy Surface Implementation Plan
+
+**Goal:** Expose the current deterministic Stage-1 knowledge promotion policy without requiring a concrete drawer.
+
+**Architecture:** Keep gate requirements in `src/knowledge_gate.rs` as the source of truth. Add a shared policy list, then wire it into CLI and MCP read-only surfaces.
+
+## Steps
+
+- [x] Validate task contract with `agent-spec parse/lint`.
+- [x] Add shared promotion policy entry types and `promotion_policy()` helper.
+- [x] Add `mempal knowledge policy --format plain|json`.
+- [x] Add `mempal_knowledge_policy` MCP tool and DTO.
+- [x] Add CLI and MCP tests for thresholds, reviewer rule, invalid format, and no side effects.
+- [x] Update usage docs, MIND-MODEL-DESIGN, AGENTS, and CLAUDE.
+- [x] Run formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p27-knowledge-policy-surface.spec.md
+agent-spec lint specs/p27-knowledge-policy-surface.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,6 +97,7 @@ Use this when you already know the concepts and just need the right command quic
 | `mempal search <QUERY> [--wing W] [--room R] [--json]` | hybrid search (BM25 + vector + RRF) with tunnel hints |
 | `mempal context <QUERY> [--format json] [--include-evidence] [--dao-tian-limit N]` | assemble mind-model runtime context (`dao_tian -> dao_ren -> shu -> qi`); default `dao_tian` budget is 1 |
 | `mempal knowledge distill --statement ... --content ... --tier dao_ren --supporting-ref <ID>` | create candidate knowledge from evidence refs |
+| `mempal knowledge policy [--format json]` | inspect read-only Stage-1 promotion policy thresholds |
 | `mempal knowledge gate <ID> [--format json]` | evaluate whether knowledge satisfies promotion gate policy without mutating it |
 | `mempal knowledge promote <ID> --status promoted --verification-ref <ID> --reason ...` | promote bootstrap knowledge into active runtime use |
 | `mempal knowledge demote <ID> --status demoted --evidence-ref <ID> --reason ... --reason-type contradicted` | demote or retire contradicted / obsolete bootstrap knowledge |
@@ -217,10 +218,18 @@ Equivalent MCP distill request:
 }
 ```
 
-P20 adds a read-only promotion gate report. Use it before `promote` to check the
-minimum deterministic policy without changing status, refs, vectors, schema, or
-the audit log. P21 exposes the same policy to MCP agents as
-`mempal_knowledge_gate`.
+P20 adds a read-only promotion gate report. P27 exposes the current Stage-1
+policy table directly:
+
+```bash
+mempal knowledge policy --format json
+```
+
+Use `gate` before `promote` to check the minimum deterministic policy against a
+specific drawer without changing status, refs, vectors, schema, or the audit
+log. P21 exposes the same drawer-specific gate to MCP agents as
+`mempal_knowledge_gate`, while P27 exposes the policy table as
+`mempal_knowledge_policy`.
 
 ```bash
 mempal knowledge gate drawer_knowledge --format json
@@ -540,12 +549,13 @@ mempal serve --mcp
 
 If `mempal` was built without the `rest` feature, plain `mempal serve` behaves the same way.
 
-The MCP server exposes sixteen tools:
+The MCP server exposes seventeen tools:
 
 - `mempal_status` — state + protocol + AAAK spec
 - `mempal_search` — hybrid search (BM25 + vector + RRF) with tunnel hints and AAAK-derived structured signals (`entities` / `topics` / `flags` / `emotions` / `importance_stars`)
 - `mempal_context` — mind-model runtime context pack (`dao_tian -> dao_ren -> shu -> qi`, evidence opt-in, `dao_tian_limit` default 1); guides workflow / skill / tool choice but never executes skills
 - `mempal_knowledge_distill` — create candidate `dao_ren` / `qi` knowledge from existing evidence refs; deterministic and never auto-promotes
+- `mempal_knowledge_policy` — read-only Stage-1 promotion policy table for `dao_tian`, `dao_ren`, `shu`, and `qi`
 - `mempal_knowledge_gate` — read-only promotion readiness check for knowledge drawers; returns the same deterministic gate report as `mempal knowledge gate --format json`
 - `mempal_knowledge_promote` — gate-enforced lifecycle promotion with supplied verification refs
 - `mempal_knowledge_demote` — demote or retire knowledge with counterexample evidence refs

--- a/specs/p27-knowledge-policy-surface.spec.md
+++ b/specs/p27-knowledge-policy-surface.spec.md
@@ -1,0 +1,98 @@
+spec: task
+name: "P27: read-only knowledge promotion policy surface"
+inherits: project
+tags: [memory, knowledge, lifecycle, policy, mcp, cli]
+---
+
+## Intent
+
+P20/P21 implemented deterministic promotion gates, but the policy is only visible
+when evaluating a concrete drawer. `docs/MIND-MODEL-DESIGN.md` still lists
+promotion thresholds and `dao_tian` human review as open questions even though
+the current Stage-1 runtime already has a concrete policy.
+
+This task adds a read-only policy surface so humans and MCP-connected agents can
+inspect the current Stage-1 promotion policy without needing a fixture drawer.
+
+## Decisions
+
+- Add CLI command `mempal knowledge policy`.
+- CLI supports `--format plain|json`, defaulting to `plain`.
+- Add MCP tool `mempal_knowledge_policy`.
+- The policy response lists deterministic entries for:
+  - `dao_tian -> canonical`
+  - `dao_ren -> promoted`
+  - `shu -> promoted`
+  - `qi -> promoted`
+- Each entry exposes the same requirement fields used by `mempal knowledge gate`:
+  - `min_supporting_refs`
+  - `min_verification_refs`
+  - `min_teaching_refs`
+  - `reviewer_required`
+  - `counterexamples_block`
+- The policy source of truth must be shared with gate evaluation so documentation,
+  CLI, MCP, and enforcement do not drift.
+- `dao_tian -> canonical` keeps `reviewer_required=true`; Stage 1 does not allow
+  evaluator-only canonization.
+- The command and MCP tool are read-only and must not open or mutate drawers,
+  vectors, triples, schema, or audit logs.
+
+## Acceptance Criteria
+
+Scenario: CLI prints promotion policy as JSON
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_policy_json_lists_stage1_thresholds
+  Given any initialized mempal home
+  When running `mempal knowledge policy --format json`
+  Then the command exits successfully
+  And JSON includes `dao_tian -> canonical` with supporting 3, verification 2, teaching 1, and reviewer required
+  And JSON includes `dao_ren -> promoted` with supporting 2 and verification 1
+
+Scenario: CLI prints promotion policy as plain text
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_policy_plain_lists_reviewer_rule
+  Given any initialized mempal home
+  When running `mempal knowledge policy`
+  Then stdout includes `dao_tian -> canonical`
+  And stdout includes `reviewer_required=true`
+
+Scenario: MCP exposes the same promotion policy
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_policy_lists_stage1_thresholds
+  Given an MCP server
+  When calling `mempal_knowledge_policy`
+  Then the response includes the same `dao_tian -> canonical` and `dao_ren -> promoted` thresholds as CLI policy
+
+Scenario: MCP policy has no database side effects
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_policy_has_no_db_side_effects
+  Given a database with known schema, drawer, triple, and taxonomy counts
+  When calling `mempal_knowledge_policy` repeatedly
+  Then those counts remain unchanged
+
+Scenario: CLI rejects unsupported policy output format
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_policy_rejects_invalid_format
+  Given any initialized mempal home
+  When running `mempal knowledge policy --format yaml`
+  Then the command fails with an unsupported format error
+
+## Out of Scope
+
+- Do not change existing gate thresholds.
+- Do not add configurable promotion policy.
+- Do not add evaluator-only `dao_tian` canonization.
+- Do not change lifecycle mutation behavior.
+- Do not change context or wake-up assembly.
+- Do not change database schema.
+
+## Constraints
+
+- Keep `src/knowledge_gate.rs` as the source of truth for gate requirements.
+- Keep CLI and MCP policy responses aligned.
+- Update `docs/MIND-MODEL-DESIGN.md` so thresholds and `dao_tian` reviewer policy are no longer listed as open questions.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -163,10 +163,13 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 
 12. CHECK KNOWLEDGE PROMOTION READINESS
    Before proposing that a knowledge drawer should be promoted or treated as
-   canonical, call mempal_knowledge_gate with its drawer_id. The tool is a
-   read-only policy check over existing evidence refs. If allowed=false, use
-   the reasons to gather more evidence or keep the drawer at its current
-   lifecycle status. A passing gate is advisory; it does not auto-promote.
+   canonical, call mempal_knowledge_policy to inspect the current Stage-1
+   thresholds, then call mempal_knowledge_gate with the drawer_id. The policy
+   and gate tools are read-only checks over deterministic evidence-ref rules.
+   dao_tian -> canonical requires a human reviewer in Stage 1; evaluator-only
+   canonization is not allowed. If allowed=false, use the reasons to gather
+   more evidence or keep the drawer at its current lifecycle status. A passing
+   gate is advisory; it does not auto-promote.
 
 13. DISTILL KNOWLEDGE FROM EVIDENCE
    When repeated evidence suggests a reusable rule, call
@@ -195,6 +198,7 @@ TOOLS:
   mempal_search        — semantic search with wing/room filters, citation-bearing
   mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi)
   mempal_knowledge_distill — create candidate knowledge from evidence refs
+  mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
@@ -371,11 +375,21 @@ mod tests {
             "MEMORY_PROTOCOL must include Rule 12 knowledge gate guidance"
         );
         assert!(
+            MEMORY_PROTOCOL.contains("mempal_knowledge_policy"),
+            "MEMORY_PROTOCOL must mention mempal_knowledge_policy"
+        );
+        assert!(
             MEMORY_PROTOCOL.contains("mempal_knowledge_gate"),
             "MEMORY_PROTOCOL must mention mempal_knowledge_gate in TOOLS list"
         );
         assert!(
-            MEMORY_PROTOCOL.contains("A passing gate is advisory; it does not auto-promote"),
+            MEMORY_PROTOCOL.contains("dao_tian -> canonical requires a human reviewer"),
+            "MEMORY_PROTOCOL must keep dao_tian human review policy explicit"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("A passing")
+                && MEMORY_PROTOCOL.contains("gate is advisory")
+                && MEMORY_PROTOCOL.contains("does not auto-promote"),
             "MEMORY_PROTOCOL must state that the gate is advisory"
         );
     }

--- a/src/knowledge_gate.rs
+++ b/src/knowledge_gate.rs
@@ -35,6 +35,29 @@ pub struct GateEvidenceCounts {
     pub verification: usize,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct PromotionPolicyEntry {
+    pub tier: String,
+    pub target_status: String,
+    pub requirements: GateRequirements,
+}
+
+pub fn promotion_policy() -> Vec<PromotionPolicyEntry> {
+    [
+        (KnowledgeTier::DaoTian, KnowledgeStatus::Canonical),
+        (KnowledgeTier::DaoRen, KnowledgeStatus::Promoted),
+        (KnowledgeTier::Shu, KnowledgeStatus::Promoted),
+        (KnowledgeTier::Qi, KnowledgeStatus::Promoted),
+    ]
+    .into_iter()
+    .map(|(tier, target_status)| PromotionPolicyEntry {
+        tier: tier_slug(&tier).to_string(),
+        target_status: status_slug(&target_status).to_string(),
+        requirements: gate_requirements_for_policy(&tier, &target_status),
+    })
+    .collect()
+}
+
 pub fn evaluate_gate_by_id(
     db: &Database,
     drawer_id: &str,
@@ -139,6 +162,25 @@ fn validate_tier_status(tier: &KnowledgeTier, status: &KnowledgeStatus) -> Resul
 }
 
 fn gate_requirements(tier: &KnowledgeTier, target_status: &KnowledgeStatus) -> GateRequirements {
+    promotion_policy()
+        .into_iter()
+        .find(|entry| {
+            entry.tier == tier_slug(tier) && entry.target_status == status_slug(target_status)
+        })
+        .map(|entry| entry.requirements)
+        .unwrap_or_else(|| GateRequirements {
+            min_supporting_refs: 0,
+            min_verification_refs: 0,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        })
+}
+
+fn gate_requirements_for_policy(
+    tier: &KnowledgeTier,
+    target_status: &KnowledgeStatus,
+) -> GateRequirements {
     match (tier, target_status) {
         (KnowledgeTier::DaoTian, KnowledgeStatus::Canonical) => GateRequirements {
             min_supporting_refs: 3,
@@ -161,13 +203,7 @@ fn gate_requirements(tier: &KnowledgeTier, target_status: &KnowledgeStatus) -> G
             reviewer_required: false,
             counterexamples_block: true,
         },
-        _ => GateRequirements {
-            min_supporting_refs: 0,
-            min_verification_refs: 0,
-            min_teaching_refs: 0,
-            reviewer_required: false,
-            counterexamples_block: true,
-        },
+        _ => unreachable!("promotion_policy only requests defined gate policy entries"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,9 @@ use mempal::ingest::{
 };
 use mempal::knowledge_anchor::{PublishAnchorRequest, publish_anchor};
 use mempal::knowledge_distill::{DistillPlan, DistillRequest, commit_distill, prepare_distill};
-use mempal::knowledge_gate::{GateReport, evaluate_gate_by_id};
+use mempal::knowledge_gate::{
+    GateReport, PromotionPolicyEntry, evaluate_gate_by_id, promotion_policy,
+};
 use mempal::knowledge_lifecycle::{
     DemoteRequest, PromoteRequest, demote_knowledge, promote_knowledge,
 };
@@ -321,6 +323,10 @@ enum KnowledgeCommands {
         reviewer: Option<String>,
         #[arg(long = "allow-counterexamples")]
         allow_counterexamples: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Policy {
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -1353,6 +1359,20 @@ async fn knowledge_command(
                 other => bail!("unsupported gate format: {other}"),
             }
         }
+        KnowledgeCommands::Policy { format } => {
+            let policy = promotion_policy();
+            match format.as_str() {
+                "plain" => print_promotion_policy(&policy),
+                "json" => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&policy)
+                            .context("failed to serialize knowledge policy")?
+                    );
+                }
+                other => bail!("unsupported policy format: {other}"),
+            }
+        }
         KnowledgeCommands::PublishAnchor {
             drawer_id,
             to,
@@ -1437,6 +1457,21 @@ fn print_gate_report(report: &GateReport) {
     );
     for reason in &report.reasons {
         println!("reason={reason}");
+    }
+}
+
+fn print_promotion_policy(policy: &[PromotionPolicyEntry]) {
+    for entry in policy {
+        println!(
+            "{} -> {} supporting>={} verification>={} teaching>={} reviewer_required={} counterexamples_block={}",
+            entry.tier,
+            entry.target_status,
+            entry.requirements.min_supporting_refs,
+            entry.requirements.min_verification_refs,
+            entry.requirements.min_teaching_refs,
+            entry.requirements.reviewer_required,
+            entry.requirements.counterexamples_block
+        );
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -28,7 +28,7 @@ use crate::knowledge_anchor::{PublishAnchorRequest as CorePublishAnchorRequest, 
 use crate::knowledge_distill::{
     DistillPlan, DistillRequest as CoreDistillRequest, commit_distill, prepare_distill,
 };
-use crate::knowledge_gate::evaluate_gate_by_id;
+use crate::knowledge_gate::{evaluate_gate_by_id, promotion_policy};
 use crate::knowledge_lifecycle::{
     DemoteRequest as CoreDemoteRequest, PromoteRequest as CorePromoteRequest, demote_knowledge,
     promote_knowledge,
@@ -48,11 +48,12 @@ use super::tools::{
     DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, IngestRequest,
     IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeDemoteRequest,
     KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
-    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePromoteRequest, KnowledgePromoteResponse,
-    KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse, PeekMessageDto,
-    PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest, SearchResponse,
-    SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse,
-    TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
+    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse, KnowledgePromoteRequest,
+    KnowledgePromoteResponse, KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse,
+    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest,
+    SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest,
+    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
+    TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -197,6 +198,14 @@ impl MempalMcpServer {
 
     pub async fn status_json_for_test(&self) -> std::result::Result<StatusResponse, ErrorData> {
         self.mempal_status().await.map(|response| response.0)
+    }
+
+    pub async fn knowledge_policy_json_for_test(
+        &self,
+    ) -> std::result::Result<KnowledgePolicyResponse, ErrorData> {
+        self.mempal_knowledge_policy()
+            .await
+            .map(|response| response.0)
     }
 }
 
@@ -802,6 +811,16 @@ impl MempalMcpServer {
         .map_err(knowledge_gate_error)?;
 
         Ok(Json(KnowledgeGateResponse::from(report)))
+    }
+
+    #[tool(
+        name = "mempal_knowledge_policy",
+        description = "Read-only Stage-1 knowledge promotion policy table. Lists deterministic gate thresholds for dao_tian -> canonical, dao_ren -> promoted, shu -> promoted, and qi -> promoted without requiring a drawer and without mutating storage."
+    )]
+    async fn mempal_knowledge_policy(
+        &self,
+    ) -> std::result::Result<Json<KnowledgePolicyResponse>, ErrorData> {
+        Ok(Json(KnowledgePolicyResponse::from(promotion_policy())))
     }
 
     #[tool(
@@ -2353,6 +2372,82 @@ mod tests {
                 .as_deref()
                 .unwrap_or_default()
                 .contains("dao_tian -> dao_ren -> shu -> qi")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_policy_lists_stage1_thresholds() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let response = server
+            .knowledge_policy_json_for_test()
+            .await
+            .expect("policy should succeed");
+        let dao_tian = response
+            .entries
+            .iter()
+            .find(|entry| entry.tier == "dao_tian" && entry.target_status == "canonical")
+            .expect("dao_tian policy");
+        assert_eq!(dao_tian.requirements.min_supporting_refs, 3);
+        assert_eq!(dao_tian.requirements.min_verification_refs, 2);
+        assert_eq!(dao_tian.requirements.min_teaching_refs, 1);
+        assert!(dao_tian.requirements.reviewer_required);
+
+        let dao_ren = response
+            .entries
+            .iter()
+            .find(|entry| entry.tier == "dao_ren" && entry.target_status == "promoted")
+            .expect("dao_ren policy");
+        assert_eq!(dao_ren.requirements.min_supporting_refs, 2);
+        assert_eq!(dao_ren.requirements.min_verification_refs, 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_policy_has_no_db_side_effects() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_evidence",
+            "policy side-effect evidence",
+            "mempal",
+            Some("policy"),
+            "/tmp/policy.md",
+            2,
+        );
+        let db = Database::open(&db_path).expect("open db");
+        let baseline_schema = db.schema_version().expect("schema");
+        let baseline_drawers = db.drawer_count().expect("drawers");
+        let baseline_triples = db.triple_count().expect("triples");
+        let baseline_taxonomy = db.taxonomy_count().expect("taxonomy");
+
+        for _ in 0..3 {
+            let response = server
+                .knowledge_policy_json_for_test()
+                .await
+                .expect("policy should succeed");
+            assert!(!response.entries.is_empty());
+        }
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.schema_version().expect("schema"), baseline_schema);
+        assert_eq!(db.drawer_count().expect("drawers"), baseline_drawers);
+        assert_eq!(db.triple_count().expect("triples"), baseline_triples);
+        assert_eq!(db.taxonomy_count().expect("taxonomy"), baseline_taxonomy);
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_includes_mempal_knowledge_policy() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let policy_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_knowledge_policy")
+            .expect("mempal_knowledge_policy tool exists");
+        assert!(
+            policy_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Stage-1 knowledge promotion policy")
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -5,7 +5,7 @@ use crate::core::types::{
 };
 use crate::knowledge_anchor::PublishAnchorOutcome;
 use crate::knowledge_distill::DistillOutcome;
-use crate::knowledge_gate::GateReport;
+use crate::knowledge_gate::{GateReport, PromotionPolicyEntry};
 use crate::knowledge_lifecycle::{DemoteOutcome, PromoteOutcome};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
@@ -246,6 +246,39 @@ pub struct KnowledgeGateEvidenceCountsDto {
     pub counterexample: usize,
     pub teaching: usize,
     pub verification: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgePolicyResponse {
+    pub entries: Vec<KnowledgePolicyEntryDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgePolicyEntryDto {
+    pub tier: String,
+    pub target_status: String,
+    pub requirements: KnowledgeGateRequirementsDto,
+}
+
+impl From<Vec<PromotionPolicyEntry>> for KnowledgePolicyResponse {
+    fn from(entries: Vec<PromotionPolicyEntry>) -> Self {
+        Self {
+            entries: entries
+                .into_iter()
+                .map(|entry| KnowledgePolicyEntryDto {
+                    tier: entry.tier,
+                    target_status: entry.target_status,
+                    requirements: KnowledgeGateRequirementsDto {
+                        min_supporting_refs: entry.requirements.min_supporting_refs,
+                        min_verification_refs: entry.requirements.min_verification_refs,
+                        min_teaching_refs: entry.requirements.min_teaching_refs,
+                        reviewer_required: entry.requirements.reviewer_required,
+                        counterexamples_block: entry.requirements.counterexamples_block,
+                    },
+                })
+                .collect(),
+        }
+    }
 }
 
 impl From<GateReport> for KnowledgeGateResponse {

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -313,6 +313,15 @@ fn gate_json(output: &Output) -> Value {
     serde_json::from_slice(&output.stdout).expect("gate json")
 }
 
+fn policy_entry<'a>(value: &'a Value, tier: &str, target_status: &str) -> &'a Value {
+    value
+        .as_array()
+        .expect("policy array")
+        .iter()
+        .find(|entry| entry["tier"] == tier && entry["target_status"] == target_status)
+        .expect("policy entry")
+}
+
 #[test]
 fn test_cli_knowledge_publish_anchor_worktree_to_repo() {
     let (home, db) = setup_home();
@@ -963,6 +972,64 @@ fn test_cli_knowledge_gate_requires_reviewer_for_dao_tian() {
     assert!(reviewed.status.success());
     let value = gate_json(&reviewed);
     assert_eq!(value["allowed"], true);
+}
+
+#[test]
+fn test_cli_knowledge_policy_json_lists_stage1_thresholds() {
+    let (home, _db) = setup_home();
+    let output = run_mempal(home.path(), &["knowledge", "policy", "--format", "json"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("policy json");
+    let dao_tian = policy_entry(&value, "dao_tian", "canonical");
+    assert_eq!(
+        dao_tian["requirements"]["min_supporting_refs"],
+        serde_json::json!(3)
+    );
+    assert_eq!(
+        dao_tian["requirements"]["min_verification_refs"],
+        serde_json::json!(2)
+    );
+    assert_eq!(
+        dao_tian["requirements"]["min_teaching_refs"],
+        serde_json::json!(1)
+    );
+    assert_eq!(
+        dao_tian["requirements"]["reviewer_required"],
+        serde_json::json!(true)
+    );
+
+    let dao_ren = policy_entry(&value, "dao_ren", "promoted");
+    assert_eq!(
+        dao_ren["requirements"]["min_supporting_refs"],
+        serde_json::json!(2)
+    );
+    assert_eq!(
+        dao_ren["requirements"]["min_verification_refs"],
+        serde_json::json!(1)
+    );
+}
+
+#[test]
+fn test_cli_knowledge_policy_plain_lists_reviewer_rule() {
+    let (home, _db) = setup_home();
+    let output = run_mempal(home.path(), &["knowledge", "policy"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("dao_tian -> canonical"));
+    assert!(stdout.contains("reviewer_required=true"));
+}
+
+#[test]
+fn test_cli_knowledge_policy_rejects_invalid_format() {
+    let (home, _db) = setup_home();
+    let output = run_mempal(home.path(), &["knowledge", "policy", "--format", "yaml"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported policy format"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add P27 spec and implementation plan for a read-only knowledge promotion policy surface.
- Add shared promotion_policy source in knowledge_gate and expose it via CLI and MCP.
- Add CLI command: mempal knowledge policy --format plain|json.
- Add MCP tool: mempal_knowledge_policy.
- Update protocol, usage docs, MIND-MODEL-DESIGN, AGENTS, and CLAUDE.

## Verification

- agent-spec parse specs/p27-knowledge-policy-surface.spec.md
- agent-spec lint specs/p27-knowledge-policy-surface.spec.md --min-score 0.7
- cargo fmt --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
