### PR TITLE
feat: add knowledge card mcp read api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p32-knowledge-card-schema-v8.spec.md` | 完成 | schema v8 migration：新增 Phase-2 knowledge card 三表、约束、索引、append-only events |
 | `specs/p33-knowledge-card-core-api.spec.md` | 完成 | Phase-2 knowledge card DB core API：Rust types + card/link/event create/read/update/list，不暴露 CLI/MCP/REST |
 | `specs/p34-knowledge-card-cli.spec.md` | 完成 | Phase-2 knowledge card 最小 CLI 管理入口：create/get/list/link/event/events，不接入 MCP/REST/search/context |
+| `specs/p35-knowledge-card-mcp-read.spec.md` | 完成 | Phase-2 knowledge card MCP 只读入口：`mempal_knowledge_cards` list/get/events，不开放写操作 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -124,6 +125,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md` — P32 knowledge card schema v8（已完成）
 - `docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md` — P33 knowledge card core API（已完成）
 - `docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md` — P34 knowledge card CLI（已完成）
+- `docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md` — P35 knowledge card MCP read（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p32-knowledge-card-schema-v8.spec.md` | 完成 | schema v8 migration：新增 Phase-2 knowledge card 三表、约束、索引、append-only events |
 | `specs/p33-knowledge-card-core-api.spec.md` | 完成 | Phase-2 knowledge card DB core API：Rust types + card/link/event create/read/update/list，不暴露 CLI/MCP/REST |
 | `specs/p34-knowledge-card-cli.spec.md` | 完成 | Phase-2 knowledge card 最小 CLI 管理入口：create/get/list/link/event/events，不接入 MCP/REST/search/context |
+| `specs/p35-knowledge-card-mcp-read.spec.md` | 完成 | Phase-2 knowledge card MCP 只读入口：`mempal_knowledge_cards` list/get/events，不开放写操作 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -122,6 +123,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p32-knowledge-card-schema-v8-implementation.md` — P32 knowledge card schema v8（已完成）
 - `docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md` — P33 knowledge card core API（已完成）
 - `docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md` — P34 knowledge card CLI（已完成）
+- `docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md` — P35 knowledge card MCP read（已完成）
 
 ### Spec 使用方式
 

