### PR TITLE
docs: define wake-up context boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p26-dao-tian-runtime-budget.spec.md` | 完成 | `mempal context` / `mempal_context` 默认最多注入 1 条 `dao_tian`，支持显式禁用或提高预算 |
 | `specs/p27-knowledge-policy-surface.spec.md` | 完成 | `mempal knowledge policy` / `mempal_knowledge_policy`：只读 Stage-1 promotion policy 阈值表 |
 | `specs/p28-field-taxonomy-surface.spec.md` | 完成 | `mempal field-taxonomy` / `mempal_field_taxonomy`：只读 Stage-1 field taxonomy guidance |
+| `specs/p29-wake-up-context-boundary.spec.md` | 完成 | 固化 wake-up 与 mind-model context 边界：wake-up 保持 L0/L1 refresh，typed `dao/shu/qi` 组装只属于 `mempal context` / `mempal_context` |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -112,6 +113,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md` — P26 dao_tian runtime budget（已完成）
 - `docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md` — P27 knowledge policy surface（已完成）
 - `docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md` — P28 field taxonomy surface（已完成）
+- `docs/plans/2026-04-26-p29-wake-up-context-boundary-implementation.md` — P29 wake-up/context boundary（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p26-dao-tian-runtime-budget.spec.md` | 完成 | `mempal context` / `mempal_context` 默认最多注入 1 条 `dao_tian`，支持显式禁用或提高预算 |
 | `specs/p27-knowledge-policy-surface.spec.md` | 完成 | `mempal knowledge policy` / `mempal_knowledge_policy`：只读 Stage-1 promotion policy 阈值表 |
 | `specs/p28-field-taxonomy-surface.spec.md` | 完成 | `mempal field-taxonomy` / `mempal_field_taxonomy`：只读 Stage-1 field taxonomy guidance |
+| `specs/p29-wake-up-context-boundary.spec.md` | 完成 | 固化 wake-up 与 mind-model context 边界：wake-up 保持 L0/L1 refresh，typed `dao/shu/qi` 组装只属于 `mempal context` / `mempal_context` |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -110,6 +111,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p26-dao-tian-runtime-budget-implementation.md` — P26 dao_tian runtime budget（已完成）
 - `docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md` — P27 knowledge policy surface（已完成）
 - `docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md` — P28 field taxonomy surface（已完成）
+- `docs/plans/2026-04-26-p29-wake-up-context-boundary-implementation.md` — P29 wake-up/context boundary（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -820,6 +820,9 @@ Implemented Phase-1 runtime surface:
 - `dao_tian` is sparse by default in runtime context: `mempal context` and
   `mempal_context` inject at most 1 `dao_tian` item unless the caller explicitly
   sets `--dao-tian-limit` / `dao_tian_limit`; `0` disables `dao_tian`
+- `wake-up` remains an L0/L1 memory refresh surface and does not assemble typed
+  `dao_tian -> dao_ren -> shu -> qi` sections; typed operating guidance belongs
+  to `mempal context` / `mempal_context`
 - evidence remains opt-in via `--include-evidence`
 - same-tier items prefer `worktree`, then current `repo`, then `repo://legacy`, then `global`
 - `global` anchor candidates use `domain=global`, preserving the invariant that global anchors do not hold project-local domain memory
@@ -911,8 +914,7 @@ This design does not assume:
 
 The following remain open and should be resolved in later design work:
 
-1. Should `wake-up` eventually consume typed `dao_tian` / `dao_ren`, or should that remain exclusive to `mempal context`?
-2. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
+1. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
 
 ## Current Recommendation
 
@@ -921,7 +923,8 @@ Proceed with the following assumptions unless future evidence rejects them:
 - `dao` belongs to the memory layer
 - `research-rs` is an external `qi` tool, not a `dao` container
 - evidence memory and knowledge memory should be explicitly separated
-- runtime should wake `dao` before `shu`, and `shu` before `qi`
+- runtime typed context should assemble `dao` before `shu`, and `shu` before
+  `qi`; wake-up remains a refresh surface, not the typed assembler
 - the implementation should begin with drawer bootstrap and evolve into a dedicated knowledge model
 
 ## Closing Summary

