### PR TITLE
feat: add knowledge card core api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p30-knowledge-card-storage-boundary.spec.md` | 完成 | 固化 Phase-2 knowledge card 存储边界：未来 `knowledge_cards` 使用同一个 SQLite `palace.db` 的独立表，不拆外部 persistence layer |
 | `specs/p31-knowledge-card-schema.spec.md` | 完成 | schema v8 Phase-2 `knowledge_cards` / `knowledge_evidence_links` / `knowledge_events` 最小 schema contract |
 | `specs/p32-knowledge-card-schema-v8.spec.md` | 完成 | schema v8 migration：新增 Phase-2 knowledge card 三表、约束、索引、append-only events |
+| `specs/p33-knowledge-card-core-api.spec.md` | 完成 | Phase-2 knowledge card DB core API：Rust types + card/link/event create/read/update/list，不暴露 CLI/MCP/REST |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -120,6 +121,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p30-knowledge-card-storage-boundary-implementation.md` — P30 knowledge card storage boundary（已完成）
 - `docs/plans/2026-04-27-p31-knowledge-card-schema-spec.md` — P31 knowledge card schema spec（已完成）
 - `docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md` — P32 knowledge card schema v8（已完成）
+- `docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md` — P33 knowledge card core API（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p30-knowledge-card-storage-boundary.spec.md` | 完成 | 固化 Phase-2 knowledge card 存储边界：未来 `knowledge_cards` 使用同一个 SQLite `palace.db` 的独立表，不拆外部 persistence layer |
 | `specs/p31-knowledge-card-schema.spec.md` | 完成 | schema v8 Phase-2 `knowledge_cards` / `knowledge_evidence_links` / `knowledge_events` 最小 schema contract |
 | `specs/p32-knowledge-card-schema-v8.spec.md` | 完成 | schema v8 migration：新增 Phase-2 knowledge card 三表、约束、索引、append-only events |
+| `specs/p33-knowledge-card-core-api.spec.md` | 完成 | Phase-2 knowledge card DB core API：Rust types + card/link/event create/read/update/list，不暴露 CLI/MCP/REST |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -118,6 +119,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p30-knowledge-card-storage-boundary-implementation.md` — P30 knowledge card storage boundary（已完成）
 - `docs/plans/2026-04-27-p31-knowledge-card-schema-spec.md` — P31 knowledge card schema spec（已完成）
 - `docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md` — P32 knowledge card schema v8（已完成）
+- `docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md` — P33 knowledge card core API（已完成）
 
 ### Spec 使用方式
 