--- a/docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md
+++ b/docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md
@@ -1,0 +1,30 @@
+# P35 Knowledge Card MCP Read Implementation Plan
+
+**Goal:** Add a read-only MCP inspection tool for Phase-2 knowledge cards:
+`mempal_knowledge_cards` with `list`, `get`, and `events` actions.
+
+**Architecture:** Keep DTOs in `src/mcp/tools.rs` and dispatch in
+`src/mcp/server.rs`, reusing P33 `Database` read APIs. Update protocol text and
+repo inventories. Do not expose MCP writes.
+
+## Steps
+
+- [x] Add P35 task contract.
+- [x] Add knowledge card MCP DTOs and response conversions.
+- [x] Add `mempal_knowledge_cards` action dispatch for `list/get/events`.
+- [x] Add protocol/tool registry read-only guidance.
+- [x] Add MCP tests for filters, get/missing, events, rejected writes, and registry/protocol.
+- [x] Update AGENTS / CLAUDE inventories.
+- [x] Run spec lint, formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p35-knowledge-card-mcp-read.spec.md
+agent-spec lint specs/p35-knowledge-card-mcp-read.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p35-knowledge-card-mcp-read.spec.md
+++ b/specs/p35-knowledge-card-mcp-read.spec.md
@@ -1,0 +1,93 @@
+spec: task
+name: "P35: knowledge card MCP read API"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, mcp, phase-2]
+---
+
+## Intent
+
+P34 exposed Phase-2 knowledge cards through a local CLI. P35 adds the first MCP
+read surface so agents can inspect cards and event history from the same schema
+v8 tables without gaining write access through MCP.
+
+## Decisions
+
+- Add one MCP tool named `mempal_knowledge_cards`.
+- Support read-only actions: `list`, `get`, and `events`.
+- `list` accepts the same filters as `KnowledgeCardFilter`: tier, status,
+  domain, field, anchor_kind, and anchor_id.
+- `get` requires `card_id` and returns exactly one card or an MCP error when
+  missing.
+- `events` requires `card_id` and returns append-only events for that card.
+- Reuse P33 `Database` read APIs; do not write direct SQL in the MCP handler.
+- Include the tool in `MEMORY_PROTOCOL` as a Phase-2 read-only inspection tool.
+- Do not add MCP write actions for create, update, delete, link, or event append.
+- Do not add REST, CLI changes beyond docs inventory, search, context, wake-up,
+  lifecycle automation, promotion gates, or backfill behavior.
+
+## Acceptance Criteria
+
+Scenario: MCP list returns filtered cards
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_cards_list_filters
+  Given schema v8 with multiple knowledge cards
+  When calling `mempal_knowledge_cards` with action `list` and tier/status/field filters
+  Then only matching cards are returned
+
+Scenario: MCP get returns one card or missing error
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_cards_get_and_missing
+  Given schema v8 with one knowledge card
+  When calling `mempal_knowledge_cards` with action `get` and its card id
+  Then the returned card includes statement, content, tier, status, domain, field, and anchor metadata
+  When calling action `get` for a missing card id
+  Then the tool returns an MCP error
+
+Scenario: MCP events returns event history
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_cards_events
+  Given schema v8 with one knowledge card and two events
+  When calling `mempal_knowledge_cards` with action `events`
+  Then the response contains those events ordered by created_at and id
+
+Scenario: MCP rejects write actions
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_cards_rejects_write_actions
+  Given schema v8
+  When calling `mempal_knowledge_cards` with action `create`
+  Then the tool returns an invalid params error
+  And no knowledge card rows are written
+
+Scenario: tool registry and protocol expose read-only boundary
+  Test:
+    Package: mempal
+    Filter: test_mcp_tool_registry_and_protocol_include_knowledge_cards_readonly
+  Given a mempal MCP server
+  When listing registered MCP tools and reading `MEMORY_PROTOCOL`
+  Then `mempal_knowledge_cards` is present
+  And its description and protocol text say it is read-only
+
+## Out of Scope
+
+- Do not add MCP card create.
+- Do not add MCP card update.
+- Do not add MCP card delete.
+- Do not add MCP evidence link writes.
+- Do not add MCP event append writes.
+- Do not add REST endpoints.
+- Do not change CLI behavior.
+- Do not change search results.
+- Do not change context assembly.
+- Do not change wake-up.
+- Do not backfill existing `memory_kind=knowledge` drawers into cards.
+
+## Constraints
+
+- Keep the MCP surface action-based to match existing `mempal_tunnels` and
+  `mempal_kg` style.
+- Keep all returned records source-backed by schema v8 card/event ids.
+- Invalid actions must fail before any database mutation.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -202,6 +202,12 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    updates only anchor metadata and audit history; it does not rewrite content,
    re-embed vectors, or change knowledge tier/status.
 