--- a/docs/plans/2026-04-26-p29-wake-up-context-boundary-implementation.md
+++ b/docs/plans/2026-04-26-p29-wake-up-context-boundary-implementation.md
@@ -1,0 +1,30 @@
+# P29 Wake-Up / Context Boundary Implementation Plan
+
+**Goal:** Resolve the remaining design question by keeping `wake-up` as an
+L0/L1 memory refresh and keeping typed `dao_tian -> dao_ren -> shu -> qi`
+assembly exclusive to `mempal context` / `mempal_context`.
+
+**Architecture:** This is a boundary-hardening task. Update protocol and docs,
+then add regression tests that prevent wake-up from growing typed mind-model
+sections or tier budgets.
+
+## Steps
+
+- [x] Validate task contract with `agent-spec parse/lint`.
+- [x] Update MEMORY_PROTOCOL with explicit wake-up/context responsibility split.
+- [x] Add wake-up regression tests for plain and AAAK output.
+- [x] Update usage docs and MIND-MODEL-DESIGN.
+- [x] Update AGENTS and CLAUDE spec inventories.
+- [x] Run formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p29-wake-up-context-boundary.spec.md
+agent-spec lint specs/p29-wake-up-context-boundary.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,7 +102,7 @@ Use this when you already know the concepts and just need the right command quic
 | `mempal knowledge gate <ID> [--format json]` | evaluate whether knowledge satisfies promotion gate policy without mutating it |
 | `mempal knowledge promote <ID> --status promoted --verification-ref <ID> --reason ...` | promote bootstrap knowledge into active runtime use |
 | `mempal knowledge demote <ID> --status demoted --evidence-ref <ID> --reason ... --reason-type contradicted` | demote or retire contradicted / obsolete bootstrap knowledge |
-| `mempal wake-up [--format aaak]` | context refresh sorted by importance (not just recency) |
+| `mempal wake-up [--format aaak]` | L0/L1 refresh sorted by importance; not a typed mind-model context pack |
 | `mempal compress <TEXT>` | format arbitrary text as AAAK |
 | `mempal kg add <S> <P> <O> [--source-drawer ID]` | add a knowledge graph triple |
 | `mempal kg query [--subject S] [--predicate P] [--object O]` | query triples |
@@ -323,6 +323,11 @@ Compact AAAK-formatted refresh:
 ```bash
 mempal wake-up --format aaak
 ```
+
+Use `mempal context` when the agent needs typed operating guidance such as
+`dao_tian -> dao_ren -> shu -> qi`. `wake-up` may show selected knowledge
+statements, but it keeps the L0/L1 refresh shape and does not assemble typed
+tier sections or apply `dao_tian_limit`.
 
 ## Core Workflows
 
@@ -585,7 +590,7 @@ The MCP server exposes eighteen tools:
 - `mempal_cowork_push` — send a short handoff message (≤ 8 KB) to the partner agent's inbox; delivered at the partner's next UserPromptSubmit via a drain hook
 - `mempal_fact_check` — offline contradiction detection against KG triples and known entities
 
-The server also embeds MEMORY_PROTOCOL (behavioral rules) in the MCP `initialize.instructions` field so any MCP client learns the workflow on connect — zero configuration. The protocol treats `mempal_context` as guidance for choosing an approach, workflow, skill, or tool; `mempal_field_taxonomy` as guidance for choosing typed-memory `field` values; and `trigger_hints` as bias metadata only. These hints never override system, user, repo, or client-native skill rules.
+The server also embeds MEMORY_PROTOCOL (behavioral rules) in the MCP `initialize.instructions` field so any MCP client learns the workflow on connect — zero configuration. The protocol treats `wake-up` as an L0/L1 refresh surface, `mempal_context` as typed guidance for choosing an approach, workflow, skill, or tool, `mempal_field_taxonomy` as guidance for choosing typed-memory `field` values, and `trigger_hints` as bias metadata only. These hints never override system, user, repo, or client-native skill rules.
 
 Example request shapes:
 