--- a/docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md
+++ b/docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md
@@ -1,0 +1,31 @@
+# P33 Knowledge Card Core API Implementation Plan
+
+**Goal:** Add typed Rust structs and core `Database` APIs for schema v8
+knowledge cards, evidence links, and events without exposing a runtime surface.
+
+**Architecture:** Keep the implementation in `src/core/types.rs` and
+`src/core/db.rs`. Use existing enum vocabulary and SQLite constraints. Validate
+evidence links at the API layer so only active evidence drawers can be linked.
+
+## Steps
+
+- [x] Add P33 task contract.
+- [x] Add knowledge card / link / event Rust types.
+- [x] Add DB insert/get/list/update APIs for cards.
+- [x] Add DB link/list APIs for evidence links.
+- [x] Add DB append/list APIs for events.
+- [x] Add integration tests over the typed DB APIs.
+- [x] Update AGENTS / CLAUDE inventories.
+- [x] Run formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p33-knowledge-card-core-api.spec.md
+agent-spec lint specs/p33-knowledge-card-core-api.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p33-knowledge-card-core-api.spec.md
+++ b/specs/p33-knowledge-card-core-api.spec.md
@@ -1,0 +1,116 @@
+spec: task
+name: "P33: knowledge card core DB API"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, db-api, phase-2]
+---
+
+## Intent
+
+P32 added the schema v8 tables for Phase-2 knowledge cards. P33 adds the Rust
+domain types and core `Database` APIs needed to create, read, update, list, link
+evidence, and append events. This remains a DB-layer feature only; no CLI, MCP,
+REST, search, context, or backfill behavior is exposed yet.
+
+## Decisions
+
+- Add Rust types for `KnowledgeCard`, `KnowledgeEvidenceLink`, and
+  `KnowledgeCardEvent`.
+- Add enums for `KnowledgeEvidenceRole` and `KnowledgeEventType`.
+- Reuse existing `KnowledgeTier`, `KnowledgeStatus`, `MemoryDomain`,
+  `AnchorKind`, and `TriggerHints` types for card metadata.
+- Add `KnowledgeCardFilter` for read/list filtering.
+- Add `Database::insert_knowledge_card`.
+- Add `Database::get_knowledge_card`.
+- Add `Database::list_knowledge_cards`.
+- Add `Database::update_knowledge_card`.
+- Add `Database::insert_knowledge_evidence_link`.
+- Add `Database::knowledge_evidence_links`.
+- Add `Database::append_knowledge_event`.
+- Add `Database::knowledge_events`.
+- `insert_knowledge_evidence_link` must reject missing drawers and drawers whose
+  `memory_kind != evidence`.
+- `append_knowledge_event` appends rows only; existing schema triggers continue
+  to reject event update/delete.
+- Do not add delete APIs for cards or events in P33.
+- Do not add CLI, MCP, REST, search, context, wake-up, lifecycle, promotion gate,
+  or backfill behavior.
+
+## Acceptance Criteria
+
+Scenario: create and get knowledge card roundtrip
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_insert_get_roundtrip
+  Given schema v8
+  When inserting a `KnowledgeCard` through `Database::insert_knowledge_card`
+  Then `Database::get_knowledge_card` returns the same typed card
+  And trigger hints and optional metadata roundtrip
+
+Scenario: list knowledge cards supports filters
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_list_filters
+  Given schema v8 with cards across tier, status, domain, field, and anchor
+  When calling `Database::list_knowledge_cards` with each filter
+  Then only matching cards are returned
+
+Scenario: update knowledge card preserves identity
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_update_preserves_identity_and_created_at
+  Given an existing knowledge card
+  When updating statement, content, status, scope constraints, trigger hints, and updated_at
+  Then the card id and created_at remain unchanged
+  And the mutable fields are updated
+
+Scenario: evidence link validates evidence drawer kind
+  Test:
+    Package: mempal
+    Filter: test_knowledge_evidence_link_requires_evidence_drawer
+  Given one card, one evidence drawer, and one knowledge drawer
+  When linking the evidence drawer
+  Then the link succeeds
+  When linking the knowledge drawer or a missing drawer
+  Then the API rejects the link before storing it
+
+Scenario: evidence links list by card
+  Test:
+    Package: mempal
+    Filter: test_knowledge_evidence_links_list_by_card
+  Given two cards with evidence links
+  When listing links for one card
+  Then only that card's links are returned ordered by created_at and id
+
+Scenario: events append and list by card
+  Test:
+    Package: mempal
+    Filter: test_knowledge_events_append_and_list_by_card
+  Given two cards with events
+  When listing events for one card
+  Then only that card's events are returned ordered by created_at and id
+  And metadata roundtrips as JSON
+
+Scenario: no runtime surfaces are added
+  Test: docs_p33_no_runtime_surface_added
+  Given P33 is DB-layer only
+  When running `! rg -n "mempal_knowledge_card|KnowledgeCard" src/main.rs src/mcp src/api src/search`
+  Then no user-facing knowledge card runtime is exposed
+
+## Out of Scope
+
+- Do not add CLI commands.
+- Do not add MCP tools.
+- Do not add REST endpoints.
+- Do not change search result shape.
+- Do not change context assembly.
+- Do not change wake-up.
+- Do not migrate or backfill existing `memory_kind=knowledge` drawers.
+- Do not implement card deletion.
+- Do not make card APIs write the existing JSONL audit log.
+
+## Constraints
+
+- Keep the API close to the schema names; avoid premature abstraction.
+- Preserve raw evidence in `drawers`; cards only link to evidence drawer ids.
+- Keep event history append-only.
+- Keep the implementation inside `src/core` and tests; no runtime surface wiring.

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -9,9 +9,11 @@ use thiserror::Error;
 
 use super::anchor;
 use super::types::{
-    AnchorKind, ChunkNeighbors, Drawer, ExplicitTunnel, KnowledgeStatus, KnowledgeTier,
-    MemoryDomain, MemoryKind, NeighborChunk, Provenance, ReindexSource, SourceType, TaxonomyEntry,
-    Triple, TripleStats, TunnelEndpoint, TunnelFollowResult,
+    AnchorKind, ChunkNeighbors, Drawer, ExplicitTunnel, KnowledgeCard, KnowledgeCardEvent,
+    KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+    KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, NeighborChunk, Provenance,
+    ReindexSource, SourceType, TaxonomyEntry, Triple, TripleStats, TunnelEndpoint,
+    TunnelFollowResult,
 };
 use super::utils::{build_tunnel_id, current_timestamp, format_tunnel_endpoint};
 
