### PR TITLE
feat: add knowledge card cli

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p31-knowledge-card-schema.spec.md` | 完成 | schema v8 Phase-2 `knowledge_cards` / `knowledge_evidence_links` / `knowledge_events` 最小 schema contract |
 | `specs/p32-knowledge-card-schema-v8.spec.md` | 完成 | schema v8 migration：新增 Phase-2 knowledge card 三表、约束、索引、append-only events |
 | `specs/p33-knowledge-card-core-api.spec.md` | 完成 | Phase-2 knowledge card DB core API：Rust types + card/link/event create/read/update/list，不暴露 CLI/MCP/REST |
+| `specs/p34-knowledge-card-cli.spec.md` | 完成 | Phase-2 knowledge card 最小 CLI 管理入口：create/get/list/link/event/events，不接入 MCP/REST/search/context |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -122,6 +123,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p31-knowledge-card-schema-spec.md` — P31 knowledge card schema spec（已完成）
 - `docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md` — P32 knowledge card schema v8（已完成）
 - `docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md` — P33 knowledge card core API（已完成）
+- `docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md` — P34 knowledge card CLI（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p31-knowledge-card-schema.spec.md` | 完成 | schema v8 Phase-2 `knowledge_cards` / `knowledge_evidence_links` / `knowledge_events` 最小 schema contract |
 | `specs/p32-knowledge-card-schema-v8.spec.md` | 完成 | schema v8 migration：新增 Phase-2 knowledge card 三表、约束、索引、append-only events |
 | `specs/p33-knowledge-card-core-api.spec.md` | 完成 | Phase-2 knowledge card DB core API：Rust types + card/link/event create/read/update/list，不暴露 CLI/MCP/REST |
+| `specs/p34-knowledge-card-cli.spec.md` | 完成 | Phase-2 knowledge card 最小 CLI 管理入口：create/get/list/link/event/events，不接入 MCP/REST/search/context |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -120,6 +121,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p31-knowledge-card-schema-spec.md` — P31 knowledge card schema spec（已完成）
 - `docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md` — P32 knowledge card schema v8（已完成）
 - `docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md` — P33 knowledge card core API（已完成）
+- `docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md` — P34 knowledge card CLI（已完成）
 
 ### Spec 使用方式
 

