### PR TITLE
docs: define knowledge card storage boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p27-knowledge-policy-surface.spec.md` | 完成 | `mempal knowledge policy` / `mempal_knowledge_policy`：只读 Stage-1 promotion policy 阈值表 |
 | `specs/p28-field-taxonomy-surface.spec.md` | 完成 | `mempal field-taxonomy` / `mempal_field_taxonomy`：只读 Stage-1 field taxonomy guidance |
 | `specs/p29-wake-up-context-boundary.spec.md` | 完成 | 固化 wake-up 与 mind-model context 边界：wake-up 保持 L0/L1 refresh，typed `dao/shu/qi` 组装只属于 `mempal context` / `mempal_context` |
+| `specs/p30-knowledge-card-storage-boundary.spec.md` | 完成 | 固化 Phase-2 knowledge card 存储边界：未来 `knowledge_cards` 使用同一个 SQLite `palace.db` 的独立表，不拆外部 persistence layer |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -114,6 +115,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md` — P27 knowledge policy surface（已完成）
 - `docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md` — P28 field taxonomy surface（已完成）
 - `docs/plans/2026-04-26-p29-wake-up-context-boundary-implementation.md` — P29 wake-up/context boundary（已完成）
+- `docs/plans/2026-04-27-p30-knowledge-card-storage-boundary-implementation.md` — P30 knowledge card storage boundary（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p27-knowledge-policy-surface.spec.md` | 完成 | `mempal knowledge policy` / `mempal_knowledge_policy`：只读 Stage-1 promotion policy 阈值表 |
 | `specs/p28-field-taxonomy-surface.spec.md` | 完成 | `mempal field-taxonomy` / `mempal_field_taxonomy`：只读 Stage-1 field taxonomy guidance |
 | `specs/p29-wake-up-context-boundary.spec.md` | 完成 | 固化 wake-up 与 mind-model context 边界：wake-up 保持 L0/L1 refresh，typed `dao/shu/qi` 组装只属于 `mempal context` / `mempal_context` |
+| `specs/p30-knowledge-card-storage-boundary.spec.md` | 完成 | 固化 Phase-2 knowledge card 存储边界：未来 `knowledge_cards` 使用同一个 SQLite `palace.db` 的独立表，不拆外部 persistence layer |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -112,6 +113,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p27-knowledge-policy-surface-implementation.md` — P27 knowledge policy surface（已完成）
 - `docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md` — P28 field taxonomy surface（已完成）
 - `docs/plans/2026-04-26-p29-wake-up-context-boundary-implementation.md` — P29 wake-up/context boundary（已完成）
+- `docs/plans/2026-04-27-p30-knowledge-card-storage-boundary-implementation.md` — P30 knowledge card storage boundary（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -864,6 +864,25 @@ This yields a cleaner separation:
 - knowledge says what is believed
 - events say how that belief evolved
 
+Storage decision:
+
+- Phase-2 `knowledge_cards` should live in the same SQLite `palace.db`
+- they should be separate tables from `drawers`, not overloaded drawer rows
+- `drawers` remain the raw evidence and citation root
+- `knowledge_evidence_links` should reference evidence drawers by `drawer_id`
+- `knowledge_events` should be transactional with knowledge-card lifecycle
+  changes and evidence-link mutations
+- a separate persistence layer is out of scope unless future measured needs
+  prove the single-file SQLite boundary insufficient
+
+Rationale:
+
+- mempal's product invariant is a local single-binary, single-file memory palace
+- knowledge promotion/demotion must stay transactionally tied to evidence refs
+- citations remain simpler and safer when evidence drawer ids are the durable root
+- using a second database or service would add operational complexity before the
+  Phase-2 model has proven it needs independent scaling
+
 ## Decision on Bootstrap vs Final Architecture
 
 Current recommendation:
@@ -910,12 +929,6 @@ This design does not assume:
 - replacing raw evidence with compressed knowledge
 - collapsing evidence, knowledge, and workflow into one storage object forever
 
-## Open Questions
-
-The following remain open and should be resolved in later design work:
-
-1. When Phase 2 begins, should knowledge cards live in the same DB or a separate persistence layer?
-
 ## Current Recommendation
 
 Proceed with the following assumptions unless future evidence rejects them:
@@ -925,7 +938,8 @@ Proceed with the following assumptions unless future evidence rejects them:
 - evidence memory and knowledge memory should be explicitly separated
 - runtime typed context should assemble `dao` before `shu`, and `shu` before
   `qi`; wake-up remains a refresh surface, not the typed assembler
-- the implementation should begin with drawer bootstrap and evolve into a dedicated knowledge model
+- the implementation should begin with drawer bootstrap and evolve into a
+  dedicated knowledge model inside the same SQLite `palace.db`
 
 ## Closing Summary
 

--- a/docs/plans/2026-04-27-p30-knowledge-card-storage-boundary-implementation.md
+++ b/docs/plans/2026-04-27-p30-knowledge-card-storage-boundary-implementation.md
@@ -1,0 +1,29 @@
+# P30 Knowledge Card Storage Boundary Implementation Plan
+
+**Goal:** Resolve the last MIND-MODEL-DESIGN open question: Phase-2
+`knowledge_cards` should live in the same SQLite `palace.db`, but in separate
+tables from evidence drawers.
+
+**Architecture:** This is a design-boundary task only. Update specs and docs so
+future implementation has a fixed persistence decision, while explicitly keeping
+Phase-2 schema, migrations, and runtime surfaces out of scope.
+
+## Steps
+
+- [x] Validate task contract with `agent-spec parse/lint`.
+- [x] Update MIND-MODEL-DESIGN Phase-2 storage decision.
+- [x] Remove the resolved Open Questions section.
+- [x] Update usage docs and repository agent inventories.
+- [x] Verify no Phase-2 schema/runtime implementation was introduced.
+
+## Verification
+
+```bash
+agent-spec parse specs/p30-knowledge-card-storage-boundary.spec.md
+agent-spec lint specs/p30-knowledge-card-storage-boundary.spec.md --min-score 0.7
+rg -n "same SQLite .*palace.db|knowledge_cards.*same SQLite" docs/MIND-MODEL-DESIGN.md
+! rg -n "^## Open Questions|should knowledge cards live" docs/MIND-MODEL-DESIGN.md
+rg -n "Phase-2 .*same SQLite palace.db|not implemented" docs/usage.md
+rg -n "p30-knowledge-card-storage-boundary|P30 knowledge card storage boundary" AGENTS.md CLAUDE.md
+! rg -n "CREATE TABLE knowledge_cards|struct KnowledgeCard|mempal_knowledge_card" src tests
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -288,6 +288,11 @@ mempal knowledge demote drawer_knowledge \
 
 Lifecycle commands only update existing `memory_kind=knowledge` drawers. They validate that `--verification-ref` / `--evidence-ref` values start with `drawer_`, exist, and point to `memory_kind=evidence`. They do not change content, re-embed vectors, bump schema, or add Phase-2 `knowledge_cards`. Successful distill and lifecycle changes append JSONL audit entries.
 
+Phase-2 knowledge cards are not implemented yet. The design target is a future
+same SQLite palace.db table split: `drawers` remain the evidence/citation root,
+while `knowledge_cards`, `knowledge_evidence_links`, and `knowledge_events`
+become separate tables in the same database.
+
 ### 4. Search
 
 ```bash