--- a/specs/p29-wake-up-context-boundary.spec.md
+++ b/specs/p29-wake-up-context-boundary.spec.md
@@ -1,0 +1,89 @@
+spec: task
+name: "P29: wake-up and mind-model context boundary"
+inherits: project
+tags: [memory, wake-up, context, mind-model, protocol]
+---
+
+## Intent
+
+`wake-up` and `mempal context` now both touch active memory, but they have
+different jobs:
+
+- `wake-up` refreshes agent identity and the most important recent drawers.
+- `mempal context` assembles typed mind-model guidance in the order
+  `dao_tian -> dao_ren -> shu -> qi`.
+
+This task resolves the remaining design question by making that boundary
+explicit. `wake-up` must not become a second typed context assembler.
+
+## Decisions
+
+- Keep `wake-up` as an L0/L1 memory refresh surface.
+- Keep typed mind-model assembly exclusive to `mempal context` and
+  `mempal_context`.
+- `wake-up` may include knowledge drawers if they are selected by the existing
+  importance-ranked top-drawer logic.
+- When `wake-up` includes a knowledge drawer, it continues using the effective
+  wake-up text: `statement` first, then `content` fallback.
+- `wake-up` must not add tier sections such as `dao_tian`, `dao_ren`, `shu`, or
+  `qi`.
+- `wake-up` must not apply `dao_tian_limit` or any other tier-specific context
+  budget.
+- Protocol guidance must tell agents to use `wake-up` for refresh and
+  `mempal_context` for typed operating guidance.
+- No schema, ranking, MCP tool, REST API, or CLI flag changes.
+
+## Acceptance Criteria
+
+Scenario: protocol documents the boundary
+  Test:
+    Package: mempal
+    Filter: contains_wake_up_context_boundary_guidance
+  Given the embedded MEMORY_PROTOCOL
+  When reading Rule 1 / Rule 3b guidance
+  Then it states that wake-up is not the typed dao/shu/qi assembler
+  And it directs agents to use `mempal_context` for typed operating guidance
+
+Scenario: plain wake-up does not add mind-model sections
+  Test:
+    Package: mempal
+    Filter: test_wake_up_does_not_assemble_mind_model_sections
+  Given active `dao_tian` and `dao_ren` knowledge drawers
+  When running `mempal wake-up`
+  Then stdout still uses the existing L0/L1 structure
+  And stdout does not contain tier section headings such as `## dao_tian` or `## dao_ren`
+  And selected knowledge drawers still display their `statement`
+
+Scenario: AAAK wake-up remains a refresh summary
+  Test:
+    Package: mempal
+    Filter: test_wake_up_aaak_does_not_assemble_mind_model_sections
+  Given active `dao_tian` and `qi` knowledge drawers
+  When running `mempal wake-up --format aaak`
+  Then the decoded text contains selected statement text
+  And it does not introduce typed mind-model section headings
+
+Scenario: existing wake-up ordering remains unchanged
+  Test:
+    Package: mempal
+    Filter: test_wake_up_preserves_existing_top_drawer_order
+  Given multiple drawers with different importance
+  When running `mempal wake-up`
+  Then the existing top-drawer ordering is preserved
+
+## Out of Scope
+
+- Do not change database schema.
+- Do not add a new MCP tool.
+- Do not add `wake-up` CLI flags.
+- Do not change `top_drawers` ranking.
+- Do not make `wake-up` consume `dao_tian_limit`.
+- Do not move typed context assembly out of `src/context.rs`.
+- Do not execute skills or tools based on wake-up output.
+
+## Constraints
+
+- `mempal context` / `mempal_context` remain the only Stage-1 typed
+  mind-model context assemblers.
+- `wake-up` remains backward-compatible with existing plain, protocol, and
+  AAAK modes.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -27,6 +27,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    context above. Others (Codex, Cursor, raw MCP clients) do NOT — for those,
    step 0 is how you wake up. Trust drawer_ids and source_file citations in
    any results you receive; they reference real files on disk.
+   Wake-up is an L0/L1 refresh surface, not the typed dao/shu/qi assembler.
+   It may show important knowledge drawers, but it does not assemble tiered
+   sections or apply dao_tian budgets. For typed operating guidance, use
+   mempal_context.
 
 2. VERIFY BEFORE ASSERTING
    Before stating project facts ("we chose X", "we use Y", "the auth flow is Z"),
@@ -67,6 +71,8 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 
    Use mempal_context to choose an approach, workflow, or skill. Use
    mempal_search to verify project facts, past decisions, and citations.
+   Do not use wake-up as a substitute for mempal_context when you need typed
+   dao/shu/qi guidance; wake-up preserves a refresh-oriented L0/L1 shape.
    Use mempal_field_taxonomy when choosing a `field` value for typed evidence,
    knowledge, search, or context. Field taxonomy is guidance only; custom
    field strings remain valid when the recommended fields are too coarse.
@@ -356,6 +362,22 @@ mod tests {
             MEMORY_PROTOCOL.contains("Use\n   mempal_search to verify project facts"),
             "MEMORY_PROTOCOL must keep fact verification and citations on mempal_search"
         );
+    }
+
+    #[test]
+    fn contains_wake_up_context_boundary_guidance() {
+        for phrase in [
+            "Wake-up is an L0/L1 refresh surface",
+            "not the typed dao/shu/qi assembler",
+            "does not assemble tiered\n   sections or apply dao_tian budgets",
+            "For typed operating guidance, use\n   mempal_context",
+            "Do not use wake-up as a substitute for mempal_context",
+        ] {
+            assert!(
+                MEMORY_PROTOCOL.contains(phrase),
+                "MEMORY_PROTOCOL must include wake-up/context boundary phrase: {phrase}"
+            );
+        }
     }
 
     #[test]

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -2492,6 +2492,94 @@ fn test_wake_up_aaak_prefers_knowledge_statement() {
 }
 
 #[test]