+16. INSPECT PHASE-2 KNOWLEDGE CARDS READ-ONLY
+   Use mempal_knowledge_cards to inspect Phase-2 knowledge card records and
+   append-only event history. This tool is read-only: list/get/events are the
+   only supported actions. It does not create cards, link evidence, append
+   events, mutate lifecycle, search, assemble context, or backfill drawers.
+
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
@@ -210,6 +216,7 @@ TOOLS:
   mempal_knowledge_distill — create candidate knowledge from evidence refs
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
+  mempal_knowledge_cards — read-only Phase-2 knowledge card list/get/events
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,8 +6,9 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     types::{
-        AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeStatus, KnowledgeTier,
-        MemoryDomain, MemoryKind, Provenance, SourceType, TriggerHints, Triple,
+        AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
+        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, SourceType,
+        TriggerHints, Triple,
     },
     utils::{
         build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp,
@@ -48,6 +49,7 @@ use super::tools::{
     ContextRequest, ContextResponse, CoworkPushRequest, CoworkPushResponse, DeleteRequest,
     DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
     FieldTaxonomyResponse, IngestRequest, IngestResponse, KgRequest, KgResponse, KgStatsDto,
+    KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse,
     KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
     KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
@@ -205,6 +207,17 @@ impl MempalMcpServer {
         &self,
     ) -> std::result::Result<KnowledgePolicyResponse, ErrorData> {
         self.mempal_knowledge_policy()
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn knowledge_cards_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<KnowledgeCardsResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_knowledge_cards(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -583,6 +596,14 @@ fn trim_to_owned(value: Option<&str>) -> Option<String> {
     trim_to_option(value).map(ToOwned::to_owned)
 }
 
+fn required_string<'a>(
+    value: Option<&'a str>,
+    field: &'static str,
+) -> std::result::Result<&'a str, ErrorData> {
+    trim_to_option(value)
+        .ok_or_else(|| ErrorData::invalid_params(format!("{field} is required"), None))
+}
+
 fn anchor_error(error: anchor::AnchorError) -> ErrorData {
     ErrorData::invalid_params(error.to_string(), None)
 }
@@ -830,6 +851,85 @@ impl MempalMcpServer {
         &self,
     ) -> std::result::Result<Json<KnowledgePolicyResponse>, ErrorData> {
         Ok(Json(KnowledgePolicyResponse::from(promotion_policy())))
+    }
+
+    #[tool(
+        name = "mempal_knowledge_cards",
+        description = "Read-only Phase-2 knowledge card inspection. Actions: list/get/events. Reads schema v8 knowledge_cards and knowledge_events only; does not create cards, link evidence, append events, mutate lifecycle, search, assemble context, or backfill."
+    )]
+    async fn mempal_knowledge_cards(
+        &self,
+        Parameters(request): Parameters<KnowledgeCardsRequest>,
+    ) -> std::result::Result<Json<KnowledgeCardsResponse>, ErrorData> {
+        let action = trim_to_option(Some(request.action.as_str()))
+            .ok_or_else(|| ErrorData::invalid_params("action must not be empty", None))?;
+        let db = self.open_db()?;
+
+        match action {
+            "list" => {
+                let filter = KnowledgeCardFilter {
+                    tier: parse_tier(request.tier.as_deref())?,
+                    status: parse_status(request.status.as_deref())?,
+                    domain: parse_domain(request.domain.as_deref())?,
+                    field: trim_to_owned(request.field.as_deref()),
+                    anchor_kind: parse_anchor_kind(request.anchor_kind.as_deref())?,
+                    anchor_id: trim_to_owned(request.anchor_id.as_deref()),
+                };
+                let cards = db.list_knowledge_cards(&filter).map_err(|error| {
+                    ErrorData::internal_error(
+                        format!("failed to list knowledge cards: {error}"),
+                        None,
+                    )
+                })?;
+                Ok(Json(KnowledgeCardsResponse {
+                    cards: cards.into_iter().map(KnowledgeCardDto::from).collect(),
+                    events: Vec::new(),
+                }))
+            }
+            "get" => {
+                let card_id = required_string(request.card_id.as_deref(), "card_id")?;
+                let card = db
+                    .get_knowledge_card(card_id)
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to get knowledge card: {error}"),
+                            None,
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        ErrorData::invalid_params(
+                            format!("knowledge card not found: {card_id}"),
+                            None,
+                        )
+                    })?;
+                Ok(Json(KnowledgeCardsResponse {
+                    cards: vec![KnowledgeCardDto::from(card)],
+                    events: Vec::new(),
+                }))
+            }
+            "events" => {
+                let card_id = required_string(request.card_id.as_deref(), "card_id")?;
+                let events = db.knowledge_events(card_id).map_err(|error| {
+                    ErrorData::internal_error(
+                        format!("failed to list knowledge card events: {error}"),
+                        None,
+                    )
+                })?;
+                Ok(Json(KnowledgeCardsResponse {
+                    cards: Vec::new(),
+                    events: events
+                        .into_iter()
+                        .map(KnowledgeCardEventDto::from)
+                        .collect(),
+                }))
+            }
+            other => Err(ErrorData::invalid_params(
+                format!(
+                    "unsupported knowledge cards action: {other}; read-only actions are list, get, events"
+                ),
+                None,
+            )),
+        }
     }
 
     #[tool(