--- a/specs/p30-knowledge-card-storage-boundary.spec.md
+++ b/specs/p30-knowledge-card-storage-boundary.spec.md
@@ -1,0 +1,80 @@
+spec: task
+name: "P30: Phase-2 knowledge card storage boundary"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, storage, design]
+---
+
+## Intent
+
+Phase 1 stores evidence and bootstrap knowledge in `drawers`. The remaining
+MIND-MODEL-DESIGN question is where Phase-2 `knowledge_cards` should live when
+knowledge is structurally separated from evidence. This task resolves the
+design boundary without implementing the Phase-2 schema.
+
+## Decisions
+
+- Phase-2 `knowledge_cards` will live in the same SQLite `palace.db`.
+- Phase-2 must use separate tables such as `knowledge_cards`,
+  `knowledge_evidence_links`, and `knowledge_events`.
+- `drawers` remain the evidence/raw-text store and citation root.
+- Knowledge cards reference evidence drawers by `drawer_id`; they do not copy
+  or replace evidence content.
+- Knowledge-card lifecycle events stay transactional with the evidence links
+  they modify.
+- Do not introduce a separate persistence layer unless a future measured need
+  proves the single-file SQLite boundary insufficient.
+- P30 is design-only: it does not add tables, migrations, CLI commands, MCP
+  tools, or REST APIs.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL-DESIGN records the storage decision
+  Test: docs_p30_mind_model_records_same_db_storage
+  Given the MIND-MODEL-DESIGN Phase-2 section
+  When running `rg -n "same SQLite .*palace.db|knowledge_cards.*same SQLite" docs/MIND-MODEL-DESIGN.md`
+  Then it states that Phase-2 knowledge cards live in the same SQLite palace.db
+  And it still keeps knowledge tables structurally separate from evidence drawers
+
+Scenario: MIND-MODEL-DESIGN has no remaining open questions
+  Test: docs_p30_mind_model_has_no_open_questions
+  Given the MIND-MODEL-DESIGN document
+  When running `! rg -n "^## Open Questions|should knowledge cards live" docs/MIND-MODEL-DESIGN.md`
+  Then no Open Questions section remains
+  And the previous knowledge-card storage question is not left unresolved
+
+Scenario: usage docs state Phase 2 is not implemented yet
+  Test: docs_p30_usage_states_phase2_not_implemented
+  Given the usage guide
+  When running `rg -n "Phase-2 .*same SQLite palace.db|not implemented" docs/usage.md`
+  Then it states that Phase-2 knowledge cards are a future same-DB table split
+  And it does not imply the Phase-2 tables already exist
+
+Scenario: task inventory marks P30 complete
+  Test: docs_p30_agent_inventories_mark_complete
+  Given repository agent instructions
+  When running `rg -n "p30-knowledge-card-storage-boundary|P30 knowledge card storage boundary" AGENTS.md CLAUDE.md`
+  Then P30 is listed as completed
+  And its plan is listed with the completed implementation plans
+
+Scenario: Phase-2 implementation remains out of scope
+  Test: docs_p30_no_phase2_runtime_surface_added
+  Given this design-only task
+  When running `! rg -n "CREATE TABLE knowledge_cards|struct KnowledgeCard|mempal_knowledge_card" src tests`
+  Then no Phase-2 knowledge card schema or runtime surface has been added
+
+## Out of Scope
+
+- Do not add schema migrations.
+- Do not create `knowledge_cards`, `knowledge_evidence_links`, or
+  `knowledge_events` tables yet.
+- Do not add `KnowledgeCard` Rust types.
+- Do not add CLI, MCP, or REST surfaces for knowledge cards.
+- Do not migrate existing knowledge drawers.
+- Do not change context assembly, wake-up, search, ranking, or promotion gates.
+- Do not split persistence into a second database or external service.
+
+## Constraints
+
+- Preserve the single-binary, single-file local memory model.
+- Preserve raw evidence citations through existing drawer ids.
+- Treat same-DB Phase 2 as a future schema evolution, not a P30 implementation.


### PR DESCRIPTION
## Summary

- Resolve the final `docs/MIND-MODEL-DESIGN.md` open question.
- Decide Phase-2 `knowledge_cards` live as separate tables inside the same SQLite `palace.db`.
- Keep P30 design-only: no schema, runtime surface, CLI/MCP/REST command, or migration is added.

## Verification

- `agent-spec parse specs/p30-knowledge-card-storage-boundary.spec.md`
- `agent-spec lint specs/p30-knowledge-card-storage-boundary.spec.md --min-score 0.7`
- `rg -n "same SQLite .*palace.db|knowledge_cards.*same SQLite" docs/MIND-MODEL-DESIGN.md`
- `rg -n "^## Open Questions|should knowledge cards live" docs/MIND-MODEL-DESIGN.md` returns no matches
- `rg -n "Phase-2 .*same SQLite palace.db|not implemented" docs/usage.md`
- `rg -n "p30-knowledge-card-storage-boundary|P30 knowledge card storage boundary" AGENTS.md CLAUDE.md`
- `rg -n "CREATE TABLE knowledge_cards|struct KnowledgeCard|mempal_knowledge_card" src tests` returns no matches