@@ -726,6 +728,292 @@ impl Database {
             ],
         )?;
         Ok(affected > 0)
+    }
+
+    pub fn insert_knowledge_card(&self, card: &KnowledgeCard) -> Result<(), DbError> {
+        anchor::validate_anchor_domain(&card.domain, &card.anchor_kind)
+            .map_err(|message| DbError::InvalidDrawerMetadata(message.to_string()))?;
+
+        self.conn.execute(
+            r#"
+            INSERT INTO knowledge_cards (
+                id,
+                statement,
+                content,
+                tier,
+                status,
+                domain,
+                field,
+                anchor_kind,
+                anchor_id,
+                parent_anchor_id,
+                scope_constraints,
+                trigger_hints,
+                created_at,
+                updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+            "#,
+            params![
+                card.id.as_str(),
+                card.statement.as_str(),
+                card.content.as_str(),
+                knowledge_tier_as_str(&card.tier),
+                knowledge_status_as_str(&card.status),
+                memory_domain_as_str(&card.domain),
+                card.field.as_str(),
+                anchor_kind_as_str(&card.anchor_kind),
+                card.anchor_id.as_str(),
+                card.parent_anchor_id.as_deref(),
+                card.scope_constraints.as_deref(),
+                encode_optional_json(card.trigger_hints.as_ref())?,
+                card.created_at.as_str(),
+                card.updated_at.as_str(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_knowledge_card(&self, card_id: &str) -> Result<Option<KnowledgeCard>, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT
+                id,
+                statement,
+                content,
+                tier,
+                status,
+                domain,
+                field,
+                anchor_kind,
+                anchor_id,
+                parent_anchor_id,
+                scope_constraints,
+                trigger_hints,
+                created_at,
+                updated_at
+            FROM knowledge_cards
+            WHERE id = ?1
+            "#,
+        )?;
+        let mut rows = statement.query_map([card_id], |row| {
+            knowledge_card_from_row(row).map_err(row_decode_error)
+        })?;
+
+        match rows.next() {
+            Some(row) => Ok(Some(row?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn list_knowledge_cards(
+        &self,
+        filter: &KnowledgeCardFilter,
+    ) -> Result<Vec<KnowledgeCard>, DbError> {
+        let tier = filter.tier.as_ref().map(knowledge_tier_as_str);
+        let status = filter.status.as_ref().map(knowledge_status_as_str);
+        let domain = filter.domain.as_ref().map(memory_domain_as_str);
+        let anchor_kind = filter.anchor_kind.as_ref().map(anchor_kind_as_str);
+
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT
+                id,
+                statement,
+                content,
+                tier,
+                status,
+                domain,
+                field,
+                anchor_kind,
+                anchor_id,
+                parent_anchor_id,
+                scope_constraints,
+                trigger_hints,
+                created_at,
+                updated_at
+            FROM knowledge_cards
+            WHERE (?1 IS NULL OR tier = ?1)
+              AND (?2 IS NULL OR status = ?2)
+              AND (?3 IS NULL OR domain = ?3)
+              AND (?4 IS NULL OR field = ?4)
+              AND (?5 IS NULL OR anchor_kind = ?5)
+              AND (?6 IS NULL OR anchor_id = ?6)
+            ORDER BY tier, status, id
+            "#,
+        )?;
+        let rows = statement
+            .query_map(
+                params![
+                    tier,
+                    status,
+                    domain,
+                    filter.field.as_deref(),
+                    anchor_kind,
+                    filter.anchor_id.as_deref(),
+                ],
+                |row| knowledge_card_from_row(row).map_err(row_decode_error),
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    pub fn update_knowledge_card(&self, card: &KnowledgeCard) -> Result<bool, DbError> {
+        anchor::validate_anchor_domain(&card.domain, &card.anchor_kind)
+            .map_err(|message| DbError::InvalidDrawerMetadata(message.to_string()))?;
+
+        let affected = self.conn.execute(
+            r#"
+            UPDATE knowledge_cards
+            SET statement = ?2,
+                content = ?3,
+                tier = ?4,
+                status = ?5,
+                domain = ?6,
+                field = ?7,
+                anchor_kind = ?8,
+                anchor_id = ?9,
+                parent_anchor_id = ?10,
+                scope_constraints = ?11,
+                trigger_hints = ?12,
+                updated_at = ?13
+            WHERE id = ?1
+            "#,
+            params![
+                card.id.as_str(),
+                card.statement.as_str(),
+                card.content.as_str(),
+                knowledge_tier_as_str(&card.tier),
+                knowledge_status_as_str(&card.status),
+                memory_domain_as_str(&card.domain),
+                card.field.as_str(),
+                anchor_kind_as_str(&card.anchor_kind),
+                card.anchor_id.as_str(),
+                card.parent_anchor_id.as_deref(),
+                card.scope_constraints.as_deref(),
+                encode_optional_json(card.trigger_hints.as_ref())?,
+                card.updated_at.as_str(),
+            ],
+        )?;
+        Ok(affected > 0)
+    }
+
+    pub fn insert_knowledge_evidence_link(
+        &self,
+        link: &KnowledgeEvidenceLink,
+    ) -> Result<(), DbError> {
+        let evidence = self.get_drawer(&link.evidence_drawer_id)?.ok_or_else(|| {
+            DbError::InvalidDrawerMetadata(format!(
+                "evidence drawer {} does not exist",
+                link.evidence_drawer_id
+            ))
+        })?;
+        if evidence.memory_kind != MemoryKind::Evidence {
+            return Err(DbError::InvalidDrawerMetadata(format!(
+                "evidence link target {} must be an evidence drawer",
+                link.evidence_drawer_id
+            )));
+        }
+
+        self.conn.execute(
+            r#"
+            INSERT INTO knowledge_evidence_links (
+                id,
+                card_id,
+                evidence_drawer_id,
+                role,
+                note,
+                created_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            "#,
+            params![
+                link.id.as_str(),
+                link.card_id.as_str(),
+                link.evidence_drawer_id.as_str(),
+                knowledge_evidence_role_as_str(&link.role),
+                link.note.as_deref(),
+                link.created_at.as_str(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn knowledge_evidence_links(
+        &self,
+        card_id: &str,
+    ) -> Result<Vec<KnowledgeEvidenceLink>, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT id, card_id, evidence_drawer_id, role, note, created_at
+            FROM knowledge_evidence_links
+            WHERE card_id = ?1
+            ORDER BY created_at, id
+            "#,
+        )?;
+        let rows = statement
+            .query_map([card_id], |row| {
+                knowledge_evidence_link_from_row(row).map_err(row_decode_error)
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    pub fn append_knowledge_event(&self, event: &KnowledgeCardEvent) -> Result<(), DbError> {
+        self.conn.execute(
+            r#"
+            INSERT INTO knowledge_events (
+                id,
+                card_id,
+                event_type,
+                from_status,
+                to_status,
+                reason,
+                actor,
+                metadata,
+                created_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            "#,
+            params![
+                event.id.as_str(),
+                event.card_id.as_str(),
+                knowledge_event_type_as_str(&event.event_type),
+                event.from_status.as_ref().map(knowledge_status_as_str),
+                event.to_status.as_ref().map(knowledge_status_as_str),
+                event.reason.as_str(),
+                event.actor.as_deref(),
+                encode_optional_json(event.metadata.as_ref())?,
+                event.created_at.as_str(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn knowledge_events(&self, card_id: &str) -> Result<Vec<KnowledgeCardEvent>, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT
+                id,
+                card_id,
+                event_type,
+                from_status,
+                to_status,
+                reason,
+                actor,
+                metadata,
+                created_at
+            FROM knowledge_events
+            WHERE card_id = ?1
+            ORDER BY created_at, id
+            "#,
+        )?;
+        let rows = statement
+            .query_map([card_id], |row| {
+                knowledge_event_from_row(row).map_err(row_decode_error)
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     pub fn neighbor_chunks(
@@ -1744,6 +2032,58 @@ fn knowledge_status_from_str(status: &str) -> Result<KnowledgeStatus, DbError> {
     }
 }
 
+fn knowledge_evidence_role_as_str(role: &KnowledgeEvidenceRole) -> &'static str {
+    match role {
+        KnowledgeEvidenceRole::Supporting => "supporting",
+        KnowledgeEvidenceRole::Verification => "verification",
+        KnowledgeEvidenceRole::Counterexample => "counterexample",
+        KnowledgeEvidenceRole::Teaching => "teaching",
+    }
+}
+
+fn knowledge_evidence_role_from_str(role: &str) -> Result<KnowledgeEvidenceRole, DbError> {
+    match role {
+        "supporting" => Ok(KnowledgeEvidenceRole::Supporting),
+        "verification" => Ok(KnowledgeEvidenceRole::Verification),
+        "counterexample" => Ok(KnowledgeEvidenceRole::Counterexample),
+        "teaching" => Ok(KnowledgeEvidenceRole::Teaching),
+        other => Err(DbError::InvalidEnumValue {
+            kind: "knowledge_evidence_role",
+            value: other.to_string(),
+        }),
+    }
+}
+
+fn knowledge_event_type_as_str(event_type: &KnowledgeEventType) -> &'static str {
+    match event_type {
+        KnowledgeEventType::Created => "created",
+        KnowledgeEventType::Promoted => "promoted",
+        KnowledgeEventType::Demoted => "demoted",
+        KnowledgeEventType::Retired => "retired",
+        KnowledgeEventType::Linked => "linked",
+        KnowledgeEventType::Unlinked => "unlinked",
+        KnowledgeEventType::Updated => "updated",
+        KnowledgeEventType::PublishedAnchor => "published_anchor",
+    }
+}
+
+fn knowledge_event_type_from_str(event_type: &str) -> Result<KnowledgeEventType, DbError> {
+    match event_type {
+        "created" => Ok(KnowledgeEventType::Created),
+        "promoted" => Ok(KnowledgeEventType::Promoted),
+        "demoted" => Ok(KnowledgeEventType::Demoted),
+        "retired" => Ok(KnowledgeEventType::Retired),
+        "linked" => Ok(KnowledgeEventType::Linked),
+        "unlinked" => Ok(KnowledgeEventType::Unlinked),
+        "updated" => Ok(KnowledgeEventType::Updated),
+        "published_anchor" => Ok(KnowledgeEventType::PublishedAnchor),
+        other => Err(DbError::InvalidEnumValue {
+            kind: "knowledge_event_type",
+            value: other.to_string(),
+        }),
+    }
+}
+
 fn encode_json<T: serde::Serialize + ?Sized>(value: &T) -> Result<String, DbError> {
     Ok(serde_json::to_string(value)?)
 }
@@ -1770,6 +2110,71 @@ where
 
 fn row_decode_error(error: DbError) -> rusqlite::Error {
     rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+}
+
+fn knowledge_card_from_row(row: &Row<'_>) -> Result<KnowledgeCard, DbError> {
+    let tier = knowledge_tier_from_str(&row.get::<_, String>(3)?)?;
+    let status = knowledge_status_from_str(&row.get::<_, String>(4)?)?;
+    let domain = memory_domain_from_str(&row.get::<_, String>(5)?)?;
+    let anchor_kind = anchor_kind_from_str(&row.get::<_, String>(7)?)?;
+    let trigger_hints = parse_optional_json(row.get::<_, Option<String>>(11)?.as_deref())?;
+
+    anchor::validate_anchor_domain(&domain, &anchor_kind)
+        .map_err(|message| DbError::InvalidDrawerMetadata(message.to_string()))?;
+
+    Ok(KnowledgeCard {
+        id: row.get(0)?,
+        statement: row.get(1)?,
+        content: row.get(2)?,
+        tier,
+        status,
+        domain,
+        field: row.get(6)?,
+        anchor_kind,
+        anchor_id: row.get(8)?,
+        parent_anchor_id: row.get(9)?,
+        scope_constraints: row.get(10)?,
+        trigger_hints,
+        created_at: row.get(12)?,
+        updated_at: row.get(13)?,
+    })
+}
+
+fn knowledge_evidence_link_from_row(row: &Row<'_>) -> Result<KnowledgeEvidenceLink, DbError> {
+    Ok(KnowledgeEvidenceLink {
+        id: row.get(0)?,
+        card_id: row.get(1)?,
+        evidence_drawer_id: row.get(2)?,
+        role: knowledge_evidence_role_from_str(&row.get::<_, String>(3)?)?,
+        note: row.get(4)?,
+        created_at: row.get(5)?,
+    })
+}
+
+fn knowledge_event_from_row(row: &Row<'_>) -> Result<KnowledgeCardEvent, DbError> {
+    let from_status = row
+        .get::<_, Option<String>>(3)?
+        .as_deref()
+        .map(knowledge_status_from_str)
+        .transpose()?;
+    let to_status = row
+        .get::<_, Option<String>>(4)?
+        .as_deref()
+        .map(knowledge_status_from_str)
+        .transpose()?;
+    let metadata = parse_optional_json(row.get::<_, Option<String>>(7)?.as_deref())?;
+
+    Ok(KnowledgeCardEvent {
+        id: row.get(0)?,
+        card_id: row.get(1)?,
+        event_type: knowledge_event_type_from_str(&row.get::<_, String>(2)?)?,
+        from_status,
+        to_status,
+        reason: row.get(5)?,
+        actor: row.get(6)?,
+        metadata,
+        created_at: row.get(8)?,
+    })
 }
 
 fn drawer_from_row(row: &Row<'_>) -> Result<Drawer, DbError> {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -67,6 +67,79 @@ pub struct TriggerHints {
     pub tool_needs: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnowledgeEvidenceRole {
+    Supporting,
+    Verification,
+    Counterexample,
+    Teaching,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnowledgeEventType {
+    Created,
+    Promoted,
+    Demoted,
+    Retired,
+    Linked,
+    Unlinked,
+    Updated,
+    PublishedAnchor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeCard {
+    pub id: String,
+    pub statement: String,
+    pub content: String,
+    pub tier: KnowledgeTier,
+    pub status: KnowledgeStatus,
+    pub domain: MemoryDomain,
+    pub field: String,
+    pub anchor_kind: AnchorKind,
+    pub anchor_id: String,
+    pub parent_anchor_id: Option<String>,
+    pub scope_constraints: Option<String>,
+    pub trigger_hints: Option<TriggerHints>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct KnowledgeCardFilter {
+    pub tier: Option<KnowledgeTier>,
+    pub status: Option<KnowledgeStatus>,
+    pub domain: Option<MemoryDomain>,
+    pub field: Option<String>,
+    pub anchor_kind: Option<AnchorKind>,
+    pub anchor_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeEvidenceLink {
+    pub id: String,
+    pub card_id: String,
+    pub evidence_drawer_id: String,
+    pub role: KnowledgeEvidenceRole,
+    pub note: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KnowledgeCardEvent {
+    pub id: String,
+    pub card_id: String,
+    pub event_type: KnowledgeEventType,
+    pub from_status: Option<KnowledgeStatus>,
+    pub to_status: Option<KnowledgeStatus>,
+    pub reason: String,
+    pub actor: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: String,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct BootstrapIdentityParts<'a> {
     pub memory_kind: &'a MemoryKind,

--- a/tests/knowledge_card_core.rs
+++ b/tests/knowledge_card_core.rs
@@ -1,0 +1,299 @@
+use mempal::core::db::Database;
+use mempal::core::types::{
+    AnchorKind, BootstrapEvidenceArgs, Drawer, KnowledgeCard, KnowledgeCardEvent,
+    KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+    KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, SourceType, TriggerHints,
+};
+use serde_json::json;
+use tempfile::TempDir;
+
+fn new_db() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    (tmp, db)
+}
+
+fn card(id: &str) -> KnowledgeCard {
+    KnowledgeCard {
+        id: id.to_string(),
+        statement: format!("Statement for {id}."),
+        content: format!("Detailed rationale for {id}."),
+        tier: KnowledgeTier::Shu,
+        status: KnowledgeStatus::Promoted,
+        domain: MemoryDomain::Project,
+        field: "debugging".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        scope_constraints: Some("Only applies to Rust code.".to_string()),
+        trigger_hints: Some(TriggerHints {
+            intent_tags: vec!["debugging".to_string()],
+            workflow_bias: vec!["test-first".to_string()],
+            tool_needs: vec!["cargo".to_string()],
+        }),
+        created_at: "1710000000".to_string(),
+        updated_at: "1710000000".to_string(),
+    }
+}
+
+fn insert_evidence_drawer(db: &Database, id: &str) {
+    db.insert_drawer(&Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: id.to_string(),
+        content: "Evidence body.".to_string(),
+        wing: "mempal".to_string(),
+        room: Some("phase2".to_string()),
+        source_file: Some(format!("tests://{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    }))
+    .expect("insert evidence drawer");
+}
+
+fn insert_knowledge_drawer(db: &Database, id: &str) {
+    let mut drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: id.to_string(),
+        content: "Knowledge drawer body.".to_string(),
+        wing: "mempal".to_string(),
+        room: Some("phase2".to_string()),
+        source_file: Some(format!("knowledge://project/phase2/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    });
+    drawer.memory_kind = MemoryKind::Knowledge;
+    drawer.provenance = None;
+    drawer.statement = Some("Knowledge drawer statement.".to_string());
+    drawer.tier = Some(KnowledgeTier::Shu);
+    drawer.status = Some(KnowledgeStatus::Promoted);
+    drawer.supporting_refs = vec!["drawer_ev_linkable".to_string()];
+    db.insert_drawer(&drawer).expect("insert knowledge drawer");
+}
+
+fn link(
+    id: &str,
+    card_id: &str,
+    drawer_id: &str,
+    role: KnowledgeEvidenceRole,
+) -> KnowledgeEvidenceLink {
+    KnowledgeEvidenceLink {
+        id: id.to_string(),
+        card_id: card_id.to_string(),
+        evidence_drawer_id: drawer_id.to_string(),
+        role,
+        note: Some("supports the card".to_string()),
+        created_at: "1710000000".to_string(),
+    }
+}
+
+fn event(id: &str, card_id: &str, event_type: KnowledgeEventType) -> KnowledgeCardEvent {
+    KnowledgeCardEvent {
+        id: id.to_string(),
+        card_id: card_id.to_string(),
+        event_type,
+        from_status: Some(KnowledgeStatus::Candidate),
+        to_status: Some(KnowledgeStatus::Promoted),
+        reason: "validated by evidence".to_string(),
+        actor: Some("codex".to_string()),
+        metadata: Some(json!({
+            "verification_refs": ["drawer_ev_linkable"],
+            "score": 1
+        })),
+        created_at: "1710000000".to_string(),
+    }
+}
+
+#[test]
+fn test_knowledge_card_insert_get_roundtrip() {
+    let (_tmp, db) = new_db();
+    let card = card("card_roundtrip");
+
+    db.insert_knowledge_card(&card).expect("insert card");
+    let loaded = db
+        .get_knowledge_card("card_roundtrip")
+        .expect("get card")
+        .expect("card exists");
+
+    assert_eq!(loaded, card);
+    assert_eq!(
+        loaded.trigger_hints.expect("trigger hints").tool_needs,
+        vec!["cargo"]
+    );
+}
+
+#[test]
+fn test_knowledge_card_list_filters() {
+    let (_tmp, db) = new_db();
+    let mut rust_card = card("card_rust");
+    rust_card.tier = KnowledgeTier::DaoRen;
+    rust_card.status = KnowledgeStatus::Promoted;
+    rust_card.domain = MemoryDomain::Project;
+    rust_card.field = "software-engineering".to_string();
+    rust_card.anchor_kind = AnchorKind::Worktree;
+    rust_card.anchor_id = "worktree:///tmp/mempal".to_string();
+
+    let mut global_card = card("card_global");
+    global_card.tier = KnowledgeTier::DaoTian;
+    global_card.status = KnowledgeStatus::Canonical;
+    global_card.domain = MemoryDomain::Global;
+    global_card.field = "epistemics".to_string();
+    global_card.anchor_kind = AnchorKind::Global;
+    global_card.anchor_id = "global://all".to_string();
+
+    db.insert_knowledge_card(&rust_card)
+        .expect("insert rust card");
+    db.insert_knowledge_card(&global_card)
+        .expect("insert global card");
+
+    let by_tier = db
+        .list_knowledge_cards(&KnowledgeCardFilter {
+            tier: Some(KnowledgeTier::DaoTian),
+            ..KnowledgeCardFilter::default()
+        })
+        .expect("list by tier");
+    assert_eq!(by_tier, vec![global_card.clone()]);
+
+    let by_field = db
+        .list_knowledge_cards(&KnowledgeCardFilter {
+            domain: Some(MemoryDomain::Project),
+            field: Some("software-engineering".to_string()),
+            anchor_kind: Some(AnchorKind::Worktree),
+            anchor_id: Some("worktree:///tmp/mempal".to_string()),
+            ..KnowledgeCardFilter::default()
+        })
+        .expect("list by field");
+    assert_eq!(by_field, vec![rust_card]);
+}
+
+#[test]
+fn test_knowledge_card_update_preserves_identity_and_created_at() {
+    let (_tmp, db) = new_db();
+    let mut card = card("card_update");
+    db.insert_knowledge_card(&card).expect("insert card");
+
+    card.statement = "Updated statement.".to_string();
+    card.content = "Updated content.".to_string();
+    card.status = KnowledgeStatus::Demoted;
+    card.scope_constraints = Some("Updated constraints.".to_string());
+    card.trigger_hints = None;
+    card.created_at = "9999999999".to_string();
+    card.updated_at = "1710009999".to_string();
+
+    assert!(db.update_knowledge_card(&card).expect("update card"));
+    let loaded = db
+        .get_knowledge_card("card_update")
+        .expect("get card")
+        .expect("card exists");
+
+    assert_eq!(loaded.id, "card_update");
+    assert_eq!(loaded.created_at, "1710000000");
+    assert_eq!(loaded.updated_at, "1710009999");
+    assert_eq!(loaded.statement, "Updated statement.");
+    assert_eq!(loaded.status, KnowledgeStatus::Demoted);
+    assert_eq!(loaded.trigger_hints, None);
+}
+
+#[test]
+fn test_knowledge_evidence_link_requires_evidence_drawer() {
+    let (_tmp, db) = new_db();
+    db.insert_knowledge_card(&card("card_linkable"))
+        .expect("insert card");
+    insert_evidence_drawer(&db, "drawer_ev_linkable");
+    insert_knowledge_drawer(&db, "drawer_kn_not_evidence");
+
+    db.insert_knowledge_evidence_link(&link(
+        "link_ok",
+        "card_linkable",
+        "drawer_ev_linkable",
+        KnowledgeEvidenceRole::Supporting,
+    ))
+    .expect("link evidence drawer");
+
+    let wrong_kind = db
+        .insert_knowledge_evidence_link(&link(
+            "link_wrong_kind",
+            "card_linkable",
+            "drawer_kn_not_evidence",
+            KnowledgeEvidenceRole::Supporting,
+        ))
+        .expect_err("knowledge drawer must not link as evidence");
+    assert!(
+        wrong_kind
+            .to_string()
+            .contains("must be an evidence drawer")
+    );
+
+    let missing = db
+        .insert_knowledge_evidence_link(&link(
+            "link_missing",
+            "card_linkable",
+            "drawer_missing",
+            KnowledgeEvidenceRole::Supporting,
+        ))
+        .expect_err("missing drawer must fail");
+    assert!(missing.to_string().contains("does not exist"));
+}
+
+#[test]
+fn test_knowledge_evidence_links_list_by_card() {
+    let (_tmp, db) = new_db();
+    db.insert_knowledge_card(&card("card_links_a"))
+        .expect("insert card a");
+    db.insert_knowledge_card(&card("card_links_b"))
+        .expect("insert card b");
+    insert_evidence_drawer(&db, "drawer_ev_a");
+    insert_evidence_drawer(&db, "drawer_ev_b");
+
+    db.insert_knowledge_evidence_link(&link(
+        "link_a",
+        "card_links_a",
+        "drawer_ev_a",
+        KnowledgeEvidenceRole::Supporting,
+    ))
+    .expect("insert link a");
+    db.insert_knowledge_evidence_link(&link(
+        "link_b",
+        "card_links_b",
+        "drawer_ev_b",
+        KnowledgeEvidenceRole::Verification,
+    ))
+    .expect("insert link b");
+
+    let links = db
+        .knowledge_evidence_links("card_links_a")
+        .expect("list links");
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].id, "link_a");
+    assert_eq!(links[0].role, KnowledgeEvidenceRole::Supporting);
+}
+
+#[test]
+fn test_knowledge_events_append_and_list_by_card() {
+    let (_tmp, db) = new_db();
+    db.insert_knowledge_card(&card("card_events_a"))
+        .expect("insert card a");
+    db.insert_knowledge_card(&card("card_events_b"))
+        .expect("insert card b");
+
+    db.append_knowledge_event(&event(
+        "event_a_created",
+        "card_events_a",
+        KnowledgeEventType::Created,
+    ))
+    .expect("append event a");
+    db.append_knowledge_event(&event(
+        "event_b_created",
+        "card_events_b",
+        KnowledgeEventType::Created,
+    ))
+    .expect("append event b");
+
+    let events = db.knowledge_events("card_events_a").expect("list events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].id, "event_a_created");
+    assert_eq!(events[0].event_type, KnowledgeEventType::Created);
+    assert_eq!(events[0].metadata.as_ref().expect("metadata")["score"], 1);
+}


### PR DESCRIPTION
## Summary

- add Phase-2 knowledge card Rust domain types and filters
- add core `Database` APIs for card create/read/update/list, evidence links, and append/list events
- validate evidence links only point at existing `memory_kind=evidence` drawers
- keep P33 DB-layer only: no CLI, MCP, REST, search, context, wake-up, lifecycle, or backfill surface

## Validation

- `agent-spec parse specs/p33-knowledge-card-core-api.spec.md`
- `agent-spec lint specs/p33-knowledge-card-core-api.spec.md --min-score 0.7`
- `cargo fmt --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
