### PR TITLE
feat: expose field taxonomy guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P27）
+### 已完成的 Spec（P0-P28）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -74,6 +74,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p25-mcp-anchor-publication.spec.md` | 完成 | `mempal_knowledge_publish_anchor` MCP 工具：显式 outward anchor publication |
 | `specs/p26-dao-tian-runtime-budget.spec.md` | 完成 | `mempal context` / `mempal_context` 默认最多注入 1 条 `dao_tian`，支持显式禁用或提高预算 |
 | `specs/p27-knowledge-policy-surface.spec.md` | 完成 | `mempal knowledge policy` / `mempal_knowledge_policy`：只读 Stage-1 promotion policy 阈值表 |
+| `specs/p28-field-taxonomy-surface.spec.md` | 完成 | `mempal field-taxonomy` / `mempal_field_taxonomy`：只读 Stage-1 field taxonomy guidance |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -110,6 +111,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md` — P25 MCP anchor publication（已完成）
 - `docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md` — P26 dao_tian runtime budget（已完成）
 - `docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md` — P27 knowledge policy surface（已完成）
+- `docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md` — P28 field taxonomy surface（已完成）
 
 ### Spec 使用方式
 
@@ -130,13 +132,14 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
 
-## MCP 工具（17 个）
+## MCP 工具（18 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26） |
+| `mempal_field_taxonomy` | read-only Stage-1 field taxonomy guidance：推荐 `field` 值但不限制自定义字段（P28） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_policy` | read-only Stage-1 promotion policy：列出 `dao_tian/dao_ren/shu/qi` 提升阈值（P27） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
-### 已完成的 Spec（P0-P27）
+### 已完成的 Spec（P0-P28）
 
 | Spec | 状态 | 范围 |
 |------|------|------|
@@ -72,6 +72,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p25-mcp-anchor-publication.spec.md` | 完成 | `mempal_knowledge_publish_anchor` MCP 工具：显式 outward anchor publication |
 | `specs/p26-dao-tian-runtime-budget.spec.md` | 完成 | `mempal context` / `mempal_context` 默认最多注入 1 条 `dao_tian`，支持显式禁用或提高预算 |
 | `specs/p27-knowledge-policy-surface.spec.md` | 完成 | `mempal knowledge policy` / `mempal_knowledge_policy`：只读 Stage-1 promotion policy 阈值表 |
+| `specs/p28-field-taxonomy-surface.spec.md` | 完成 | `mempal field-taxonomy` / `mempal_field_taxonomy`：只读 Stage-1 field taxonomy guidance |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -108,6 +109,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p25-mcp-anchor-publication-implementation.md` — P25 MCP anchor publication（已完成）
 - `docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md` — P26 dao_tian runtime budget（已完成）
 - `docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md` — P27 knowledge policy surface（已完成）
+- `docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md` — P28 field taxonomy surface（已完成）
 
 ### Spec 使用方式
 
@@ -128,13 +130,14 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
 