--- a/docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md
+++ b/docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md
@@ -1,0 +1,31 @@
+# P34 Knowledge Card CLI Implementation Plan
+
+**Goal:** Add the first operator-facing CLI surface for Phase-2 knowledge cards
+without exposing MCP, REST, search, context, wake-up, lifecycle automation, or
+backfill behavior.
+
+**Architecture:** Add a top-level `knowledge-card` command family in
+`src/main.rs` that calls the P33 `Database` APIs. Keep JSON/plain output helpers
+local to the CLI and keep card evidence as drawer links.
+
+## Steps
+
+- [x] Add P34 task contract.
+- [x] Add `knowledge-card` CLI subcommands for create/get/list/link/event/events.
+- [x] Add parsing and output helpers for card enums, filters, links, and events.
+- [x] Add CLI integration tests covering create/get, list filters, link validation,
+      event history, and invalid format errors.
+- [x] Update AGENTS / CLAUDE inventories.
+- [x] Run spec lint, formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p34-knowledge-card-cli.spec.md
+agent-spec lint specs/p34-knowledge-card-cli.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p34-knowledge-card-cli.spec.md
+++ b/specs/p34-knowledge-card-cli.spec.md
@@ -1,0 +1,109 @@
+spec: task
+name: "P34: knowledge card CLI management"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, cli, phase-2]
+---
+
+## Intent
+
+P33 added the DB-layer API for Phase-2 knowledge cards. P34 exposes a minimal
+operator-facing CLI surface so cards can be created, inspected, filtered, linked
+to evidence drawers, and annotated with append-only lifecycle events without
+adding MCP, REST, search, context, or backfill behavior.
+
+## Decisions
+
+- Add a new top-level `mempal knowledge-card` command family.
+- Add `knowledge-card create` for inserting a single card.
+- Add `knowledge-card get` for inspecting one card.
+- Add `knowledge-card list` for filtered card listing.
+- Add `knowledge-card link` for linking one evidence drawer to one card.
+- Add `knowledge-card events` for listing a card's append-only event history.
+- Add `knowledge-card event` for appending one lifecycle event.
+- Keep stdout format support minimal: plain by default, `--format json` where a
+  command returns structured records.
+- Generate deterministic ids when `--id` is omitted; callers may also provide
+  explicit ids for reproducible tests and migrations.
+- `knowledge-card link` must reuse P33 validation and reject non-evidence
+  drawers before writing.
+- Do not add update or delete CLI commands in P34.
+- Do not add MCP tools, REST endpoints, search integration, context integration,
+  wake-up behavior, lifecycle automation, promotion gates, or backfill behavior.
+
+## Acceptance Criteria
+
+Scenario: create and get card through CLI
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_create_get_json
+  Given an initialized mempal home
+  When running `mempal knowledge-card create` with explicit id and metadata
+  Then stdout includes `card_id=card_cli`
+  When running `mempal knowledge-card get card_cli --format json`
+  Then the JSON contains the same statement, content, tier, status, domain, field, and anchor metadata
+
+Scenario: create generates deterministic id when omitted
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_create_generates_id
+  Given an initialized mempal home
+  When running `mempal knowledge-card create` without `--id`
+  Then stdout includes `card_id=card_`
+  And the generated card can be loaded with `mempal knowledge-card get`
+
+Scenario: list cards supports filters
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_list_filters_plain
+  Given multiple knowledge cards with different tier, status, domain, field, and anchor metadata
+  When running `mempal knowledge-card list --tier dao_ren --status promoted --field rust`
+  Then stdout includes only the matching card id and excludes non-matching cards
+
+Scenario: link rejects non-evidence drawers
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_link_requires_evidence_drawer
+  Given one knowledge card, one evidence drawer, and one knowledge drawer
+  When running `mempal knowledge-card link card_cli drawer_evidence --role supporting`
+  Then the link succeeds and stdout includes `link_id=`
+  When running `mempal knowledge-card link card_cli drawer_knowledge --role supporting`
+  Then the command exits non-zero
+  And stderr says the target must be an evidence drawer
+
+Scenario: event append and events list roundtrip JSON
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_event_append_and_list_json
+  Given one knowledge card
+  When running `mempal knowledge-card event card_cli --type created --reason seeded`
+  Then stdout includes `event_id=`
+  When running `mempal knowledge-card events card_cli --format json`
+  Then the JSON array contains the created event and reason
+
+Scenario: invalid format is rejected
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_rejects_invalid_format
+  Given an initialized mempal home
+  When running `mempal knowledge-card list --format yaml`
+  Then the command exits non-zero
+  And stderr says the format is unsupported
+
+## Out of Scope
+
+- Do not add card update CLI.
+- Do not add card delete CLI.
+- Do not add MCP tools.
+- Do not add REST endpoints.
+- Do not change search results.
+- Do not change context assembly.
+- Do not change wake-up.
+- Do not mutate Stage-1 `drawers` knowledge lifecycle commands.
+- Do not backfill existing `memory_kind=knowledge` drawers into cards.
+
+## Constraints
+
+- Store cards in schema v8 `knowledge_cards`.
+- Preserve raw evidence in `drawers`; CLI links cards to evidence drawer ids.
+- Keep lifecycle history append-only by only inserting `knowledge_events`.
+- Reuse the P33 `Database` APIs instead of writing direct SQL in CLI command functions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,9 @@ use mempal::core::{
     db::Database,
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
-        AnchorKind, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, TaxonomyEntry,
-        TriggerHints, TunnelEndpoint,
+        AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
+        KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain,
+        MemoryKind, TaxonomyEntry, TriggerHints, TunnelEndpoint,
     },
     utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
 };
