### PR TITLE
feat: add knowledge card schema v8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,12 +77,12 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p28-field-taxonomy-surface.spec.md` | 完成 | `mempal field-taxonomy` / `mempal_field_taxonomy`：只读 Stage-1 field taxonomy guidance |
 | `specs/p29-wake-up-context-boundary.spec.md` | 完成 | 固化 wake-up 与 mind-model context 边界：wake-up 保持 L0/L1 refresh，typed `dao/shu/qi` 组装只属于 `mempal context` / `mempal_context` |
 | `specs/p30-knowledge-card-storage-boundary.spec.md` | 完成 | 固化 Phase-2 knowledge card 存储边界：未来 `knowledge_cards` 使用同一个 SQLite `palace.db` 的独立表，不拆外部 persistence layer |
+| `specs/p31-knowledge-card-schema.spec.md` | 完成 | schema v8 Phase-2 `knowledge_cards` / `knowledge_evidence_links` / `knowledge_events` 最小 schema contract |
+| `specs/p32-knowledge-card-schema-v8.spec.md` | 完成 | schema v8 migration：新增 Phase-2 knowledge card 三表、约束、索引、append-only events |
 
 ### 当前 Spec（草稿，未实现）
 
-| Spec | 范围 |
-|------|------|
-| `specs/p31-knowledge-card-schema.spec.md` | schema v8 Phase-2 `knowledge_cards` / `knowledge_evidence_links` / `knowledge_events` 最小 schema contract；当前仅 spec，未实现 migration |
+暂无。
 
 ### 实现计划
 
@@ -118,7 +118,8 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md` — P28 field taxonomy surface（已完成）
 - `docs/plans/2026-04-26-p29-wake-up-context-boundary-implementation.md` — P29 wake-up/context boundary（已完成）
 - `docs/plans/2026-04-27-p30-knowledge-card-storage-boundary-implementation.md` — P30 knowledge card storage boundary（已完成）
-- `docs/plans/2026-04-27-p31-knowledge-card-schema-spec.md` — P31 knowledge card schema spec（草稿，未实现）
+- `docs/plans/2026-04-27-p31-knowledge-card-schema-spec.md` — P31 knowledge card schema spec（已完成）
+- `docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md` — P32 knowledge card schema v8（已完成）
 
 ### Spec 使用方式
 
@@ -129,7 +130,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 
 ## 关键架构约束
 
-- **存储**：SQLite + sqlite-vec，单文件 `~/.mempal/palace.db`，schema v4
+- **存储**：SQLite + sqlite-vec，单文件 `~/.mempal/palace.db`，schema v8
 - **嵌入**：model2vec-rs 默认（potion-multilingual-128M, 256d），可选 ort (ONNX) 通过 `onnx` feature flag
 - **搜索**：BM25 (FTS5) + 向量 + RRF 融合混合检索
 - **AAAK 是输出格式化器**：不被 ingest 或 search 依赖
@@ -184,7 +185,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 
 ```
 crates/
-├── mempal-core/      # 数据模型 + SQLite schema v4 + taxonomy + triples
+├── mempal-core/      # 数据模型 + SQLite schema v8 + taxonomy + triples
 ├── mempal-ingest/    # 导入管道
 ├── mempal-search/    # 混合搜索（BM25+向量+RRF）+ 路由 + tunnel hints
 ├── mempal-embed/     # 嵌入层（model2vec 默认, ort 可选）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,12 +75,12 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p28-field-taxonomy-surface.spec.md` | 完成 | `mempal field-taxonomy` / `mempal_field_taxonomy`：只读 Stage-1 field taxonomy guidance |
 | `specs/p29-wake-up-context-boundary.spec.md` | 完成 | 固化 wake-up 与 mind-model context 边界：wake-up 保持 L0/L1 refresh，typed `dao/shu/qi` 组装只属于 `mempal context` / `mempal_context` |
 | `specs/p30-knowledge-card-storage-boundary.spec.md` | 完成 | 固化 Phase-2 knowledge card 存储边界：未来 `knowledge_cards` 使用同一个 SQLite `palace.db` 的独立表，不拆外部 persistence layer |
