### PR TITLE
feat: add knowledge card backfill report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p33-knowledge-card-core-api.spec.md` | 完成 | Phase-2 knowledge card DB core API：Rust types + card/link/event create/read/update/list，不暴露 CLI/MCP/REST |
 | `specs/p34-knowledge-card-cli.spec.md` | 完成 | Phase-2 knowledge card 最小 CLI 管理入口：create/get/list/link/event/events，不接入 MCP/REST/search/context |
 | `specs/p35-knowledge-card-mcp-read.spec.md` | 完成 | Phase-2 knowledge card MCP 只读入口：`mempal_knowledge_cards` list/get/events，不开放写操作 |
+| `specs/p36-knowledge-card-backfill-report.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 只读 backfill-plan report；dry-run，不迁移 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -126,6 +127,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md` — P33 knowledge card core API（已完成）
 - `docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md` — P34 knowledge card CLI（已完成）
 - `docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md` — P35 knowledge card MCP read（已完成）
+- `docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md` — P36 knowledge card backfill report（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p33-knowledge-card-core-api.spec.md` | 完成 | Phase-2 knowledge card DB core API：Rust types + card/link/event create/read/update/list，不暴露 CLI/MCP/REST |
 | `specs/p34-knowledge-card-cli.spec.md` | 完成 | Phase-2 knowledge card 最小 CLI 管理入口：create/get/list/link/event/events，不接入 MCP/REST/search/context |
 | `specs/p35-knowledge-card-mcp-read.spec.md` | 完成 | Phase-2 knowledge card MCP 只读入口：`mempal_knowledge_cards` list/get/events，不开放写操作 |
+| `specs/p36-knowledge-card-backfill-report.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 只读 backfill-plan report；dry-run，不迁移 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -124,6 +125,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p33-knowledge-card-core-api-implementation.md` — P33 knowledge card core API（已完成）
 - `docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md` — P34 knowledge card CLI（已完成）
 - `docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md` — P35 knowledge card MCP read（已完成）
+- `docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md` — P36 knowledge card backfill report（已完成）
 
 ### Spec 使用方式
 