+fn test_wake_up_does_not_assemble_mind_model_sections() {
+    let (tmp, db) = setup_cli_home();
+    let dao_tian = Drawer {
+        importance: 5,
+        added_at: "1710011002".to_string(),
+        ..bootstrap_drawer(
+            "drawer_kn_wake_boundary_dao_tian",
+            "Universal principle rationale should not create a dao_tian section.",
+            MemoryKind::Knowledge,
+            Some(KnowledgeTier::DaoTian),
+            Some(KnowledgeStatus::Canonical),
+            Some("Evidence precedes assertion."),
+        )
+    };
+    let dao_ren = Drawer {
+        importance: 4,
+        added_at: "1710011001".to_string(),
+        ..bootstrap_drawer(
+            "drawer_kn_wake_boundary_dao_ren",
+            "Domain rule rationale should not create a dao_ren section.",
+            MemoryKind::Knowledge,
+            Some(KnowledgeTier::DaoRen),
+            Some(KnowledgeStatus::Promoted),
+            Some("Rust changes must submit to cargo check."),
+        )
+    };
+    insert_cli_wake_up_drawer(&db, &dao_tian);
+    insert_cli_wake_up_drawer(&db, &dao_ren);
+
+    let output = run_cli_wake_up(tmp.path(), None);
+
+    assert!(output.contains("## L0"));
+    assert!(output.contains("## L1"));
+    assert!(output.contains("Evidence precedes assertion."));
+    assert!(output.contains("Rust changes must submit to cargo check."));
+    for heading in ["## dao_tian", "## dao_ren", "## shu", "## qi"] {
+        assert!(
+            !output.contains(heading),
+            "wake-up must not assemble typed context section {heading}"
+        );
+    }
+}
+
+#[test]
+fn test_wake_up_aaak_does_not_assemble_mind_model_sections() {
+    let (tmp, db) = setup_cli_home();
+    let dao_tian = Drawer {
+        importance: 5,
+        added_at: "1710012002".to_string(),
+        ..bootstrap_drawer(
+            "drawer_kn_wake_aaak_boundary_dao_tian",
+            "Universal principle rationale should not create an AAAK dao_tian section.",
+            MemoryKind::Knowledge,
+            Some(KnowledgeTier::DaoTian),
+            Some(KnowledgeStatus::Canonical),
+            Some("Keep universal principles sparse."),
+        )
+    };
+    let qi = Drawer {
+        importance: 4,
+        added_at: "1710012001".to_string(),
+        ..bootstrap_drawer(
+            "drawer_kn_wake_aaak_boundary_qi",
+            "Tool usage rationale should not create an AAAK qi section.",
+            MemoryKind::Knowledge,
+            Some(KnowledgeTier::Qi),
+            Some(KnowledgeStatus::Promoted),
+            Some("Use cargo check as the Rust ground truth."),
+        )
+    };
+    insert_cli_wake_up_drawer(&db, &dao_tian);
+    insert_cli_wake_up_drawer(&db, &qi);
+
+    let output = run_cli_wake_up(tmp.path(), Some("aaak"));
+    let document = AaakDocument::parse(output.trim()).expect("parse aaak wake-up output");
+    let decoded = AaakCodec::default().decode(&document);
+
+    assert!(decoded.contains("Keep universal principles sparse."));
+    assert!(decoded.contains("Use cargo check as the Rust ground truth."));
+    for heading in ["## dao_tian", "## dao_ren", "## shu", "## qi"] {
+        assert!(
+            !decoded.contains(heading),
+            "AAAK wake-up must not assemble typed context section {heading}"
+        );
+    }
+}
+
+#[test]
 fn test_wake_up_preserves_existing_top_drawer_order() {
     let (tmp, db) = setup_cli_home();
     let highest = Drawer {


### PR DESCRIPTION
## Summary

- Define P29 wake-up/context boundary spec and implementation plan.
- Update MEMORY_PROTOCOL and docs so agents use wake-up for L0/L1 refresh and `mempal_context` for typed `dao_tian -> dao_ren -> shu -> qi` guidance.
- Add regression tests proving plain and AAAK wake-up do not assemble typed mind-model sections.

## Verification

- `agent-spec parse specs/p29-wake-up-context-boundary.spec.md`
- `agent-spec lint specs/p29-wake-up-context-boundary.spec.md --min-score 0.7`
- `cargo fmt --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