-## MCP 工具（17 个）
+## MCP 工具（18 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26） |
+| `mempal_field_taxonomy` | read-only Stage-1 field taxonomy guidance：推荐 `field` 值但不限制自定义字段（P28） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_policy` | read-only Stage-1 promotion policy：列出 `dao_tian/dao_ren/shu/qi` 提升阈值（P27） |
 | `mempal_knowledge_gate` | read-only promotion readiness check：评估 knowledge drawer 是否满足提升门槛（P21） |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -813,6 +813,10 @@ Implemented Phase-1 runtime surface:
 - `mempal context <query>` assembles a runtime context pack from typed drawers
 - `mempal_context` exposes the same pack to MCP-connected agents
 - knowledge sections are ordered as `dao_tian -> dao_ren -> shu -> qi`
+- Stage-1 field taxonomy is guidance-only and read-only: `mempal field-taxonomy`
+  and `mempal_field_taxonomy` expose recommended fields such as `general`,
+  `epistemics`, `software-engineering`, `debugging`, `tooling`, `research`,
+  `writing`, and `diary`, while custom field strings remain valid
 - `dao_tian` is sparse by default in runtime context: `mempal context` and
   `mempal_context` inject at most 1 `dao_tian` item unless the caller explicitly
   sets `--dao-tian-limit` / `dao_tian_limit`; `0` disables `dao_tian`
@@ -907,9 +911,8 @@ This design does not assume:
 
 The following remain open and should be resolved in later design work:
 
-1. How should `field` taxonomy be managed?
-2. Should `wake-up` eventually consume typed `dao_tian` / `dao_ren`, or should that remain exclusive to `mempal context`?
-3. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
+1. Should `wake-up` eventually consume typed `dao_tian` / `dao_ren`, or should that remain exclusive to `mempal context`?
+2. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
 
 ## Current Recommendation
 

--- a/docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md
+++ b/docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md
@@ -1,0 +1,27 @@
+# P28 Field Taxonomy Surface Implementation Plan
+
+**Goal:** Add a read-only field taxonomy guidance surface so agents can choose stable Stage-1 `field` values without overloading wing/room taxonomy or enforcing a schema.
+
+**Architecture:** Add a static `field_taxonomy` module with recommended entries. Wire it to a CLI command and MCP tool. Keep all existing ingest/search/context behavior permissive for custom fields.
+
+## Steps
+
+- [x] Validate task contract with `agent-spec parse/lint`.
+- [x] Add shared field taxonomy entry types and static recommended entries.
+- [x] Add `mempal field-taxonomy --format plain|json`.
+- [x] Add `mempal_field_taxonomy` MCP tool and DTO.
+- [x] Add CLI, MCP, and custom-field permissiveness tests.
+- [x] Update usage docs, MIND-MODEL-DESIGN, AGENTS, and CLAUDE.
+- [x] Run formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p28-field-taxonomy-surface.spec.md
+agent-spec lint specs/p28-field-taxonomy-surface.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,6 +96,7 @@ Use this when you already know the concepts and just need the right command quic
 | `mempal ingest --wing <WING> <DIR> [--dry-run]` | chunk, embed, and store a project tree |
 | `mempal search <QUERY> [--wing W] [--room R] [--json]` | hybrid search (BM25 + vector + RRF) with tunnel hints |
 | `mempal context <QUERY> [--format json] [--include-evidence] [--dao-tian-limit N]` | assemble mind-model runtime context (`dao_tian -> dao_ren -> shu -> qi`); default `dao_tian` budget is 1 |
+| `mempal field-taxonomy [--format json]` | inspect read-only recommended `field` values for typed memory |
 | `mempal knowledge distill --statement ... --content ... --tier dao_ren --supporting-ref <ID>` | create candidate knowledge from evidence refs |
 | `mempal knowledge policy [--format json]` | inspect read-only Stage-1 promotion policy thresholds |
 | `mempal knowledge gate <ID> [--format json]` | evaluate whether knowledge satisfies promotion gate policy without mutating it |
@@ -343,6 +344,20 @@ What a search result includes:
 
 If you care about deterministic scope, pass `--wing` and optionally `--room` explicitly instead of relying on routing.
 
+### Field Taxonomy
+
+`field` is a mind-model metadata dimension used by typed memory search and
+context assembly. It is separate from wing/room routing taxonomy. P28 exposes a
+read-only recommended field list:
+
+```bash
+mempal field-taxonomy
+mempal field-taxonomy --format json
+```
+
+The field taxonomy is guidance only. Custom fields remain valid for ingest,
+distill, search, and context when the recommended Stage-1 fields are too coarse.
+
 ### Wake-Up and AAAK
 
 `wake-up` emits a short memory summary for agent context refresh:
@@ -549,11 +564,12 @@ mempal serve --mcp
 
 If `mempal` was built without the `rest` feature, plain `mempal serve` behaves the same way.
 
-The MCP server exposes seventeen tools:
+The MCP server exposes eighteen tools:
 
 - `mempal_status` — state + protocol + AAAK spec
 - `mempal_search` — hybrid search (BM25 + vector + RRF) with tunnel hints and AAAK-derived structured signals (`entities` / `topics` / `flags` / `emotions` / `importance_stars`)
 - `mempal_context` — mind-model runtime context pack (`dao_tian -> dao_ren -> shu -> qi`, evidence opt-in, `dao_tian_limit` default 1); guides workflow / skill / tool choice but never executes skills
+- `mempal_field_taxonomy` — read-only recommended `field` values for typed evidence / knowledge; guidance only, custom fields remain valid
 - `mempal_knowledge_distill` — create candidate `dao_ren` / `qi` knowledge from existing evidence refs; deterministic and never auto-promotes
 - `mempal_knowledge_policy` — read-only Stage-1 promotion policy table for `dao_tian`, `dao_ren`, `shu`, and `qi`
 - `mempal_knowledge_gate` — read-only promotion readiness check for knowledge drawers; returns the same deterministic gate report as `mempal knowledge gate --format json`
@@ -569,7 +585,7 @@ The MCP server exposes seventeen tools:
 - `mempal_cowork_push` — send a short handoff message (≤ 8 KB) to the partner agent's inbox; delivered at the partner's next UserPromptSubmit via a drain hook
 - `mempal_fact_check` — offline contradiction detection against KG triples and known entities
 
-The server also embeds MEMORY_PROTOCOL (behavioral rules) in the MCP `initialize.instructions` field so any MCP client learns the workflow on connect — zero configuration. The protocol treats `mempal_context` as guidance for choosing an approach, workflow, skill, or tool; `trigger_hints` are bias metadata only and never override system, user, repo, or client-native skill rules.
+The server also embeds MEMORY_PROTOCOL (behavioral rules) in the MCP `initialize.instructions` field so any MCP client learns the workflow on connect — zero configuration. The protocol treats `mempal_context` as guidance for choosing an approach, workflow, skill, or tool; `mempal_field_taxonomy` as guidance for choosing typed-memory `field` values; and `trigger_hints` as bias metadata only. These hints never override system, user, repo, or client-native skill rules.
 
 Example request shapes:
 

--- a/specs/p28-field-taxonomy-surface.spec.md
+++ b/specs/p28-field-taxonomy-surface.spec.md
@@ -1,0 +1,101 @@
+spec: task
+name: "P28: read-only field taxonomy guidance surface"
+inherits: project
+tags: [memory, mind-model, field, taxonomy, mcp, cli]
+---
+
+## Intent
+
+`field` is already an explicit Stage-1 drawer metadata dimension used by search
+and context filtering, but it has no management guidance. Existing
+`mempal taxonomy` manages wing/room routing keywords and should not be overloaded
+with mind-model `field` semantics.
+
+This task adds a read-only field taxonomy guidance surface. It gives agents and
+humans a stable list of recommended Stage-1 fields without enforcing those names
+or changing storage.
+
+## Decisions
+
+- Add a read-only CLI command `mempal field-taxonomy`.
+- CLI supports `--format plain|json`, defaulting to `plain`.
+- Add MCP tool `mempal_field_taxonomy`.
+- The response lists recommended entries with:
+  - `field`
+  - `domains`
+  - `description`
+  - `examples`
+- Include at least these Stage-1 fields:
+  - `general`
+  - `epistemics`
+  - `software-engineering`
+  - `debugging`
+  - `tooling`
+  - `research`
+  - `writing`
+  - `diary`
+- The field taxonomy is guidance only; ingest, distill, search, and context must
+  continue accepting custom field strings.
+- Do not reuse the existing `taxonomy` SQLite table; that table remains
+  wing/room routing taxonomy only.
+- Do not change database schema.
+
+## Acceptance Criteria
+
+Scenario: CLI prints field taxonomy as JSON
+  Test:
+    Package: mempal
+    Filter: test_cli_field_taxonomy_json_lists_stage1_fields
+  Given any initialized mempal home
+  When running `mempal field-taxonomy --format json`
+  Then the command exits successfully
+  And JSON includes `general`, `epistemics`, `software-engineering`, `tooling`, and `diary`
+  And the `epistemics` entry includes domain `global`
+
+Scenario: CLI prints field taxonomy as plain text
+  Test:
+    Package: mempal
+    Filter: test_cli_field_taxonomy_plain_lists_descriptions
+  Given any initialized mempal home
+  When running `mempal field-taxonomy`
+  Then stdout includes `epistemics`
+  And stdout includes `domains=`
+
+Scenario: MCP exposes field taxonomy guidance
+  Test:
+    Package: mempal
+    Filter: test_mcp_field_taxonomy_lists_stage1_fields
+  Given an MCP server
+  When calling `mempal_field_taxonomy`
+  Then the response includes the same Stage-1 field entries
+
+Scenario: field taxonomy does not restrict custom fields
+  Test:
+    Package: mempal
+    Filter: test_field_taxonomy_does_not_restrict_custom_context_field
+  Given a knowledge drawer with custom `field="compiler-design"`
+  When assembling context with `field="compiler-design"`
+  Then the custom-field drawer is still returned
+
+Scenario: CLI rejects unsupported field taxonomy format
+  Test:
+    Package: mempal
+    Filter: test_cli_field_taxonomy_rejects_invalid_format
+  Given any initialized mempal home
+  When running `mempal field-taxonomy --format yaml`
+  Then the command fails with an unsupported format error
+
+## Out of Scope
+
+- Do not add a `fields` table or schema migration.
+- Do not validate or reject custom field names.
+- Do not auto-infer fields during ingest or distill.
+- Do not change search/context ranking.
+- Do not change wing/room taxonomy behavior.
+- Do not add REST field taxonomy API.
+
+## Constraints
+
+- Keep wing/room routing taxonomy separate from mind-model field taxonomy.
+- Update `docs/MIND-MODEL-DESIGN.md` so field taxonomy is no longer an open question for Stage 1.
+- Keep the surface read-only and side-effect free.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -67,6 +67,9 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 
    Use mempal_context to choose an approach, workflow, or skill. Use
    mempal_search to verify project facts, past decisions, and citations.
+   Use mempal_field_taxonomy when choosing a `field` value for typed evidence,
+   knowledge, search, or context. Field taxonomy is guidance only; custom
+   field strings remain valid when the recommended fields are too coarse.
 
 3a. TRANSLATE QUERIES TO ENGLISH
    The default embedding model is a multilingual distillation (model2vec) but
@@ -197,6 +200,7 @@ TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
   mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi)
+  mempal_field_taxonomy — read-only recommended mind-model field values
   mempal_knowledge_distill — create candidate knowledge from evidence refs
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
@@ -352,6 +356,20 @@ mod tests {
             MEMORY_PROTOCOL.contains("Use\n   mempal_search to verify project facts"),
             "MEMORY_PROTOCOL must keep fact verification and citations on mempal_search"
         );
+    }
+
+    #[test]
+    fn contains_field_taxonomy_guidance() {
+        for phrase in [
+            "Use mempal_field_taxonomy",
+            "Field taxonomy is guidance only",
+            "custom\n   field strings remain valid",
+        ] {
+            assert!(
+                MEMORY_PROTOCOL.contains(phrase),
+                "MEMORY_PROTOCOL must include field taxonomy phrase: {phrase}"
+            );
+        }
     }
 
     #[test]

--- a/src/field_taxonomy.rs
+++ b/src/field_taxonomy.rs
@@ -1,0 +1,75 @@
+#![warn(clippy::all)]
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FieldTaxonomyEntry {
+    pub field: &'static str,
+    pub domains: &'static [&'static str],
+    pub description: &'static str,
+    pub examples: &'static [&'static str],
+}
+
+pub fn field_taxonomy() -> Vec<FieldTaxonomyEntry> {
+    FIELD_TAXONOMY.to_vec()
+}
+
+const FIELD_TAXONOMY: &[FieldTaxonomyEntry] = &[
+    FieldTaxonomyEntry {
+        field: "general",
+        domains: &["project", "agent", "skill", "global"],
+        description: "Default fallback when no narrower field is known.",
+        examples: &["project decision", "miscellaneous operational note"],
+    },
+    FieldTaxonomyEntry {
+        field: "epistemics",
+        domains: &["global"],
+        description: "Cross-domain reasoning rules about evidence, uncertainty, and belief updates.",
+        examples: &[
+            "evidence precedes assertion",
+            "distinguish observation from inference",
+        ],
+    },
+    FieldTaxonomyEntry {
+        field: "software-engineering",
+        domains: &["project", "skill"],
+        description: "General software construction principles and project engineering constraints.",
+        examples: &[
+            "prefer executable feedback",
+            "avoid changing unrelated behavior",
+        ],
+    },
+    FieldTaxonomyEntry {
+        field: "debugging",
+        domains: &["project", "skill"],
+        description: "Fault isolation, reproduction, diagnostics, and verification workflows.",
+        examples: &[
+            "reproduce before patching",
+            "verify the specific failure path",
+        ],
+    },
+    FieldTaxonomyEntry {
+        field: "tooling",
+        domains: &["project", "agent", "skill"],
+        description: "Concrete tool behavior, CLI usage, environment constraints, and version notes.",
+        examples: &["cargo clippy invocation", "MCP client startup behavior"],
+    },
+    FieldTaxonomyEntry {
+        field: "research",
+        domains: &["project", "agent", "global"],
+        description: "External information gathering, source evaluation, and evidence organization.",
+        examples: &["research-rs workflow", "source-backed literature summary"],
+    },
+    FieldTaxonomyEntry {
+        field: "writing",
+        domains: &["project", "skill"],
+        description: "Technical writing, documentation structure, and explanation style.",
+        examples: &["design doc structure", "concise PR summary"],
+    },
+    FieldTaxonomyEntry {
+        field: "diary",
+        domains: &["agent"],
+        description: "Agent diary rollups and session-level behavior memory.",
+        examples: &["daily agent rollup", "session handoff note"],
+    },
+];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod core;
 pub mod cowork;
 pub mod embed;
 pub mod factcheck;
+pub mod field_taxonomy;
 pub mod ingest;
 pub mod knowledge_anchor;
 pub mod knowledge_distill;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use mempal::core::{
     utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
 };
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
+use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
 use mempal::ingest::{
     IngestOptions, IngestStats, ingest_dir_with_options, ingest_file_with_options,
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
@@ -156,6 +157,10 @@ enum Commands {
     Taxonomy {
         #[command(subcommand)]
         command: TaxonomyCommands,
+    },
+    FieldTaxonomy {
+        #[arg(long, default_value = "plain")]
+        format: String,
     },
     Serve {
         #[arg(long)]
@@ -533,6 +538,7 @@ async fn run() -> Result<()> {
         Commands::Knowledge { command } => knowledge_command(&db, &config, command).await,
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
+        Commands::FieldTaxonomy { format } => field_taxonomy_command(&format),
         Commands::Serve { mcp } => serve_command(&config, mcp).await,
         Commands::Status => status_command(&db),
         Commands::FactCheck {
@@ -1834,6 +1840,34 @@ fn taxonomy_edit_command(db: &Database, wing: &str, room: &str, keywords: &str) 
     );
 
     Ok(())
+}
+
+fn field_taxonomy_command(format: &str) -> Result<()> {
+    let entries = field_taxonomy();
+    match format {
+        "plain" => print_field_taxonomy(&entries),
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&entries)
+                    .context("failed to serialize field taxonomy")?
+            );
+        }
+        other => bail!("unsupported field taxonomy format: {other}"),
+    }
+    Ok(())
+}
+
+fn print_field_taxonomy(entries: &[FieldTaxonomyEntry]) {
+    for entry in entries {
+        println!(
+            "- {} domains={} examples={} :: {}",
+            entry.field,
+            entry.domains.join(","),
+            entry.examples.join("; "),
+            entry.description
+        );
+    }
 }
 
 fn fact_check_command(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -16,6 +16,7 @@ use crate::core::{
 };
 use crate::cowork::{PeekError, PeekRequest as CoworkPeekRequest, Tool, peek_partner};
 use crate::embed::EmbedderFactory;
+use crate::field_taxonomy::field_taxonomy;
 use crate::ingest::{
     IngestError,
     diary::{
@@ -45,15 +46,15 @@ use serde_json::Value;
 
 use super::tools::{
     ContextRequest, ContextResponse, CoworkPushRequest, CoworkPushResponse, DeleteRequest,
-    DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, IngestRequest,
-    IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeDemoteRequest,
-    KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
-    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse, KnowledgePromoteRequest,
-    KnowledgePromoteResponse, KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse,
-    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest,
-    SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest,
-    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
-    TunnelsResponse,
+    DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
+    FieldTaxonomyResponse, IngestRequest, IngestResponse, KgRequest, KgResponse, KgStatsDto,
+    KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
+    KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
+    KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
+    KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
+    ScopeCount, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
+    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
+    TunnelsRequest, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -204,6 +205,14 @@ impl MempalMcpServer {
         &self,
     ) -> std::result::Result<KnowledgePolicyResponse, ErrorData> {
         self.mempal_knowledge_policy()
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn field_taxonomy_json_for_test(
+        &self,
+    ) -> std::result::Result<FieldTaxonomyResponse, ErrorData> {
+        self.mempal_field_taxonomy()
             .await
             .map(|response| response.0)
     }
@@ -1145,6 +1154,21 @@ impl MempalMcpServer {
                 None,
             )),
         }
+    }
+
+    #[tool(
+        name = "mempal_field_taxonomy",
+        description = "Read-only mind-model field taxonomy guidance. Lists recommended Stage-1 field values such as general, epistemics, software-engineering, debugging, tooling, research, writing, and diary. Guidance only; custom fields remain accepted."
+    )]
+    async fn mempal_field_taxonomy(
+        &self,
+    ) -> std::result::Result<Json<FieldTaxonomyResponse>, ErrorData> {
+        Ok(Json(FieldTaxonomyResponse {
+            entries: field_taxonomy()
+                .into_iter()
+                .map(FieldTaxonomyEntryDto::from)
+                .collect(),
+        }))
     }
 
     #[tool(
@@ -2372,6 +2396,50 @@ mod tests {
                 .as_deref()
                 .unwrap_or_default()
                 .contains("dao_tian -> dao_ren -> shu -> qi")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_field_taxonomy_lists_stage1_fields() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let response = server
+            .field_taxonomy_json_for_test()
+            .await
+            .expect("field taxonomy should succeed");
+        for field in [
+            "general",
+            "epistemics",
+            "software-engineering",
+            "tooling",
+            "diary",
+        ] {
+            assert!(
+                response.entries.iter().any(|entry| entry.field == field),
+                "missing field {field}"
+            );
+        }
+        let epistemics = response
+            .entries
+            .iter()
+            .find(|entry| entry.field == "epistemics")
+            .expect("epistemics field");
+        assert!(epistemics.domains.iter().any(|domain| domain == "global"));
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_includes_mempal_field_taxonomy() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let field_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_field_taxonomy")
+            .expect("mempal_field_taxonomy tool exists");
+        assert!(
+            field_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("custom fields remain accepted")
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3,6 +3,7 @@ use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
     NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry, TunnelEndpoint,
 };
+use crate::field_taxonomy::FieldTaxonomyEntry;
 use crate::knowledge_anchor::PublishAnchorOutcome;
 use crate::knowledge_distill::DistillOutcome;
 use crate::knowledge_gate::{GateReport, PromotionPolicyEntry};
@@ -518,6 +519,38 @@ pub struct TaxonomyEntryDto {
     pub room: String,
     pub display_name: Option<String>,
     pub keywords: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct FieldTaxonomyResponse {
+    pub entries: Vec<FieldTaxonomyEntryDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct FieldTaxonomyEntryDto {
+    pub field: String,
+    pub domains: Vec<String>,
+    pub description: String,
+    pub examples: Vec<String>,
+}
+
+impl From<FieldTaxonomyEntry> for FieldTaxonomyEntryDto {
+    fn from(value: FieldTaxonomyEntry) -> Self {
+        Self {
+            field: value.field.to_string(),
+            domains: value
+                .domains
+                .iter()
+                .map(|domain| (*domain).to_string())
+                .collect(),
+            description: value.description.to_string(),
+            examples: value
+                .examples
+                .iter()
+                .map(|example| (*example).to_string())
+                .collect(),
+        }
+    }
 }
 
 // --- Knowledge Graph ---

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -714,6 +714,30 @@ async fn test_context_domain_and_field_filters_exclude_unrelated_knowledge() {
     assert_eq!(ids, vec!["drawer_skill_debugging"]);
 }
 
+#[tokio::test]
+async fn test_field_taxonomy_does_not_restrict_custom_context_field() {
+    let (tmp, db) = new_db();
+    let mut target = knowledge_drawer(
+        "drawer_compiler_design",
+        KnowledgeTier::DaoRen,
+        KnowledgeStatus::Promoted,
+        "Compiler lowering should preserve source-level intent.",
+        "compiler design custom field",
+    );
+    target.field = "compiler-design".to_string();
+    insert_fixture(&db, &target);
+
+    let mut request = default_request("compiler design", tmp.path());
+    request.field = "compiler-design".to_string();
+    let pack = assemble_context(&db, &embedder(), request)
+        .await
+        .expect("assemble context");
+    assert_eq!(
+        pack.sections[0].items[0].drawer_id,
+        "drawer_compiler_design"
+    );
+}
+
 #[test]
 fn test_context_empty_result_exits_successfully() {
     let (tmp, _db) = setup_cli_home();

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -322,6 +322,15 @@ fn policy_entry<'a>(value: &'a Value, tier: &str, target_status: &str) -> &'a Va
         .expect("policy entry")
 }
 
+fn field_entry<'a>(value: &'a Value, field: &str) -> &'a Value {
+    value
+        .as_array()
+        .expect("field taxonomy array")
+        .iter()
+        .find(|entry| entry["field"] == field)
+        .expect("field taxonomy entry")
+}
+
 #[test]
 fn test_cli_knowledge_publish_anchor_worktree_to_repo() {
     let (home, db) = setup_home();
@@ -1030,6 +1039,54 @@ fn test_cli_knowledge_policy_rejects_invalid_format() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unsupported policy format"));
+}
+
+#[test]
+fn test_cli_field_taxonomy_json_lists_stage1_fields() {
+    let (home, _db) = setup_home();
+    let output = run_mempal(home.path(), &["field-taxonomy", "--format", "json"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("field taxonomy json");
+    for field in [
+        "general",
+        "epistemics",
+        "software-engineering",
+        "tooling",
+        "diary",
+    ] {
+        let _ = field_entry(&value, field);
+    }
+    let epistemics = field_entry(&value, "epistemics");
+    assert!(
+        epistemics["domains"]
+            .as_array()
+            .expect("domains")
+            .iter()
+            .any(|domain| domain == "global")
+    );
+}
+
+#[test]
+fn test_cli_field_taxonomy_plain_lists_descriptions() {
+    let (home, _db) = setup_home();
+    let output = run_mempal(home.path(), &["field-taxonomy"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("epistemics"));
+    assert!(stdout.contains("domains="));
+}
+
+#[test]
+fn test_cli_field_taxonomy_rejects_invalid_format() {
+    let (home, _db) = setup_home();
+    let output = run_mempal(home.path(), &["field-taxonomy", "--format", "yaml"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported field taxonomy format"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add P28 spec and implementation plan for read-only field taxonomy guidance.
- Add static Stage-1 field taxonomy entries and expose them through CLI and MCP.
- Add CLI command: mempal field-taxonomy --format plain|json.
- Add MCP tool: mempal_field_taxonomy.
- Keep custom field strings accepted by context/search; no schema or validation changes.
- Update protocol, usage docs, MIND-MODEL-DESIGN, AGENTS, and CLAUDE.

## Verification

- agent-spec parse specs/p28-field-taxonomy-surface.spec.md
- agent-spec lint specs/p28-field-taxonomy-surface.spec.md --min-score 0.7
- cargo fmt --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test