--- a/docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md
+++ b/docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md
@@ -1,0 +1,31 @@
+# P36 Knowledge Card Backfill Report Implementation Plan
+
+**Goal:** Add a read-only dry-run report that identifies Stage-1
+`memory_kind=knowledge` drawers that can later become Phase-2 knowledge cards.
+
+**Architecture:** Add a small core module that reads Stage-1 knowledge drawers
+through `Database`, maps them to deterministic prospective card ids, and returns
+ready/skipped/already-existing candidates. Expose it through
+`mempal knowledge-card backfill-plan` only.
+
+## Steps
+
+- [x] Add P36 task contract.
+- [x] Add core report types and deterministic prospective id mapping.
+- [x] Add `Database` read helpers for knowledge drawer candidates and card count.
+- [x] Add CLI `knowledge-card backfill-plan` with plain and JSON output.
+- [x] Add core and CLI tests for classification, read-only behavior, filters, and invalid format.
+- [x] Update AGENTS / CLAUDE inventories.
+- [x] Run spec lint, formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p36-knowledge-card-backfill-report.spec.md
+agent-spec lint specs/p36-knowledge-card-backfill-report.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p36-knowledge-card-backfill-report.spec.md
+++ b/specs/p36-knowledge-card-backfill-report.spec.md
@@ -1,0 +1,92 @@
+spec: task
+name: "P36: knowledge card backfill dry-run report"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, backfill, phase-2]
+---
+
+## Intent
+
+P32-P35 made Phase-2 knowledge cards usable, but existing Stage-1 knowledge still
+lives in `drawers` with `memory_kind=knowledge`. P36 adds a read-only backfill
+planning report that maps eligible knowledge drawers to prospective card ids and
+explains skips before any migration command exists.
+
+## Decisions
+
+- Add a core report function for Stage-1 knowledge drawer to Phase-2 card planning.
+- Add a CLI command `mempal knowledge-card backfill-plan`.
+- Keep the command dry-run only; it never writes `knowledge_cards`,
+  `knowledge_evidence_links`, `knowledge_events`, `drawers`, vectors, or audit logs.
+- Generate prospective card ids deterministically from the source drawer id.
+- Mark drawers as `ready` only when required card fields are present:
+  statement, tier, status, domain, field, anchor_kind, and anchor_id.
+- Mark drawers as `already_exists` when the prospective card id is already present.
+- Mark drawers as `skipped` with reasons when required fields are missing or invalid.
+- Support optional filters for domain, field, tier, status, and anchor_kind.
+- Support plain output and `--format json`.
+- Do not add actual backfill migration, MCP, REST, search, context, wake-up, or
+  lifecycle behavior in P36.
+
+## Acceptance Criteria
+
+Scenario: core report classifies ready skipped and existing drawers
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_backfill_report_classifies_drawers
+  Given Stage-1 knowledge drawers covering ready, missing metadata, and already-carded cases
+  When building the backfill report
+  Then ready drawers include prospective card ids
+  And skipped drawers include explicit reasons
+  And existing card rows are reported as already_exists
+
+Scenario: core report is read-only
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_backfill_report_has_no_db_side_effects
+  Given a database with knowledge drawers and no card rows
+  When building the backfill report repeatedly
+  Then drawer count and knowledge card count stay unchanged
+
+Scenario: CLI plain report summarizes counts and items
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_backfill_plan_plain
+  Given an initialized mempal home with Stage-1 knowledge drawers
+  When running `mempal knowledge-card backfill-plan`
+  Then stdout includes ready, skipped, and already_exists counts
+  And stdout includes the source drawer id and prospective card id
+
+Scenario: CLI JSON report supports filters
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_backfill_plan_json_filters
+  Given knowledge drawers across multiple fields
+  When running `mempal knowledge-card backfill-plan --field rust --format json`
+  Then the JSON report contains only matching drawer candidates
+
+Scenario: command rejects unsupported format
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_backfill_plan_rejects_invalid_format
+  Given an initialized mempal home
+  When running `mempal knowledge-card backfill-plan --format yaml`
+  Then the command exits non-zero
+  And stderr says the format is unsupported
+
+## Out of Scope
+
+- Do not insert knowledge cards.
+- Do not insert evidence links.
+- Do not insert knowledge events.
+- Do not mutate drawers.
+- Do not re-embed vectors.
+- Do not write audit logs.
+- Do not add MCP tools.
+- Do not add REST endpoints.
+- Do not change search, context, wake-up, or lifecycle behavior.
+
+## Constraints
+
+- The report must use existing Stage-1 drawer metadata as source of truth.
+- Missing required metadata must be visible in report output.
+- Deterministic prospective ids must allow future migration to be idempotent.

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -858,6 +858,52 @@ impl Database {
         Ok(rows)
     }
 