@@ -39,6 +40,7 @@ use mempal::knowledge_lifecycle::{
 use mempal::mcp::MempalMcpServer;
 use mempal::search::{SearchFilters, SearchOptions, search_with_options};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 mod longmemeval;
 
@@ -149,6 +151,10 @@ enum Commands {
     Knowledge {
         #[command(subcommand)]
         command: KnowledgeCommands,
+    },
+    KnowledgeCard {
+        #[command(subcommand)]
+        command: KnowledgeCardCommands,
     },
     Tunnels {
         #[command(subcommand)]
@@ -351,6 +357,95 @@ enum KnowledgeCommands {
 }
 
 #[derive(Subcommand)]
+enum KnowledgeCardCommands {
+    Create {
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long)]
+        statement: String,
+        #[arg(long)]
+        content: String,
+        #[arg(long)]
+        tier: String,
+        #[arg(long)]
+        status: String,
+        #[arg(long, default_value = "project")]
+        domain: String,
+        #[arg(long, default_value = "general")]
+        field: String,
+        #[arg(long = "anchor-kind", default_value = "repo")]
+        anchor_kind: String,
+        #[arg(long = "anchor-id")]
+        anchor_id: String,
+        #[arg(long = "parent-anchor-id")]
+        parent_anchor_id: Option<String>,
+        #[arg(long = "scope-constraints")]
+        scope_constraints: Option<String>,
+        #[arg(long = "intent-tag")]
+        intent_tags: Vec<String>,
+        #[arg(long = "workflow-bias")]
+        workflow_bias: Vec<String>,
+        #[arg(long = "tool-need")]
+        tool_needs: Vec<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Get {
+        card_id: String,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    List {
+        #[arg(long)]
+        tier: Option<String>,
+        #[arg(long)]
+        status: Option<String>,
+        #[arg(long)]
+        domain: Option<String>,
+        #[arg(long)]
+        field: Option<String>,
+        #[arg(long = "anchor-kind")]
+        anchor_kind: Option<String>,
+        #[arg(long = "anchor-id")]
+        anchor_id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Link {
+        card_id: String,
+        evidence_drawer_id: String,
+        #[arg(long)]
+        role: String,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+    },
+    Event {
+        card_id: String,
+        #[arg(long = "type")]
+        event_type: String,
+        #[arg(long)]
+        reason: String,
+        #[arg(long = "from-status")]
+        from_status: Option<String>,
+        #[arg(long = "to-status")]
+        to_status: Option<String>,
+        #[arg(long)]
+        actor: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+    },
+    Events {
+        card_id: String,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum TunnelCommands {
     Add {
         #[arg(long)]
@@ -536,6 +631,7 @@ async fn run() -> Result<()> {
         } => reindex_command(&db, &config, stale, force, dry_run).await,
         Commands::Kg { command } => kg_command(&db, command),
         Commands::Knowledge { command } => knowledge_command(&db, &config, command).await,
+        Commands::KnowledgeCard { command } => knowledge_card_command(&db, command),
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::FieldTaxonomy { format } => field_taxonomy_command(&format),
@@ -1013,6 +1109,16 @@ fn knowledge_tier_slug(value: &KnowledgeTier) -> &'static str {
     }
 }
 
+fn parse_knowledge_tier(value: &str) -> Result<KnowledgeTier> {
+    match value {
+        "qi" => Ok(KnowledgeTier::Qi),
+        "shu" => Ok(KnowledgeTier::Shu),
+        "dao_ren" => Ok(KnowledgeTier::DaoRen),
+        "dao_tian" => Ok(KnowledgeTier::DaoTian),
+        other => bail!("unsupported knowledge tier: {other}"),
+    }
+}
+
 fn knowledge_status_slug(value: &KnowledgeStatus) -> &'static str {
     match value {
         KnowledgeStatus::Candidate => "candidate",
@@ -1023,12 +1129,88 @@ fn knowledge_status_slug(value: &KnowledgeStatus) -> &'static str {
     }
 }
 
+fn parse_knowledge_status(value: &str) -> Result<KnowledgeStatus> {
+    match value {
+        "candidate" => Ok(KnowledgeStatus::Candidate),
+        "promoted" => Ok(KnowledgeStatus::Promoted),
+        "canonical" => Ok(KnowledgeStatus::Canonical),
+        "demoted" => Ok(KnowledgeStatus::Demoted),
+        "retired" => Ok(KnowledgeStatus::Retired),
+        other => bail!("unsupported knowledge status: {other}"),
+    }
+}
+
 fn anchor_kind_slug(value: &AnchorKind) -> &'static str {
     match value {
         AnchorKind::Global => "global",
         AnchorKind::Repo => "repo",
         AnchorKind::Worktree => "worktree",
     }
+}
+
+fn parse_anchor_kind(value: &str) -> Result<AnchorKind> {
+    match value {
+        "global" => Ok(AnchorKind::Global),
+        "repo" => Ok(AnchorKind::Repo),
+        "worktree" => Ok(AnchorKind::Worktree),
+        other => bail!("unsupported anchor kind: {other}"),
+    }
+}
+
+fn knowledge_evidence_role_slug(value: &KnowledgeEvidenceRole) -> &'static str {
+    match value {
+        KnowledgeEvidenceRole::Supporting => "supporting",
+        KnowledgeEvidenceRole::Verification => "verification",
+        KnowledgeEvidenceRole::Counterexample => "counterexample",
+        KnowledgeEvidenceRole::Teaching => "teaching",
+    }
+}
+
+fn parse_knowledge_evidence_role(value: &str) -> Result<KnowledgeEvidenceRole> {
+    match value {
+        "supporting" => Ok(KnowledgeEvidenceRole::Supporting),
+        "verification" => Ok(KnowledgeEvidenceRole::Verification),
+        "counterexample" => Ok(KnowledgeEvidenceRole::Counterexample),
+        "teaching" => Ok(KnowledgeEvidenceRole::Teaching),
+        other => bail!("unsupported knowledge evidence role: {other}"),
+    }
+}
+
+fn knowledge_event_type_slug(value: &KnowledgeEventType) -> &'static str {
+    match value {
+        KnowledgeEventType::Created => "created",
+        KnowledgeEventType::Promoted => "promoted",
+        KnowledgeEventType::Demoted => "demoted",
+        KnowledgeEventType::Retired => "retired",
+        KnowledgeEventType::Linked => "linked",
+        KnowledgeEventType::Unlinked => "unlinked",
+        KnowledgeEventType::Updated => "updated",
+        KnowledgeEventType::PublishedAnchor => "published_anchor",
+    }
+}
+
+fn parse_knowledge_event_type(value: &str) -> Result<KnowledgeEventType> {
+    match value {
+        "created" => Ok(KnowledgeEventType::Created),
+        "promoted" => Ok(KnowledgeEventType::Promoted),
+        "demoted" => Ok(KnowledgeEventType::Demoted),
+        "retired" => Ok(KnowledgeEventType::Retired),
+        "linked" => Ok(KnowledgeEventType::Linked),
+        "unlinked" => Ok(KnowledgeEventType::Unlinked),
+        "updated" => Ok(KnowledgeEventType::Updated),
+        "published_anchor" => Ok(KnowledgeEventType::PublishedAnchor),
+        other => bail!("unsupported knowledge event type: {other}"),
+    }
+}
+
+fn stable_cli_id(prefix: &str, parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update([0]);
+        hasher.update(part.trim().as_bytes());
+    }
+    let digest = format!("{:x}", hasher.finalize());
+    format!("{prefix}_{}", &digest[..16])
 }
 
 fn effective_wake_up_text(drawer: &mempal::core::types::Drawer) -> &str {
@@ -1412,6 +1594,196 @@ async fn knowledge_command(
     Ok(())
 }
 
+fn knowledge_card_command(db: &Database, command: KnowledgeCardCommands) -> Result<()> {
+    match command {
+        KnowledgeCardCommands::Create {
+            id,
+            statement,
+            content,
+            tier,
+            status,
+            domain,
+            field,
+            anchor_kind,
+            anchor_id,
+            parent_anchor_id,
+            scope_constraints,
+            intent_tags,
+            workflow_bias,
+            tool_needs,
+            format,
+        } => {
+            let tier = parse_knowledge_tier(&tier)?;
+            let status = parse_knowledge_status(&status)?;
+            let domain = parse_domain(&domain)?;
+            let anchor_kind = parse_anchor_kind(&anchor_kind)?;
+            let trigger_hints = build_trigger_hints(intent_tags, workflow_bias, tool_needs);
+            let id = id.unwrap_or_else(|| {
+                stable_cli_id(
+                    "card",
+                    &[
+                        statement.as_str(),
+                        content.as_str(),
+                        knowledge_tier_slug(&tier),
+                        knowledge_status_slug(&status),
+                        domain_slug(&domain),
+                        field.as_str(),
+                        anchor_kind_slug(&anchor_kind),
+                        anchor_id.as_str(),
+                    ],
+                )
+            });
+            let now = current_timestamp();
+            let card = KnowledgeCard {
+                id: id.clone(),
+                statement,
+                content,
+                tier,
+                status,
+                domain,
+                field,
+                anchor_kind,
+                anchor_id,
+                parent_anchor_id,
+                scope_constraints,
+                trigger_hints,
+                created_at: now.clone(),
+                updated_at: now,
+            };
+            db.insert_knowledge_card(&card)
+                .context("failed to insert knowledge card")?;
+            match format.as_str() {
+                "plain" => println!("card_id={id} created=true"),
+                "json" => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&card)
+                        .context("failed to serialize knowledge card")?
+                ),
+                other => bail!("unsupported knowledge-card format: {other}"),
+            }
+        }
+        KnowledgeCardCommands::Get { card_id, format } => {
+            let card = db
+                .get_knowledge_card(&card_id)
+                .context("failed to get knowledge card")?
+                .with_context(|| format!("knowledge card not found: {card_id}"))?;
+            print_knowledge_card(&card, &format)?;
+        }
+        KnowledgeCardCommands::List {
+            tier,
+            status,
+            domain,
+            field,
+            anchor_kind,
+            anchor_id,
+            format,
+        } => {
+            let filter = KnowledgeCardFilter {
+                tier: tier.as_deref().map(parse_knowledge_tier).transpose()?,
+                status: status.as_deref().map(parse_knowledge_status).transpose()?,
+                domain: domain.as_deref().map(parse_domain).transpose()?,
+                field,
+                anchor_kind: anchor_kind.as_deref().map(parse_anchor_kind).transpose()?,
+                anchor_id,
+            };
+            let cards = db
+                .list_knowledge_cards(&filter)
+                .context("failed to list knowledge cards")?;
+            print_knowledge_cards(&cards, &format)?;
+        }
+        KnowledgeCardCommands::Link {
+            card_id,
+            evidence_drawer_id,
+            role,
+            note,
+            id,
+        } => {
+            let role = parse_knowledge_evidence_role(&role)?;
+            let id = id.unwrap_or_else(|| {
+                stable_cli_id(
+                    "link",
+                    &[
+                        card_id.as_str(),
+                        evidence_drawer_id.as_str(),
+                        knowledge_evidence_role_slug(&role),
+                        note.as_deref().unwrap_or(""),
+                    ],
+                )
+            });
+            let link = KnowledgeEvidenceLink {
+                id: id.clone(),
+                card_id,
+                evidence_drawer_id,
+                role,
+                note,
+                created_at: current_timestamp(),
+            };
+            db.insert_knowledge_evidence_link(&link)
+                .context("failed to insert knowledge evidence link")?;
+            println!("link_id={id} created=true");
+        }
+        KnowledgeCardCommands::Event {
+            card_id,
+            event_type,
+            reason,
+            from_status,
+            to_status,
+            actor,
+            metadata_json,
+            id,
+        } => {
+            let event_type = parse_knowledge_event_type(&event_type)?;
+            let from_status = from_status
+                .as_deref()
+                .map(parse_knowledge_status)
+                .transpose()?;
+            let to_status = to_status
+                .as_deref()
+                .map(parse_knowledge_status)
+                .transpose()?;
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let created_at = current_timestamp();
+            let id = id.unwrap_or_else(|| {
+                stable_cli_id(
+                    "event",
+                    &[
+                        card_id.as_str(),
+                        knowledge_event_type_slug(&event_type),
+                        reason.as_str(),
+                        created_at.as_str(),
+                    ],
+                )
+            });
+            let event = KnowledgeCardEvent {
+                id: id.clone(),
+                card_id,
+                event_type,
+                from_status,
+                to_status,
+                reason,
+                actor,
+                metadata,
+                created_at,
+            };
+            db.append_knowledge_event(&event)
+                .context("failed to append knowledge card event")?;
+            println!("event_id={id} created=true");
+        }
+        KnowledgeCardCommands::Events { card_id, format } => {
+            let events = db
+                .knowledge_events(&card_id)
+                .context("failed to list knowledge card events")?;
+            print_knowledge_card_events(&events, &format)?;
+        }
+    }
+
+    Ok(())
+}
+
 fn normalized_nonempty_strings(values: &[String]) -> Vec<String> {
     values
         .iter()
@@ -1438,6 +1810,84 @@ fn build_trigger_hints(
         workflow_bias,
         tool_needs,
     })