+| `specs/p31-knowledge-card-schema.spec.md` | 完成 | schema v8 Phase-2 `knowledge_cards` / `knowledge_evidence_links` / `knowledge_events` 最小 schema contract |
+| `specs/p32-knowledge-card-schema-v8.spec.md` | 完成 | schema v8 migration：新增 Phase-2 knowledge card 三表、约束、索引、append-only events |
 
 ### 当前 Spec（草稿，未实现）
 
-| Spec | 范围 |
-|------|------|
-| `specs/p31-knowledge-card-schema.spec.md` | schema v8 Phase-2 `knowledge_cards` / `knowledge_evidence_links` / `knowledge_events` 最小 schema contract；当前仅 spec，未实现 migration |
+暂无。
 
 ### 实现计划
 
@@ -116,7 +116,8 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-26-p28-field-taxonomy-surface-implementation.md` — P28 field taxonomy surface（已完成）
 - `docs/plans/2026-04-26-p29-wake-up-context-boundary-implementation.md` — P29 wake-up/context boundary（已完成）
 - `docs/plans/2026-04-27-p30-knowledge-card-storage-boundary-implementation.md` — P30 knowledge card storage boundary（已完成）
-- `docs/plans/2026-04-27-p31-knowledge-card-schema-spec.md` — P31 knowledge card schema spec（草稿，未实现）
+- `docs/plans/2026-04-27-p31-knowledge-card-schema-spec.md` — P31 knowledge card schema spec（已完成）
+- `docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md` — P32 knowledge card schema v8（已完成）
 
 ### Spec 使用方式
 
@@ -127,7 +128,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 
 ## 关键架构约束
 
-- **存储**：SQLite + sqlite-vec，单文件 `~/.mempal/palace.db`，schema v4
+- **存储**：SQLite + sqlite-vec，单文件 `~/.mempal/palace.db`，schema v8
 - **嵌入**：model2vec-rs 默认（potion-multilingual-128M, 256d），可选 ort (ONNX) 通过 `onnx` feature flag
 - **搜索**：BM25 (FTS5) + 向量 + RRF 融合混合检索
 - **AAAK 是输出格式化器**：不被 ingest 或 search 依赖
@@ -182,7 +183,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 
 ```
 crates/
-├── mempal-core/      # 数据模型 + SQLite schema v4 + taxonomy + triples
+├── mempal-core/      # 数据模型 + SQLite schema v8 + taxonomy + triples
 ├── mempal-ingest/    # 导入管道
 ├── mempal-search/    # 混合搜索（BM25+向量+RRF）+ 路由 + tunnel hints
 ├── mempal-embed/     # 嵌入层（model2vec 默认, ort 可选）

--- a/docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md
+++ b/docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md
@@ -1,0 +1,31 @@
+# P32 Knowledge Card Schema v8 Implementation Plan
+
+**Goal:** Implement the Phase-2 schema contract from P31 as SQLite schema v8.
+
+**Architecture:** Add a single additive migration in `src/core/db.rs` that
+creates `knowledge_cards`, `knowledge_evidence_links`, and `knowledge_events`,
+with constraints, indexes, foreign keys, and append-only event triggers. Add
+integration tests that exercise the schema directly through raw SQL. Do not add
+runtime APIs yet.
+
+## Steps
+
+- [x] Add P32 task contract.
+- [x] Bump current schema version to 8.
+- [x] Enable SQLite foreign-key enforcement on opened DB connections.
+- [x] Add v8 migration SQL for the three knowledge card tables.
+- [x] Add schema v8 integration tests.
+- [x] Update AGENTS / CLAUDE inventories and current schema notes.
+- [x] Run formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p32-knowledge-card-schema-v8.spec.md
+agent-spec lint specs/p32-knowledge-card-schema-v8.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -288,10 +288,10 @@ mempal knowledge demote drawer_knowledge \
 
 Lifecycle commands only update existing `memory_kind=knowledge` drawers. They validate that `--verification-ref` / `--evidence-ref` values start with `drawer_`, exist, and point to `memory_kind=evidence`. They do not change content, re-embed vectors, bump schema, or add Phase-2 `knowledge_cards`. Successful distill and lifecycle changes append JSONL audit entries.
 