+    pub fn knowledge_card_count(&self) -> Result<i64, DbError> {
+        self.conn
+            .query_row("SELECT COUNT(*) FROM knowledge_cards", [], |row| row.get(0))
+            .map_err(Into::into)
+    }
+
+    pub fn list_knowledge_drawers_for_card_backfill(
+        &self,
+        filter: &KnowledgeCardFilter,
+    ) -> Result<Vec<Drawer>, DbError> {
+        let tier = filter.tier.as_ref().map(knowledge_tier_as_str);
+        let status = filter.status.as_ref().map(knowledge_status_as_str);
+        let domain = filter.domain.as_ref().map(memory_domain_as_str);
+        let anchor_kind = filter.anchor_kind.as_ref().map(anchor_kind_as_str);
+
+        let mut statement = self.conn.prepare(&format!(
+            r#"
+            SELECT {DRAWER_SELECT_COLUMNS}
+            FROM drawers
+            WHERE deleted_at IS NULL
+              AND memory_kind = 'knowledge'
+              AND (?1 IS NULL OR tier = ?1)
+              AND (?2 IS NULL OR status = ?2)
+              AND (?3 IS NULL OR domain = ?3)
+              AND (?4 IS NULL OR field = ?4)
+              AND (?5 IS NULL OR anchor_kind = ?5)
+              AND (?6 IS NULL OR anchor_id = ?6)
+            ORDER BY id
+            "#,
+        ))?;
+        let rows = statement
+            .query_map(
+                params![
+                    tier,
+                    status,
+                    domain,
+                    filter.field.as_deref(),
+                    anchor_kind,
+                    filter.anchor_id.as_deref(),
+                ],
+                |row| drawer_from_row(row).map_err(row_decode_error),
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     pub fn update_knowledge_card(&self, card: &KnowledgeCard) -> Result<bool, DbError> {
         anchor::validate_anchor_domain(&card.domain, &card.anchor_kind)
             .map_err(|message| DbError::InvalidDrawerMetadata(message.to_string()))?;

--- a/src/knowledge_card_backfill.rs
+++ b/src/knowledge_card_backfill.rs
@@ -1,0 +1,172 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::core::db::{Database, DbError};
+use crate::core::types::{Drawer, KnowledgeCardFilter};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeCardBackfillReport {
+    pub ready_count: usize,
+    pub skipped_count: usize,
+    pub already_exists_count: usize,
+    pub candidates: Vec<KnowledgeCardBackfillCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeCardBackfillCandidate {
+    pub source_drawer_id: String,
+    pub prospective_card_id: String,
+    pub status: KnowledgeCardBackfillStatus,
+    pub reasons: Vec<String>,
+    pub statement: Option<String>,
+    pub tier: Option<String>,
+    pub knowledge_status: Option<String>,
+    pub domain: String,
+    pub field: String,
+    pub anchor_kind: String,
+    pub anchor_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnowledgeCardBackfillStatus {
+    Ready,
+    Skipped,
+    AlreadyExists,
+}
+
+pub fn build_backfill_report(
+    db: &Database,
+    filter: &KnowledgeCardFilter,
+) -> Result<KnowledgeCardBackfillReport, DbError> {
+    let drawers = db.list_knowledge_drawers_for_card_backfill(filter)?;
+    let mut candidates = Vec::with_capacity(drawers.len());
+    let mut ready_count = 0;
+    let mut skipped_count = 0;
+    let mut already_exists_count = 0;
+
+    for drawer in drawers {
+        let candidate = classify_drawer(db, drawer)?;
+        match candidate.status {
+            KnowledgeCardBackfillStatus::Ready => ready_count += 1,
+            KnowledgeCardBackfillStatus::Skipped => skipped_count += 1,
+            KnowledgeCardBackfillStatus::AlreadyExists => already_exists_count += 1,
+        }
+        candidates.push(candidate);
+    }
+
+    Ok(KnowledgeCardBackfillReport {
+        ready_count,
+        skipped_count,
+        already_exists_count,
+        candidates,
+    })
+}
+
+pub fn prospective_card_id(source_drawer_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"knowledge-card-backfill-v1");
+    hasher.update([0]);
+    hasher.update(source_drawer_id.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("card_{}", &digest[..16])
+}
+
+fn classify_drawer(
+    db: &Database,
+    drawer: Drawer,
+) -> Result<KnowledgeCardBackfillCandidate, DbError> {
+    let prospective_card_id = prospective_card_id(&drawer.id);
+    let reasons = skip_reasons(&drawer);
+    let status = if !reasons.is_empty() {
+        KnowledgeCardBackfillStatus::Skipped
+    } else if db.get_knowledge_card(&prospective_card_id)?.is_some() {
+        KnowledgeCardBackfillStatus::AlreadyExists
+    } else {
+        KnowledgeCardBackfillStatus::Ready
+    };
+
+    Ok(KnowledgeCardBackfillCandidate {
+        source_drawer_id: drawer.id,
+        prospective_card_id,
+        status,
+        reasons,
+        statement: drawer.statement,
+        tier: drawer
+            .tier
+            .as_ref()
+            .map(knowledge_tier_slug)
+            .map(str::to_string),
+        knowledge_status: drawer
+            .status
+            .as_ref()
+            .map(knowledge_status_slug)
+            .map(str::to_string),
+        domain: memory_domain_slug(&drawer.domain).to_string(),
+        field: drawer.field,
+        anchor_kind: anchor_kind_slug(&drawer.anchor_kind).to_string(),
+        anchor_id: drawer.anchor_id,
+    })
+}
+
+fn skip_reasons(drawer: &Drawer) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if drawer
+        .statement
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_none()
+    {
+        reasons.push("missing statement".to_string());
+    }
+    if drawer.tier.is_none() {
+        reasons.push("missing tier".to_string());
+    }
+    if drawer.status.is_none() {
+        reasons.push("missing status".to_string());
+    }
+    if drawer.field.trim().is_empty() {
+        reasons.push("missing field".to_string());
+    }
+    if drawer.anchor_id.trim().is_empty() {
+        reasons.push("missing anchor_id".to_string());
+    }
+    reasons
+}
+
+fn memory_domain_slug(value: &crate::core::types::MemoryDomain) -> &'static str {
+    match value {
+        crate::core::types::MemoryDomain::Project => "project",
+        crate::core::types::MemoryDomain::Agent => "agent",
+        crate::core::types::MemoryDomain::Skill => "skill",
+        crate::core::types::MemoryDomain::Global => "global",
+    }
+}
+
+fn knowledge_tier_slug(value: &crate::core::types::KnowledgeTier) -> &'static str {
+    match value {
+        crate::core::types::KnowledgeTier::Qi => "qi",
+        crate::core::types::KnowledgeTier::Shu => "shu",
+        crate::core::types::KnowledgeTier::DaoRen => "dao_ren",
+        crate::core::types::KnowledgeTier::DaoTian => "dao_tian",
+    }
+}
+
+fn knowledge_status_slug(value: &crate::core::types::KnowledgeStatus) -> &'static str {
+    match value {
+        crate::core::types::KnowledgeStatus::Candidate => "candidate",
+        crate::core::types::KnowledgeStatus::Promoted => "promoted",
+        crate::core::types::KnowledgeStatus::Canonical => "canonical",
+        crate::core::types::KnowledgeStatus::Demoted => "demoted",
+        crate::core::types::KnowledgeStatus::Retired => "retired",
+    }
+}
+
+fn anchor_kind_slug(value: &crate::core::types::AnchorKind) -> &'static str {
+    match value {
+        crate::core::types::AnchorKind::Global => "global",
+        crate::core::types::AnchorKind::Repo => "repo",
+        crate::core::types::AnchorKind::Worktree => "worktree",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod factcheck;
 pub mod field_taxonomy;
 pub mod ingest;
 pub mod knowledge_anchor;
+pub mod knowledge_card_backfill;
 pub mod knowledge_distill;
 pub mod knowledge_gate;
 pub mod knowledge_lifecycle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use mempal::ingest::{
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
 use mempal::knowledge_anchor::{PublishAnchorRequest, publish_anchor};
+use mempal::knowledge_card_backfill::{KnowledgeCardBackfillReport, build_backfill_report};
 use mempal::knowledge_distill::{DistillPlan, DistillRequest, commit_distill, prepare_distill};
 use mempal::knowledge_gate::{
     GateReport, PromotionPolicyEntry, evaluate_gate_by_id, promotion_policy,
@@ -440,6 +441,22 @@ enum KnowledgeCardCommands {
     },
     Events {
         card_id: String,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    BackfillPlan {
+        #[arg(long)]
+        tier: Option<String>,
+        #[arg(long)]
+        status: Option<String>,
+        #[arg(long)]
+        domain: Option<String>,
+        #[arg(long)]
+        field: Option<String>,
+        #[arg(long = "anchor-kind")]
+        anchor_kind: Option<String>,
+        #[arg(long = "anchor-id")]
+        anchor_id: Option<String>,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -1779,6 +1796,27 @@ fn knowledge_card_command(db: &Database, command: KnowledgeCardCommands) -> Resu
                 .context("failed to list knowledge card events")?;
             print_knowledge_card_events(&events, &format)?;
         }
+        KnowledgeCardCommands::BackfillPlan {
+            tier,
+            status,
+            domain,
+            field,
+            anchor_kind,
+            anchor_id,
+            format,
+        } => {
+            let filter = KnowledgeCardFilter {
+                tier: tier.as_deref().map(parse_knowledge_tier).transpose()?,
+                status: status.as_deref().map(parse_knowledge_status).transpose()?,
+                domain: domain.as_deref().map(parse_domain).transpose()?,
+                field,
+                anchor_kind: anchor_kind.as_deref().map(parse_anchor_kind).transpose()?,
+                anchor_id,
+            };
+            let report = build_backfill_report(db, &filter)
+                .context("failed to build knowledge card backfill plan")?;
+            print_knowledge_card_backfill_report(&report, &format)?;
+        }
     }
 
     Ok(())
@@ -1887,6 +1925,46 @@ fn print_knowledge_card_events(events: &[KnowledgeCardEvent], format: &str) -> R
             Ok(())
         }
         other => bail!("unsupported knowledge-card format: {other}"),
+    }
+}
+
+fn print_knowledge_card_backfill_report(
+    report: &KnowledgeCardBackfillReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!(
+                "ready={} skipped={} already_exists={}",
+                report.ready_count, report.skipped_count, report.already_exists_count
+            );
+            if report.candidates.is_empty() {
+                println!("no knowledge drawers");
+                return Ok(());
+            }
+            for candidate in &report.candidates {
+                println!(
+                    "{} -> {} status={:?}",
+                    candidate.source_drawer_id, candidate.prospective_card_id, candidate.status
+                );
+                if !candidate.reasons.is_empty() {
+                    println!("  reasons: {}", candidate.reasons.join("; "));
+                }
+                if let Some(statement) = candidate.statement.as_deref() {
+                    println!("  statement: {statement}");
+                }
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize knowledge card backfill report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card backfill-plan format: {other}"),
     }
 }
 

--- a/tests/knowledge_card_backfill.rs
+++ b/tests/knowledge_card_backfill.rs
@@ -1,0 +1,214 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use mempal::core::db::Database;
+use mempal::core::types::{
+    AnchorKind, Drawer, KnowledgeCard, KnowledgeCardFilter, KnowledgeStatus, KnowledgeTier,
+    MemoryDomain, MemoryKind, SourceType,
+};
+use mempal::knowledge_card_backfill::{
+    KnowledgeCardBackfillStatus, build_backfill_report, prospective_card_id,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_home() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_dir = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_dir).expect("create .mempal");
+    let db = Database::open(&mempal_dir.join("palace.db")).expect("open db");
+    (tmp, db)
+}
+
+fn run_mempal(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .env("HOME", home)
+        .args(args)
+        .output()
+        .expect("run mempal")
+}
+
+fn stdout_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+fn knowledge_drawer(id: &str, field: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: format!("Content for {id}."),
+        wing: "mempal".to_string(),
+        room: Some("knowledge".to_string()),
+        source_file: Some(format!("knowledge://project/{field}/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 3,
+        memory_kind: MemoryKind::Knowledge,
+        domain: MemoryDomain::Project,
+        field: field.to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        provenance: None,
+        statement: Some(format!("Statement for {id}.")),
+        tier: Some(KnowledgeTier::Shu),
+        status: Some(KnowledgeStatus::Promoted),
+        supporting_refs: vec!["drawer_evidence".to_string()],
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn insert_drawer(db: &Database, drawer: Drawer) {
+    db.insert_drawer(&drawer).expect("insert drawer");
+}
+
+fn insert_existing_card(db: &Database, source_drawer_id: &str) {
+    let card = KnowledgeCard {
+        id: prospective_card_id(source_drawer_id),
+        statement: "Existing card.".to_string(),
+        content: "Existing content.".to_string(),
+        tier: KnowledgeTier::Shu,
+        status: KnowledgeStatus::Promoted,
+        domain: MemoryDomain::Project,
+        field: "rust".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        scope_constraints: None,
+        trigger_hints: None,
+        created_at: "1710000000".to_string(),
+        updated_at: "1710000000".to_string(),
+    };
+    db.insert_knowledge_card(&card).expect("insert card");
+}
+
+#[test]
+fn test_knowledge_card_backfill_report_classifies_drawers() {
+    let (_home, db) = setup_home();
+    insert_drawer(&db, knowledge_drawer("drawer_ready", "rust"));
+    let mut missing = knowledge_drawer("drawer_missing", "rust");
+    missing.statement = None;
+    missing.tier = None;
+    insert_drawer(&db, missing);
+    insert_drawer(&db, knowledge_drawer("drawer_existing", "rust"));
+    insert_existing_card(&db, "drawer_existing");
+
+    let report = build_backfill_report(&db, &KnowledgeCardFilter::default()).expect("build report");
+
+    assert_eq!(report.ready_count, 1);
+    assert_eq!(report.skipped_count, 1);
+    assert_eq!(report.already_exists_count, 1);
+
+    let ready = report
+        .candidates
+        .iter()
+        .find(|item| item.source_drawer_id == "drawer_ready")
+        .expect("ready candidate");
+    assert_eq!(ready.status, KnowledgeCardBackfillStatus::Ready);
+    assert_eq!(
+        ready.prospective_card_id,
+        prospective_card_id("drawer_ready")
+    );
+
+    let skipped = report
+        .candidates
+        .iter()
+        .find(|item| item.source_drawer_id == "drawer_missing")
+        .expect("skipped candidate");
+    assert_eq!(skipped.status, KnowledgeCardBackfillStatus::Skipped);
+    assert!(skipped.reasons.contains(&"missing statement".to_string()));
+    assert!(skipped.reasons.contains(&"missing tier".to_string()));
+
+    let existing = report
+        .candidates
+        .iter()
+        .find(|item| item.source_drawer_id == "drawer_existing")
+        .expect("existing candidate");
+    assert_eq!(existing.status, KnowledgeCardBackfillStatus::AlreadyExists);
+}
+
+#[test]
+fn test_knowledge_card_backfill_report_has_no_db_side_effects() {
+    let (_home, db) = setup_home();
+    insert_drawer(&db, knowledge_drawer("drawer_ready", "rust"));
+    let drawer_count = db.drawer_count().expect("drawer count");
+    let card_count = db.knowledge_card_count().expect("card count");
+
+    for _ in 0..3 {
+        let report =
+            build_backfill_report(&db, &KnowledgeCardFilter::default()).expect("build report");
+        assert_eq!(report.ready_count, 1);
+    }
+
+    assert_eq!(db.drawer_count().expect("drawer count"), drawer_count);
+    assert_eq!(db.knowledge_card_count().expect("card count"), card_count);
+}
+
+#[test]
+fn test_cli_knowledge_card_backfill_plan_plain() {
+    let (home, db) = setup_home();
+    insert_drawer(&db, knowledge_drawer("drawer_ready", "rust"));
+    let mut missing = knowledge_drawer("drawer_missing", "rust");
+    missing.statement = None;
+    insert_drawer(&db, missing);
+    insert_drawer(&db, knowledge_drawer("drawer_existing", "rust"));
+    insert_existing_card(&db, "drawer_existing");
+
+    let output = run_mempal(home.path(), &["knowledge-card", "backfill-plan"]);
+    assert!(output.status.success(), "{}", stderr_text(&output));
+    let stdout = stdout_text(&output);
+    assert!(stdout.contains("ready=1 skipped=1 already_exists=1"));
+    assert!(stdout.contains("drawer_ready"));
+    assert!(stdout.contains(&prospective_card_id("drawer_ready")));
+}
+
+#[test]
+fn test_cli_knowledge_card_backfill_plan_json_filters() {
+    let (home, db) = setup_home();
+    insert_drawer(&db, knowledge_drawer("drawer_rust", "rust"));
+    insert_drawer(&db, knowledge_drawer("drawer_docs", "docs"));
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "backfill-plan",
+            "--field",
+            "rust",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(output.status.success(), "{}", stderr_text(&output));
+    let value: Value = serde_json::from_slice(&output.stdout).expect("parse json");
+    assert_eq!(value["ready_count"], 1);
+    let candidates = value["candidates"].as_array().expect("candidates");
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0]["source_drawer_id"], "drawer_rust");
+}
+
+#[test]
+fn test_cli_knowledge_card_backfill_plan_rejects_invalid_format() {
+    let (home, _db) = setup_home();
+
+    let output = run_mempal(
+        home.path(),
+        &["knowledge-card", "backfill-plan", "--format", "yaml"],
+    );
+    assert!(!output.status.success());
+    assert!(stderr_text(&output).contains("unsupported knowledge-card backfill-plan format"));
+}


### PR DESCRIPTION
## Summary

- add read-only `knowledge_card_backfill` report module for Stage-1 knowledge drawer -> Phase-2 card planning
- add deterministic prospective card ids based on source drawer id
- classify candidates as `ready`, `skipped`, or `already_exists`
- expose explicit skip reasons for missing required metadata
- add `mempal knowledge-card backfill-plan` with plain and JSON output plus filters
- keep P36 dry-run only: no card/link/event inserts, drawer mutation, vector rewrite, audit write, MCP/REST, search/context/wake-up/lifecycle changes

## Validation

- `agent-spec parse specs/p36-knowledge-card-backfill-report.spec.md`
- `agent-spec lint specs/p36-knowledge-card-backfill-report.spec.md --min-score 0.7`
- `cargo fmt --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