+}
+
+fn print_knowledge_cards(cards: &[KnowledgeCard], format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            if cards.is_empty() {
+                println!("no knowledge cards");
+                return Ok(());
+            }
+            for card in cards {
+                println!(
+                    "{} tier={} status={} domain={} field={} anchor={} {}",
+                    card.id,
+                    knowledge_tier_slug(&card.tier),
+                    knowledge_status_slug(&card.status),
+                    domain_slug(&card.domain),
+                    card.field,
+                    anchor_kind_slug(&card.anchor_kind),
+                    card.anchor_id
+                );
+                println!("statement: {}", card.statement);
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(cards)
+                    .context("failed to serialize knowledge cards")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card format: {other}"),
+    }
+}
+
+fn print_knowledge_card(card: &KnowledgeCard, format: &str) -> Result<()> {
+    match format {
+        "plain" => print_knowledge_cards(std::slice::from_ref(card), format),
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(card).context("failed to serialize knowledge card")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card format: {other}"),
+    }
+}
+
+fn print_knowledge_card_events(events: &[KnowledgeCardEvent], format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            if events.is_empty() {
+                println!("no knowledge card events");
+                return Ok(());
+            }
+            for event in events {
+                println!(
+                    "{} card_id={} type={} reason={}",
+                    event.id,
+                    event.card_id,
+                    knowledge_event_type_slug(&event.event_type),
+                    event.reason
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(events)
+                    .context("failed to serialize knowledge card events")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card format: {other}"),
+    }
 }
 
 fn print_gate_report(report: &GateReport) {

--- a/tests/knowledge_card_cli.rs
+++ b/tests/knowledge_card_cli.rs
@@ -1,0 +1,338 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use mempal::core::db::Database;
+use mempal::core::types::{
+    AnchorKind, BootstrapEvidenceArgs, Drawer, KnowledgeCard, KnowledgeStatus, KnowledgeTier,
+    MemoryDomain, MemoryKind, SourceType,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_home() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_dir = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_dir).expect("create .mempal");
+    let db = Database::open(&mempal_dir.join("palace.db")).expect("open db");
+    (tmp, db)
+}
+
+fn run_mempal(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .env("HOME", home)
+        .args(args)
+        .output()
+        .expect("run mempal")
+}
+
+fn card(id: &str, tier: KnowledgeTier, status: KnowledgeStatus, field: &str) -> KnowledgeCard {
+    KnowledgeCard {
+        id: id.to_string(),
+        statement: format!("Statement for {id}."),
+        content: format!("Content for {id}."),
+        tier,
+        status,
+        domain: MemoryDomain::Project,
+        field: field.to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        scope_constraints: None,
+        trigger_hints: None,
+        created_at: "1710000000".to_string(),
+        updated_at: "1710000000".to_string(),
+    }
+}
+
+fn insert_card(db: &Database, card: KnowledgeCard) {
+    db.insert_knowledge_card(&card).expect("insert card");
+}
+
+fn insert_evidence_drawer(db: &Database, id: &str) {
+    db.insert_drawer(&Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: id.to_string(),
+        content: "Evidence body.".to_string(),
+        wing: "mempal".to_string(),
+        room: Some("phase2".to_string()),
+        source_file: Some(format!("tests://{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    }))
+    .expect("insert evidence drawer");
+}
+
+fn insert_knowledge_drawer(db: &Database, id: &str) {
+    let mut drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: id.to_string(),
+        content: "Knowledge body.".to_string(),
+        wing: "mempal".to_string(),
+        room: Some("phase2".to_string()),
+        source_file: Some(format!("knowledge://project/phase2/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    });
+    drawer.memory_kind = MemoryKind::Knowledge;
+    drawer.provenance = None;
+    drawer.statement = Some("Knowledge statement.".to_string());
+    drawer.tier = Some(KnowledgeTier::Shu);
+    drawer.status = Some(KnowledgeStatus::Promoted);
+    drawer.supporting_refs = vec!["drawer_evidence".to_string()];
+    db.insert_drawer(&drawer).expect("insert knowledge drawer");
+}
+
+fn stdout_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+#[test]
+fn test_cli_knowledge_card_create_get_json() {
+    let (home, _db) = setup_home();
+
+    let create = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "create",
+            "--id",
+            "card_cli",
+            "--statement",
+            "Evidence-backed knowledge cards are managed separately.",
+            "--content",
+            "Cards store distilled statements and link back to raw evidence drawers.",
+            "--tier",
+            "dao_ren",
+            "--status",
+            "promoted",
+            "--domain",
+            "project",
+            "--field",
+            "rust",
+            "--anchor-kind",
+            "repo",
+            "--anchor-id",
+            "repo://mempal",
+            "--intent-tag",
+            "memory",
+            "--tool-need",
+            "cargo",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr_text(&create));
+    assert!(stdout_text(&create).contains("card_id=card_cli"));
+
+    let get = run_mempal(
+        home.path(),
+        &["knowledge-card", "get", "card_cli", "--format", "json"],
+    );
+    assert!(get.status.success(), "{}", stderr_text(&get));
+    let value: Value = serde_json::from_slice(&get.stdout).expect("parse card json");
+    assert_eq!(value["id"], "card_cli");
+    assert_eq!(
+        value["statement"],
+        "Evidence-backed knowledge cards are managed separately."
+    );
+    assert_eq!(value["tier"], "dao_ren");
+    assert_eq!(value["status"], "promoted");
+    assert_eq!(value["domain"], "project");
+    assert_eq!(value["field"], "rust");
+    assert_eq!(value["anchor_kind"], "repo");
+    assert_eq!(value["anchor_id"], "repo://mempal");
+    assert_eq!(value["trigger_hints"]["intent_tags"][0], "memory");
+}
+
+#[test]
+fn test_cli_knowledge_card_create_generates_id() {
+    let (home, _db) = setup_home();
+
+    let create = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "create",
+            "--statement",
+            "Generated card ids are stable.",
+            "--content",
+            "The CLI hashes card metadata when no id is provided.",
+            "--tier",
+            "shu",
+            "--status",
+            "promoted",
+            "--field",
+            "rust",
+            "--anchor-id",
+            "repo://mempal",
+        ],
+    );
+    assert!(create.status.success(), "{}", stderr_text(&create));
+    let stdout = stdout_text(&create);
+    let card_id = stdout
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix("card_id="))
+        .expect("generated card id");
+    assert!(card_id.starts_with("card_"));
+
+    let get = run_mempal(home.path(), &["knowledge-card", "get", card_id]);
+    assert!(get.status.success(), "{}", stderr_text(&get));
+    assert!(stdout_text(&get).contains("Generated card ids are stable."));
+}
+
+#[test]
+fn test_cli_knowledge_card_list_filters_plain() {
+    let (home, db) = setup_home();
+    insert_card(
+        &db,
+        card(
+            "card_match",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Promoted,
+            "rust",
+        ),
+    );
+    insert_card(
+        &db,
+        card(
+            "card_wrong_tier",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "rust",
+        ),
+    );
+    insert_card(
+        &db,
+        card(
+            "card_wrong_field",
+            KnowledgeTier::DaoRen,
+            KnowledgeStatus::Promoted,
+            "docs",
+        ),
+    );
+
+    let list = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "list",
+            "--tier",
+            "dao_ren",
+            "--status",
+            "promoted",
+            "--field",
+            "rust",
+        ],
+    );
+    assert!(list.status.success(), "{}", stderr_text(&list));
+    let stdout = stdout_text(&list);
+    assert!(stdout.contains("card_match"));
+    assert!(!stdout.contains("card_wrong_tier"));
+    assert!(!stdout.contains("card_wrong_field"));
+}
+
+#[test]
+fn test_cli_knowledge_card_link_requires_evidence_drawer() {
+    let (home, db) = setup_home();
+    insert_card(
+        &db,
+        card(
+            "card_cli",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "rust",
+        ),
+    );
+    insert_evidence_drawer(&db, "drawer_evidence");
+    insert_knowledge_drawer(&db, "drawer_knowledge");
+
+    let ok = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "link",
+            "card_cli",
+            "drawer_evidence",
+            "--role",
+            "supporting",
+        ],
+    );
+    assert!(ok.status.success(), "{}", stderr_text(&ok));
+    assert!(stdout_text(&ok).contains("link_id="));
+
+    let rejected = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "link",
+            "card_cli",
+            "drawer_knowledge",
+            "--role",
+            "supporting",
+        ],
+    );
+    assert!(!rejected.status.success());
+    assert!(stderr_text(&rejected).contains("must be an evidence drawer"));
+}
+
+#[test]
+fn test_cli_knowledge_card_event_append_and_list_json() {
+    let (home, db) = setup_home();
+    insert_card(
+        &db,
+        card(
+            "card_cli",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "rust",
+        ),
+    );
+
+    let append = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "event",
+            "card_cli",
+            "--type",
+            "created",
+            "--reason",
+            "seeded",
+            "--actor",
+            "codex",
+        ],
+    );
+    assert!(append.status.success(), "{}", stderr_text(&append));
+    assert!(stdout_text(&append).contains("event_id="));
+
+    let events = run_mempal(
+        home.path(),
+        &["knowledge-card", "events", "card_cli", "--format", "json"],
+    );
+    assert!(events.status.success(), "{}", stderr_text(&events));
+    let value: Value = serde_json::from_slice(&events.stdout).expect("parse events json");
+    let array = value.as_array().expect("events array");
+    assert_eq!(array.len(), 1);
+    assert_eq!(array[0]["card_id"], "card_cli");
+    assert_eq!(array[0]["event_type"], "created");
+    assert_eq!(array[0]["reason"], "seeded");
+    assert_eq!(array[0]["actor"], "codex");
+}
+
+#[test]
+fn test_cli_knowledge_card_rejects_invalid_format() {
+    let (home, _db) = setup_home();
+
+    let output = run_mempal(home.path(), &["knowledge-card", "list", "--format", "yaml"]);
+    assert!(!output.status.success());
+    assert!(stderr_text(&output).contains("unsupported knowledge-card format"));
+}


### PR DESCRIPTION
## Summary

- add top-level `mempal knowledge-card` CLI commands for create/get/list/link/event/events
- support plain output by default and JSON for record-returning commands
- generate stable ids when `--id` is omitted while allowing explicit ids for migrations/tests
- reuse P33 `Database` APIs so evidence links reject non-evidence drawers and events remain append-only
- keep P34 out of MCP, REST, search, context, wake-up, lifecycle automation, promotion gates, and backfill

## Validation

- `agent-spec parse specs/p34-knowledge-card-cli.spec.md`
- `agent-spec lint specs/p34-knowledge-card-cli.spec.md --min-score 0.7`
- `cargo fmt --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