-Phase-2 knowledge cards are not implemented yet. The design target is a future
-same SQLite palace.db table split: `drawers` remain the evidence/citation root,
-while `knowledge_cards`, `knowledge_evidence_links`, and `knowledge_events`
-become separate tables in the same database.
+Phase-2 knowledge card tables exist in schema v8, but user-facing card runtime
+APIs are not implemented yet. `drawers` remain the active evidence/citation
+root, while `knowledge_cards`, `knowledge_evidence_links`, and
+`knowledge_events` are reserved for the Phase-2 runtime.
 
 ### 4. Search
 

--- a/specs/p32-knowledge-card-schema-v8.spec.md
+++ b/specs/p32-knowledge-card-schema-v8.spec.md
@@ -1,0 +1,122 @@
+spec: task
+name: "P32: implement Phase-2 knowledge card schema v8"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, schema, migration]
+---
+
+## Intent
+
+P31 defined the Phase-2 knowledge card schema contract. P32 implements that
+contract as schema v8 by adding `knowledge_cards`, `knowledge_evidence_links`,
+and `knowledge_events` tables to the existing SQLite `palace.db`.
+
+## Decisions
+
+- Bump `CURRENT_SCHEMA_VERSION` from 7 to 8.
+- Add a v8 migration that creates `knowledge_cards`,
+  `knowledge_evidence_links`, and `knowledge_events`.
+- Keep the migration additive and backward-compatible: existing drawers,
+  triples, tunnels, vectors, and taxonomy rows must be preserved.
+- Enable SQLite foreign-key enforcement on every `Database::open` connection.
+- `knowledge_evidence_links.evidence_drawer_id` references `drawers(id)`.
+- `knowledge_evidence_links.card_id` and `knowledge_events.card_id` reference
+  `knowledge_cards(id)`.
+- Enforce `UNIQUE(card_id, evidence_drawer_id, role)` on evidence links.
+- Enforce CHECK constraints for tier, status, domain, anchor_kind, link role,
+  and event_type.
+- Keep `knowledge_events` append-only by rejecting UPDATE and DELETE through
+  triggers.
+- Do not add Rust `KnowledgeCard` domain structs yet.
+- Do not add CLI, MCP, or REST surfaces yet.
+- Do not migrate existing `memory_kind=knowledge` drawers into cards yet.
+
+## Acceptance Criteria
+
+Scenario: current databases open at schema v8
+  Test:
+    Package: mempal
+    Filter: test_new_database_schema_version_is_8
+  Given a new palace database
+  When opening it through `Database::open`
+  Then `schema_version == 8`
+  And all three knowledge card tables exist
+
+Scenario: v7 database migrates to v8 without data loss
+  Test:
+    Package: mempal
+    Filter: test_migration_v7_to_v8_adds_knowledge_card_tables_without_data_loss
+  Given a schema v7 palace with existing drawers, triples, taxonomy, and tunnels
+  When opening it through `Database::open`
+  Then `schema_version == 8`
+  And the existing row counts are unchanged
+  And all three knowledge card tables are empty
+
+Scenario: knowledge_cards enforce enum checks
+  Test:
+    Package: mempal
+    Filter: test_knowledge_cards_reject_invalid_tier_status_domain_anchor
+  Given schema v8
+  When inserting a knowledge card with invalid tier, status, domain, or anchor_kind
+  Then SQLite rejects the row through CHECK constraints
+
+Scenario: evidence links enforce drawer foreign keys and role checks
+  Test:
+    Package: mempal
+    Filter: test_knowledge_evidence_links_reject_invalid_role_and_missing_drawer
+  Given schema v8 with one card and no matching evidence drawer
+  When inserting an evidence link with `role='invalid_role'`
+  Then SQLite rejects the row through a CHECK constraint
+  When inserting an evidence link to a missing `evidence_drawer_id`
+  Then SQLite rejects the row through a foreign-key constraint
+
+Scenario: evidence links deduplicate per role
+  Test:
+    Package: mempal
+    Filter: test_knowledge_evidence_links_dedup_card_drawer_role
+  Given schema v8 with one card and one evidence drawer
+  When inserting the same `(card_id, evidence_drawer_id, role)` twice
+  Then the second insert fails through a UNIQUE constraint
+
+Scenario: events enforce event type and card foreign key
+  Test:
+    Package: mempal
+    Filter: test_knowledge_events_reject_invalid_type_and_missing_card
+  Given schema v8
+  When inserting an event with `event_type='invalid_event'`
+  Then SQLite rejects the row through a CHECK constraint
+  When inserting an event for a missing card
+  Then SQLite rejects the row through a foreign-key constraint
+
+Scenario: knowledge events are append-only
+  Test:
+    Package: mempal
+    Filter: test_knowledge_events_are_append_only
+  Given schema v8 with one card and one event
+  When updating or deleting the event row
+  Then SQLite rejects both mutations
+
+Scenario: indexes exist for Phase-2 query paths
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_schema_indexes_exist
+  Given schema v8
+  When inspecting sqlite indexes
+  Then card tier/status, domain/field, and anchor indexes exist
+  And evidence link card/evidence indexes exist
+  And event card/created_at index exists
+
+## Out of Scope
+
+- Do not add DB CRUD APIs beyond migration support.
+- Do not add Rust domain structs for knowledge cards.
+- Do not add CLI commands.
+- Do not add MCP tools.
+- Do not add REST endpoints.
+- Do not change search, context, wake-up, lifecycle, or promotion-gate behavior.
+- Do not backfill existing knowledge drawers into cards.
+
+## Constraints
+
+- Existing schemas v1-v7 must still migrate atomically to the latest version.
+- The v8 migration must be additive and must not rewrite existing drawer rows.
+- Foreign keys must be enforced for `Database::open` connections.

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -15,7 +15,7 @@ use super::types::{
 };
 use super::utils::{build_tunnel_id, current_timestamp, format_tunnel_endpoint};
 