@@ -1783,7 +1883,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::core::types::BootstrapEvidenceArgs;
+    use crate::core::types::{
+        BootstrapEvidenceArgs, KnowledgeCard, KnowledgeCardEvent, KnowledgeEventType,
+    };
     use crate::embed::Embedder;
 
     #[derive(Clone)]
@@ -1844,6 +1946,62 @@ mod tests {
             }),
         );
         (tempdir, db_path, server)
+    }
+
+    fn knowledge_card(
+        id: &str,
+        tier: KnowledgeTier,
+        status: KnowledgeStatus,
+        field: &str,
+    ) -> KnowledgeCard {
+        KnowledgeCard {
+            id: id.to_string(),
+            statement: format!("Statement for {id}."),
+            content: format!("Content for {id}."),
+            tier,
+            status,
+            domain: MemoryDomain::Project,
+            field: field.to_string(),
+            anchor_kind: AnchorKind::Repo,
+            anchor_id: "repo://mempal".to_string(),
+            parent_anchor_id: None,
+            scope_constraints: Some("Only for MCP read tests.".to_string()),
+            trigger_hints: Some(TriggerHints {
+                intent_tags: vec!["memory".to_string()],
+                workflow_bias: vec!["inspect-first".to_string()],
+                tool_needs: vec!["mcp".to_string()],
+            }),
+            created_at: "1713000000".to_string(),
+            updated_at: "1713000000".to_string(),
+        }
+    }
+
+    fn insert_knowledge_card(db_path: &Path, card: KnowledgeCard) {
+        let db = Database::open(db_path).expect("open db");
+        db.insert_knowledge_card(&card)
+            .expect("insert knowledge card");
+    }
+
+    fn insert_knowledge_card_event(
+        db_path: &Path,
+        id: &str,
+        card_id: &str,
+        event_type: KnowledgeEventType,
+        created_at: &str,
+    ) {
+        let db = Database::open(db_path).expect("open db");
+        db.append_knowledge_event(&KnowledgeCardEvent {
+            id: id.to_string(),
+            card_id: card_id.to_string(),
+            event_type,
+            from_status: Some(KnowledgeStatus::Candidate),
+            to_status: Some(KnowledgeStatus::Promoted),
+            reason: format!("reason for {id}"),
+            actor: Some("codex".to_string()),
+            metadata: Some(serde_json::json!({ "source": "test" })),
+            created_at: created_at.to_string(),
+        })
+        .expect("append knowledge card event");
     }
 
     fn insert_drawer(
@@ -2516,6 +2674,187 @@ mod tests {
                 .as_deref()
                 .unwrap_or_default()
                 .contains("Stage-1 knowledge promotion policy")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_cards_list_filters() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_card(
+            &db_path,
+            knowledge_card(
+                "card_match",
+                KnowledgeTier::DaoRen,
+                KnowledgeStatus::Promoted,
+                "rust",
+            ),
+        );
+        insert_knowledge_card(
+            &db_path,
+            knowledge_card(
+                "card_wrong_tier",
+                KnowledgeTier::Shu,
+                KnowledgeStatus::Promoted,
+                "rust",
+            ),
+        );
+        insert_knowledge_card(
+            &db_path,
+            knowledge_card(
+                "card_wrong_field",
+                KnowledgeTier::DaoRen,
+                KnowledgeStatus::Promoted,
+                "docs",
+            ),
+        );
+
+        let response = server
+            .knowledge_cards_json_for_test(serde_json::json!({
+                "action": "list",
+                "tier": "dao_ren",
+                "status": "promoted",
+                "field": "rust"
+            }))
+            .await
+            .expect("list cards");
+
+        assert_eq!(response.cards.len(), 1);
+        assert_eq!(response.cards[0].id, "card_match");
+        assert!(response.events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_cards_get_and_missing() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_card(
+            &db_path,
+            knowledge_card(
+                "card_get",
+                KnowledgeTier::Shu,
+                KnowledgeStatus::Promoted,
+                "rust",
+            ),
+        );
+
+        let response = server
+            .knowledge_cards_json_for_test(serde_json::json!({
+                "action": "get",
+                "card_id": "card_get"
+            }))
+            .await
+            .expect("get card");
+        let card = response.cards.first().expect("card");
+        assert_eq!(card.id, "card_get");
+        assert_eq!(card.statement, "Statement for card_get.");
+        assert_eq!(card.content, "Content for card_get.");
+        assert_eq!(card.tier, "shu");
+        assert_eq!(card.status, "promoted");
+        assert_eq!(card.domain, "project");
+        assert_eq!(card.field, "rust");
+        assert_eq!(card.anchor_kind, "repo");
+        assert_eq!(card.anchor_id, "repo://mempal");
+        assert_eq!(
+            card.trigger_hints
+                .as_ref()
+                .expect("trigger hints")
+                .tool_needs,
+            vec!["mcp"]
+        );
+
+        let missing = server
+            .knowledge_cards_json_for_test(serde_json::json!({
+                "action": "get",
+                "card_id": "card_missing"
+            }))
+            .await
+            .expect_err("missing card should fail");
+        assert!(missing.to_string().contains("knowledge card not found"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_cards_events() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_card(
+            &db_path,
+            knowledge_card(
+                "card_events",
+                KnowledgeTier::Shu,
+                KnowledgeStatus::Promoted,
+                "rust",
+            ),
+        );
+        insert_knowledge_card_event(
+            &db_path,
+            "event_b",
+            "card_events",
+            KnowledgeEventType::Promoted,
+            "1713000002",
+        );
+        insert_knowledge_card_event(
+            &db_path,
+            "event_a",
+            "card_events",
+            KnowledgeEventType::Created,
+            "1713000001",
+        );
+
+        let response = server
+            .knowledge_cards_json_for_test(serde_json::json!({
+                "action": "events",
+                "card_id": "card_events"
+            }))
+            .await
+            .expect("list events");
+
+        assert!(response.cards.is_empty());
+        assert_eq!(response.events.len(), 2);
+        assert_eq!(response.events[0].id, "event_a");
+        assert_eq!(response.events[0].event_type, "created");
+        assert_eq!(response.events[1].id, "event_b");
+        assert_eq!(response.events[1].event_type, "promoted");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_knowledge_cards_rejects_write_actions() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.list_knowledge_cards(&KnowledgeCardFilter::default())
+                .expect("list cards")
+                .len()
+        };
+
+        let error = server
+            .knowledge_cards_json_for_test(serde_json::json!({
+                "action": "create"
+            }))
+            .await
+            .expect_err("write action should be rejected");
+        assert!(error.to_string().contains("read-only actions"));
+
+        let after = {
+            let db = Database::open(&db_path).expect("open db");
+            db.list_knowledge_cards(&KnowledgeCardFilter::default())
+                .expect("list cards")
+                .len()
+        };
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_knowledge_cards_readonly() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_knowledge_cards")
+            .expect("mempal_knowledge_cards tool exists");
+        let description = tool.description.as_deref().unwrap_or_default();
+        assert!(description.contains("Read-only Phase-2 knowledge card inspection"));
+        assert!(description.contains("Actions: list/get/events"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_cards"));
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL.contains("read-only Phase-2 knowledge card")
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,7 +1,8 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::types::{
-    AnchorKind, ChunkNeighbors, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
-    NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry, TunnelEndpoint,
+    AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
+    MemoryDomain, MemoryKind, NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry,
+    TunnelEndpoint,
 };
 use crate::field_taxonomy::FieldTaxonomyEntry;
 use crate::knowledge_anchor::PublishAnchorOutcome;
@@ -259,6 +260,55 @@ pub struct KnowledgePolicyEntryDto {
     pub tier: String,
     pub target_status: String,
     pub requirements: KnowledgeGateRequirementsDto,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct KnowledgeCardsRequest {
+    pub action: String,
+    pub card_id: Option<String>,
+    pub tier: Option<String>,
+    pub status: Option<String>,
+    pub domain: Option<String>,
+    pub field: Option<String>,
+    pub anchor_kind: Option<String>,
+    pub anchor_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeCardsResponse {
+    pub cards: Vec<KnowledgeCardDto>,
+    pub events: Vec<KnowledgeCardEventDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeCardDto {
+    pub id: String,
+    pub statement: String,
+    pub content: String,
+    pub tier: String,
+    pub status: String,
+    pub domain: String,
+    pub field: String,
+    pub anchor_kind: String,
+    pub anchor_id: String,
+    pub parent_anchor_id: Option<String>,
+    pub scope_constraints: Option<String>,
+    pub trigger_hints: Option<TriggerHintsDto>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeCardEventDto {
+    pub id: String,
+    pub card_id: String,
+    pub event_type: String,
+    pub from_status: Option<String>,
+    pub to_status: Option<String>,
+    pub reason: String,
+    pub actor: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: String,
 }
 
 impl From<Vec<PromotionPolicyEntry>> for KnowledgePolicyResponse {
@@ -869,6 +919,51 @@ impl From<crate::core::types::TriggerHints> for TriggerHintsDto {
     }
 }
 
+impl From<KnowledgeCard> for KnowledgeCardDto {
+    fn from(value: KnowledgeCard) -> Self {
+        Self {
+            id: value.id,
+            statement: value.statement,
+            content: value.content,
+            tier: knowledge_tier_slug(&value.tier).to_string(),
+            status: knowledge_status_slug(&value.status).to_string(),
+            domain: domain_slug(&value.domain).to_string(),
+            field: value.field,
+            anchor_kind: anchor_kind_slug(&value.anchor_kind).to_string(),
+            anchor_id: value.anchor_id,
+            parent_anchor_id: value.parent_anchor_id,
+            scope_constraints: value.scope_constraints,
+            trigger_hints: value.trigger_hints.map(TriggerHintsDto::from),
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+        }
+    }
+}
+
+impl From<KnowledgeCardEvent> for KnowledgeCardEventDto {
+    fn from(value: KnowledgeCardEvent) -> Self {
+        Self {
+            id: value.id,
+            card_id: value.card_id,
+            event_type: knowledge_event_type_slug(&value.event_type).to_string(),
+            from_status: value
+                .from_status
+                .as_ref()
+                .map(knowledge_status_slug)
+                .map(str::to_string),
+            to_status: value
+                .to_status
+                .as_ref()
+                .map(knowledge_status_slug)
+                .map(str::to_string),
+            reason: value.reason,
+            actor: value.actor,
+            metadata: value.metadata,
+            created_at: value.created_at,
+        }
+    }
+}
+
 impl From<ChunkNeighbors> for ChunkNeighborsDto {
     fn from(value: ChunkNeighbors) -> Self {
         Self {
@@ -928,6 +1023,19 @@ fn anchor_kind_slug(value: &AnchorKind) -> &'static str {
         AnchorKind::Global => "global",
         AnchorKind::Repo => "repo",
         AnchorKind::Worktree => "worktree",
+    }
+}
+
+fn knowledge_event_type_slug(value: &crate::core::types::KnowledgeEventType) -> &'static str {
+    match value {
+        crate::core::types::KnowledgeEventType::Created => "created",
+        crate::core::types::KnowledgeEventType::Promoted => "promoted",
+        crate::core::types::KnowledgeEventType::Demoted => "demoted",
+        crate::core::types::KnowledgeEventType::Retired => "retired",
+        crate::core::types::KnowledgeEventType::Linked => "linked",
+        crate::core::types::KnowledgeEventType::Unlinked => "unlinked",
+        crate::core::types::KnowledgeEventType::Updated => "updated",
+        crate::core::types::KnowledgeEventType::PublishedAnchor => "published_anchor",
     }
 }
 


### PR DESCRIPTION
## Summary

- add read-only `mempal_knowledge_cards` MCP tool for Phase-2 knowledge cards
- support `list`, `get`, and `events` actions over schema v8 card/event tables
- return typed card and event DTOs with tier/status/domain/anchor metadata
- reject unsupported/write actions before mutation
- update `MEMORY_PROTOCOL` and repo inventories with read-only boundary

## Validation

- `agent-spec parse specs/p35-knowledge-card-mcp-read.spec.md`
- `agent-spec lint specs/p35-knowledge-card-mcp-read.spec.md --min-score 0.7`
- `cargo fmt --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`

Note: one initial full `cargo test` run hit a transient local HTTP stub `WouldBlock` in `tests/context_assembler.rs`; the failing test passed on direct rerun and the following full `cargo test` passed.