-const CURRENT_SCHEMA_VERSION: u32 = 7;
+const CURRENT_SCHEMA_VERSION: u32 = 8;
 const DRAWER_SELECT_COLUMNS: &str = r#"
     id,
     content,
@@ -142,6 +142,7 @@ impl Database {
         register_sqlite_vec()?;
 
         let conn = Connection::open(path)?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
         apply_migrations(&conn)?;
 
         Ok(Self {
@@ -1465,6 +1466,80 @@ CREATE INDEX IF NOT EXISTS idx_drawers_normalize_version
     WHERE deleted_at IS NULL;
 "#;
 
+const V8_MIGRATION_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS knowledge_cards (
+    id TEXT PRIMARY KEY,
+    statement TEXT NOT NULL,
+    content TEXT NOT NULL,
+    tier TEXT NOT NULL CHECK(tier IN ('qi', 'shu', 'dao_ren', 'dao_tian')),
+    status TEXT NOT NULL CHECK(status IN ('candidate', 'promoted', 'canonical', 'demoted', 'retired')),
+    domain TEXT NOT NULL CHECK(domain IN ('project', 'agent', 'skill', 'global')),
+    field TEXT NOT NULL DEFAULT 'general',
+    anchor_kind TEXT NOT NULL CHECK(anchor_kind IN ('global', 'repo', 'worktree')),
+    anchor_id TEXT NOT NULL,
+    parent_anchor_id TEXT,
+    scope_constraints TEXT,
+    trigger_hints TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS knowledge_evidence_links (
+    id TEXT PRIMARY KEY,
+    card_id TEXT NOT NULL,
+    evidence_drawer_id TEXT NOT NULL,
+    role TEXT NOT NULL CHECK(role IN ('supporting', 'verification', 'counterexample', 'teaching')),
+    note TEXT,
+    created_at TEXT NOT NULL,
+    UNIQUE(card_id, evidence_drawer_id, role),
+    FOREIGN KEY(card_id) REFERENCES knowledge_cards(id) ON DELETE RESTRICT,
+    FOREIGN KEY(evidence_drawer_id) REFERENCES drawers(id) ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS knowledge_events (
+    id TEXT PRIMARY KEY,
+    card_id TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK(event_type IN ('created', 'promoted', 'demoted', 'retired', 'linked', 'unlinked', 'updated', 'published_anchor')),
+    from_status TEXT,
+    to_status TEXT,
+    reason TEXT NOT NULL,
+    actor TEXT,
+    metadata TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(card_id) REFERENCES knowledge_cards(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_cards_tier_status
+    ON knowledge_cards(tier, status);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_cards_domain_field
+    ON knowledge_cards(domain, field);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_cards_anchor
+    ON knowledge_cards(anchor_kind, anchor_id);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_evidence_links_card
+    ON knowledge_evidence_links(card_id);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_evidence_links_evidence
+    ON knowledge_evidence_links(evidence_drawer_id);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_events_card_created_at
+    ON knowledge_events(card_id, created_at);
+
+CREATE TRIGGER IF NOT EXISTS knowledge_events_no_update
+BEFORE UPDATE ON knowledge_events
+BEGIN
+    SELECT RAISE(ABORT, 'knowledge_events are append-only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS knowledge_events_no_delete
+BEFORE DELETE ON knowledge_events
+BEGIN
+    SELECT RAISE(ABORT, 'knowledge_events are append-only');
+END;
+"#;
+
 fn migrations() -> &'static [Migration] {
     static MIGRATIONS: &[Migration] = &[
         Migration {
@@ -1494,6 +1569,10 @@ fn migrations() -> &'static [Migration] {
         Migration {
             version: 7,
             sql: V7_MIGRATION_SQL,
+        },
+        Migration {
+            version: 8,
+            sql: V8_MIGRATION_SQL,
         },
     ];
     MIGRATIONS

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -488,6 +488,6 @@ mod tests {
         let tempdir = tempfile::tempdir().expect("create temp dir");
         let db_path = tempdir.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
-        assert_eq!(db.schema_version().expect("schema version"), 7);
+        assert_eq!(db.schema_version().expect("schema version"), 8);
     }
 }

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -783,10 +783,10 @@ async fn test_context_assembler_returns_typed_pack() {
 #[test]
 fn test_context_assembler_does_not_bump_schema() {
     let (tmp, db) = setup_cli_home();
-    assert_eq!(db.schema_version().expect("schema"), 7);
+    assert_eq!(db.schema_version().expect("schema"), 8);
     let before_tables = table_names(&db);
     let _ = run_context_plain(tmp.path(), "debug", &[]);
-    assert_eq!(db.schema_version().expect("schema"), 7);
+    assert_eq!(db.schema_version().expect("schema"), 8);
     assert_eq!(table_names(&db), before_tables);
 }
 

--- a/tests/knowledge_card_schema.rs
+++ b/tests/knowledge_card_schema.rs
@@ -1,0 +1,431 @@
+use mempal::core::db::Database;
+use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+fn new_db() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    (tmp, db)
+}
+
+fn create_v7_db(path: &std::path::Path) {
+    let conn = Connection::open(path).expect("open v7 db");
+    conn.execute_batch(
+        r#"
+        PRAGMA foreign_keys = ON;
+
+        CREATE TABLE drawers (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            wing TEXT NOT NULL,
+            room TEXT,
+            source_file TEXT,
+            source_type TEXT NOT NULL CHECK(source_type IN ('project', 'conversation', 'manual')),
+            added_at TEXT NOT NULL,
+            chunk_index INTEGER,
+            deleted_at TEXT,
+            importance INTEGER DEFAULT 0,
+            memory_kind TEXT NOT NULL CHECK(memory_kind IN ('evidence', 'knowledge')) DEFAULT 'evidence',
+            domain TEXT NOT NULL CHECK(domain IN ('project', 'agent', 'skill', 'global')) DEFAULT 'project',
+            field TEXT NOT NULL DEFAULT 'general',
+            anchor_kind TEXT NOT NULL CHECK(anchor_kind IN ('global', 'repo', 'worktree')) DEFAULT 'repo',
+            anchor_id TEXT NOT NULL DEFAULT 'repo://legacy',
+            parent_anchor_id TEXT,
+            provenance TEXT CHECK(provenance IN ('runtime', 'research', 'human')),
+            statement TEXT,
+            tier TEXT CHECK(tier IN ('qi', 'shu', 'dao_ren', 'dao_tian')),
+            status TEXT CHECK(status IN ('candidate', 'promoted', 'canonical', 'demoted', 'retired')),
+            supporting_refs TEXT NOT NULL DEFAULT '[]',
+            counterexample_refs TEXT NOT NULL DEFAULT '[]',
+            teaching_refs TEXT NOT NULL DEFAULT '[]',
+            verification_refs TEXT NOT NULL DEFAULT '[]',
+            scope_constraints TEXT,
+            trigger_hints TEXT,
+            normalize_version INTEGER NOT NULL DEFAULT 1
+        );
+
+        CREATE TABLE triples (
+            id TEXT PRIMARY KEY,
+            subject TEXT NOT NULL,
+            predicate TEXT NOT NULL,
+            object TEXT NOT NULL,
+            valid_from TEXT,
+            valid_to TEXT,
+            confidence REAL DEFAULT 1.0,
+            source_drawer TEXT REFERENCES drawers(id)
+        );
+
+        CREATE TABLE taxonomy (
+            wing TEXT NOT NULL,
+            room TEXT NOT NULL DEFAULT '',
+            display_name TEXT,
+            keywords TEXT,
+            PRIMARY KEY (wing, room)
+        );
+
+        CREATE TABLE tunnels (
+            id TEXT PRIMARY KEY,
+            left_wing TEXT NOT NULL,
+            left_room TEXT,
+            right_wing TEXT NOT NULL,
+            right_room TEXT,
+            label TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            created_by TEXT,
+            deleted_at TEXT
+        );
+
+        INSERT INTO drawers (
+            id,
+            content,
+            wing,
+            room,
+            source_file,
+            source_type,
+            added_at,
+            chunk_index,
+            importance,
+            provenance
+        )
+        VALUES (
+            'drawer_ev_001',
+            'existing evidence',
+            'mempal',
+            'phase2',
+            'tests://evidence',
+            'manual',
+            '1710000000',
+            0,
+            3,
+            'human'
+        );
+
+        INSERT INTO triples (id, subject, predicate, object, source_drawer)
+        VALUES ('triple_001', 'mempal', 'has_phase', 'phase2', 'drawer_ev_001');
+
+        INSERT INTO taxonomy (wing, room, display_name, keywords)
+        VALUES ('mempal', 'phase2', 'Phase 2', '["knowledge"]');
+
+        INSERT INTO tunnels (
+            id,
+            left_wing,
+            left_room,
+            right_wing,
+            right_room,
+            label,
+            created_at
+        )
+        VALUES (
+            'tunnel_001',
+            'mempal',
+            'phase2',
+            'mempal',
+            'bootstrap',
+            'phase links',
+            '1710000000'
+        );
+
+        PRAGMA user_version = 7;
+        "#,
+    )
+    .expect("create v7 db");
+}
+
+fn table_exists(db: &Database, table: &str) -> bool {
+    db.conn()
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1)",
+            [table],
+            |row| row.get::<_, bool>(0),
+        )
+        .expect("query table existence")
+}
+
+fn index_exists(db: &Database, index: &str) -> bool {
+    db.conn()
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='index' AND name=?1)",
+            [index],
+            |row| row.get::<_, bool>(0),
+        )
+        .expect("query index existence")
+}
+
+fn insert_evidence_drawer(db: &Database, id: &str) {
+    db.insert_drawer(&Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: id.to_string(),
+        content: "evidence body".to_string(),
+        wing: "mempal".to_string(),
+        room: Some("phase2".to_string()),
+        source_file: Some("tests://evidence".to_string()),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    }))
+    .expect("insert evidence drawer");
+}
+
+fn insert_card(db: &Database, id: &str) {
+    insert_card_with(db, id, "shu", "promoted", "project", "repo").expect("insert card");
+}
+
+fn insert_card_with(
+    db: &Database,
+    id: &str,
+    tier: &str,
+    status: &str,
+    domain: &str,
+    anchor_kind: &str,
+) -> rusqlite::Result<usize> {
+    db.conn().execute(
+        r#"
+        INSERT INTO knowledge_cards (
+            id,
+            statement,
+            content,
+            tier,
+            status,
+            domain,
+            field,
+            anchor_kind,
+            anchor_id,
+            created_at,
+            updated_at
+        )
+        VALUES (?1, 'Use evidence before assertion.', 'Knowledge card body.', ?2, ?3, ?4, 'epistemics', ?5, 'repo://mempal', '1710000000', '1710000000')
+        "#,
+        params![id, tier, status, domain, anchor_kind],
+    )
+}
+
+fn insert_link(
+    db: &Database,
+    id: &str,
+    card_id: &str,
+    drawer_id: &str,
+    role: &str,
+) -> rusqlite::Result<usize> {
+    db.conn().execute(
+        r#"
+        INSERT INTO knowledge_evidence_links (
+            id,
+            card_id,
+            evidence_drawer_id,
+            role,
+            created_at
+        )
+        VALUES (?1, ?2, ?3, ?4, '1710000000')
+        "#,
+        params![id, card_id, drawer_id, role],
+    )
+}
+
+fn insert_event(
+    db: &Database,
+    id: &str,
+    card_id: &str,
+    event_type: &str,
+) -> rusqlite::Result<usize> {
+    db.conn().execute(
+        r#"
+        INSERT INTO knowledge_events (
+            id,
+            card_id,
+            event_type,
+            reason,
+            created_at
+        )
+        VALUES (?1, ?2, ?3, 'because evidence supports it', '1710000000')
+        "#,
+        params![id, card_id, event_type],
+    )
+}
+
+#[test]
+fn test_new_database_schema_version_is_8() {
+    let (_tmp, db) = new_db();
+
+    assert_eq!(db.schema_version().expect("schema version"), 8);
+    for table in [
+        "knowledge_cards",
+        "knowledge_evidence_links",
+        "knowledge_events",
+    ] {
+        assert!(table_exists(&db, table), "{table} should exist");
+    }
+}
+
+#[test]
+fn test_migration_v7_to_v8_adds_knowledge_card_tables_without_data_loss() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    create_v7_db(&db_path);
+
+    let db = Database::open(&db_path).expect("migrate v7 db");
+
+    assert_eq!(db.schema_version().expect("schema version"), 8);
+    assert_eq!(db.drawer_count().expect("drawer count"), 1);
+    assert_eq!(db.triple_count().expect("triple count"), 1);
+    let taxonomy_count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM taxonomy", [], |row| row.get(0))
+        .expect("taxonomy count");
+    assert_eq!(taxonomy_count, 1);
+    let tunnels_count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM tunnels", [], |row| row.get(0))
+        .expect("tunnels count");
+    assert_eq!(tunnels_count, 1);
+
+    for table in [
+        "knowledge_cards",
+        "knowledge_evidence_links",
+        "knowledge_events",
+    ] {
+        let count: i64 = db
+            .conn()
+            .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                row.get(0)
+            })
+            .expect("knowledge table count");
+        assert_eq!(count, 0, "{table} should start empty after migration");
+    }
+}
+
+#[test]
+fn test_knowledge_cards_reject_invalid_tier_status_domain_anchor() {
+    let (_tmp, db) = new_db();
+
+    assert!(insert_card_with(&db, "card_bad_tier", "bad", "promoted", "project", "repo").is_err());
+    assert!(insert_card_with(&db, "card_bad_status", "shu", "bad", "project", "repo").is_err());
+    assert!(insert_card_with(&db, "card_bad_domain", "shu", "promoted", "bad", "repo").is_err());
+    assert!(insert_card_with(&db, "card_bad_anchor", "shu", "promoted", "project", "bad").is_err());
+}
+
+#[test]
+fn test_knowledge_evidence_links_reject_invalid_role_and_missing_drawer() {
+    let (_tmp, db) = new_db();
+    insert_card(&db, "card_link_validation");
+
+    assert!(
+        insert_link(
+            &db,
+            "link_bad_role",
+            "card_link_validation",
+            "drawer_missing",
+            "invalid_role",
+        )
+        .is_err()
+    );
+    assert!(
+        insert_link(
+            &db,
+            "link_missing_drawer",
+            "card_link_validation",
+            "drawer_missing",
+            "supporting",
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn test_knowledge_evidence_links_dedup_card_drawer_role() {
+    let (_tmp, db) = new_db();
+    insert_card(&db, "card_dedup");
+    insert_evidence_drawer(&db, "drawer_ev_dedup");
+
+    insert_link(
+        &db,
+        "link_dedup_1",
+        "card_dedup",
+        "drawer_ev_dedup",
+        "supporting",
+    )
+    .expect("first link insert");
+    assert!(
+        insert_link(
+            &db,
+            "link_dedup_2",
+            "card_dedup",
+            "drawer_ev_dedup",
+            "supporting",
+        )
+        .is_err()
+    );
+    insert_link(
+        &db,
+        "link_dedup_verification",
+        "card_dedup",
+        "drawer_ev_dedup",
+        "verification",
+    )
+    .expect("different role is allowed");
+}
+
+#[test]
+fn test_knowledge_events_reject_invalid_type_and_missing_card() {
+    let (_tmp, db) = new_db();
+    insert_card(&db, "card_event_validation");
+
+    assert!(
+        insert_event(
+            &db,
+            "event_bad_type",
+            "card_event_validation",
+            "invalid_event"
+        )
+        .is_err()
+    );
+    assert!(insert_event(&db, "event_missing_card", "card_missing", "created").is_err());
+}
+
+#[test]
+fn test_knowledge_events_are_append_only() {
+    let (_tmp, db) = new_db();
+    insert_card(&db, "card_append_only");
+    insert_event(&db, "event_append_only", "card_append_only", "created").expect("insert event");
+
+    assert!(
+        db.conn()
+            .execute(
+                "UPDATE knowledge_events SET reason = 'mutated' WHERE id = 'event_append_only'",
+                [],
+            )
+            .is_err()
+    );
+    assert!(
+        db.conn()
+            .execute(
+                "DELETE FROM knowledge_events WHERE id = 'event_append_only'",
+                []
+            )
+            .is_err()
+    );
+    let count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM knowledge_events", [], |row| {
+            row.get(0)
+        })
+        .expect("event count");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn test_knowledge_card_schema_indexes_exist() {
+    let (_tmp, db) = new_db();
+
+    for index in [
+        "idx_knowledge_cards_tier_status",
+        "idx_knowledge_cards_domain_field",
+        "idx_knowledge_cards_anchor",
+        "idx_knowledge_evidence_links_card",
+        "idx_knowledge_evidence_links_evidence",
+        "idx_knowledge_events_card_created_at",
+    ] {
+        assert!(index_exists(&db, index), "{index} should exist");
+    }
+}

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -545,7 +545,7 @@ fn test_migration_backfills_legacy_drawers_with_bootstrap_defaults() {
     }
 
     let db = Database::open(&db_path).expect("migrate db to latest");
-    assert_eq!(db.schema_version().expect("schema version"), 7);
+    assert_eq!(db.schema_version().expect("schema version"), 8);
 
     let drawer = db
         .get_drawer("drawer_legacy_001")

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -245,7 +245,7 @@ fn test_migration_v6_to_v7_stamps_normalize_version_1() {
 
     let db = Database::open(&db_path).expect("migrate v6 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 7);
+    assert_eq!(db.schema_version().expect("schema version"), 8);
     assert_eq!(db.drawer_count().expect("drawer count"), 20);
     assert_eq!(count_normalize_version(&db, 1), 20);
 }

--- a/tests/search_neighbors.rs
+++ b/tests/search_neighbors.rs
@@ -291,7 +291,7 @@ async fn test_neighbors_limited_to_same_wing() {
 fn test_current_schema_has_chunk_index() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 7);
+    assert_eq!(db.schema_version().expect("schema version"), 8);
     let exists: bool = db
         .conn()
         .query_row(

--- a/tests/tunnels_explicit.rs
+++ b/tests/tunnels_explicit.rs
@@ -203,7 +203,7 @@ fn test_schema_v5_to_v6_migration_preserves_data() {
 
     let db = Database::open(&db_path).expect("migrate v5 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 7);
+    assert_eq!(db.schema_version().expect("schema version"), 8);
     assert_eq!(db.drawer_count().expect("drawer count"), 2);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let tunnels_count: i64 = db


### PR DESCRIPTION
## Summary

- Implements schema v8 for Phase-2 knowledge cards.
- Adds `knowledge_cards`, `knowledge_evidence_links`, and `knowledge_events` tables with CHECK constraints, foreign keys, indexes, and append-only event triggers.
- Enables SQLite foreign-key enforcement for `Database::open` connections.
- Adds direct schema integration tests and updates current schema docs/inventories.

## Scope

No CLI, MCP, REST, search, context, wake-up, lifecycle, or backfill runtime is added in this PR.

## Verification

- `agent-spec parse specs/p32-knowledge-card-schema-v8.spec.md`
- `agent-spec lint specs/p32-knowledge-card-schema-v8.spec.md --min-score 0.7`
- `cargo fmt --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
