### PR TITLE
feat: add knowledge card backfill apply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p34-knowledge-card-cli.spec.md` | 完成 | Phase-2 knowledge card 最小 CLI 管理入口：create/get/list/link/event/events，不接入 MCP/REST/search/context |
 | `specs/p35-knowledge-card-mcp-read.spec.md` | 完成 | Phase-2 knowledge card MCP 只读入口：`mempal_knowledge_cards` list/get/events，不开放写操作 |
 | `specs/p36-knowledge-card-backfill-report.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 只读 backfill-plan report；dry-run，不迁移 |
+| `specs/p37-knowledge-card-backfill-apply.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 显式 backfill apply：默认 dry-run，`--execute` 创建 cards/links/events |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -128,6 +129,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md` — P34 knowledge card CLI（已完成）
 - `docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md` — P35 knowledge card MCP read（已完成）
 - `docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md` — P36 knowledge card backfill report（已完成）
+- `docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md` — P37 knowledge card backfill apply（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p34-knowledge-card-cli.spec.md` | 完成 | Phase-2 knowledge card 最小 CLI 管理入口：create/get/list/link/event/events，不接入 MCP/REST/search/context |
 | `specs/p35-knowledge-card-mcp-read.spec.md` | 完成 | Phase-2 knowledge card MCP 只读入口：`mempal_knowledge_cards` list/get/events，不开放写操作 |
 | `specs/p36-knowledge-card-backfill-report.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 只读 backfill-plan report；dry-run，不迁移 |
+| `specs/p37-knowledge-card-backfill-apply.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 显式 backfill apply：默认 dry-run，`--execute` 创建 cards/links/events |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -126,6 +127,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p34-knowledge-card-cli-implementation.md` — P34 knowledge card CLI（已完成）
 - `docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md` — P35 knowledge card MCP read（已完成）
 - `docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md` — P36 knowledge card backfill report（已完成）
+- `docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md` — P37 knowledge card backfill apply（已完成）
 
 ### Spec 使用方式
 

--- a/docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md
+++ b/docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md
@@ -1,0 +1,33 @@
+# P37 Knowledge Card Backfill Apply Implementation Plan
+
+**Goal:** Materialize P36 ready candidates into Phase-2 knowledge cards through
+an explicit, safe-by-default command.
+
+**Architecture:** Extend `knowledge_card_backfill` with an apply function that
+reuses the P36 report. Dry-run performs no writes. Execute creates cards,
+best-effort evidence links, and one created event per card. Stage-1 drawers stay
+untouched.
+
+## Steps
+
+- [x] Add P37 task contract.
+- [x] Add backfill apply result types and execute/dry-run core API.
+- [x] Create cards from Stage-1 drawer metadata.
+- [x] Link evidence refs by role with observable link errors.
+- [x] Append created events for created cards.
+- [x] Add CLI `knowledge-card backfill-apply`.
+- [x] Add core and CLI tests for dry-run, execute, idempotency, invalid refs, filters, and invalid format.
+- [x] Update AGENTS / CLAUDE inventories.
+- [x] Run spec lint, formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p37-knowledge-card-backfill-apply.spec.md
+agent-spec lint specs/p37-knowledge-card-backfill-apply.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p37-knowledge-card-backfill-apply.spec.md
+++ b/specs/p37-knowledge-card-backfill-apply.spec.md
@@ -1,0 +1,119 @@
+spec: task
+name: "P37: knowledge card backfill apply"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, backfill, phase-2]
+---
+
+## Intent
+
+P36 added a read-only backfill report from Stage-1 knowledge drawers to Phase-2
+knowledge cards. P37 adds the explicit apply operation that can materialize
+ready candidates as cards, evidence links, and created events while remaining
+safe by default.
+
+## Decisions
+
+- Add a core `apply_backfill` function that consumes the P36 report.
+- Add a CLI command `mempal knowledge-card backfill-apply`.
+- The CLI defaults to dry-run; it writes only when `--execute` is provided.
+- Dry-run output must show the same counts plus `created_count=0`.
+- Execute mode inserts one `knowledge_cards` row per `ready` candidate.
+- Execute mode inserts evidence links from the source drawer's supporting,
+  verification, counterexample, and teaching refs.
+- Evidence links are inserted only for refs that resolve to existing evidence
+  drawers; invalid refs are reported in `link_errors` and do not abort the card
+  insert.
+- Execute mode appends one `created` event per created card.
+- Already-existing and skipped candidates are not mutated.
+- Re-running execute mode must be idempotent: previously created cards become
+  `already_exists` and are not duplicated.
+- Support the same filters as `backfill-plan` and the same plain / JSON formats.
+- Do not delete or mutate Stage-1 knowledge drawers in P37.
+- Do not add MCP, REST, search, context, wake-up, lifecycle, or promotion-gate
+  behavior in P37.
+
+## Acceptance Criteria
+
+Scenario: core apply dry-run has no database side effects
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_backfill_apply_dry_run_no_side_effects
+  Given one ready Stage-1 knowledge drawer with evidence refs
+  When applying backfill with execute=false
+  Then no card, evidence link, event, drawer, vector, or audit row is written
+  And output reports created_count=0
+
+Scenario: core apply execute creates card links and event
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_backfill_apply_execute_creates_card_links_event
+  Given one ready Stage-1 knowledge drawer with supporting, verification, counterexample, and teaching evidence refs
+  When applying backfill with execute=true
+  Then one knowledge card is created from drawer metadata
+  And evidence links are created with the correct roles
+  And one created event is appended
+
+Scenario: execute is idempotent
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_backfill_apply_execute_is_idempotent
+  Given one ready Stage-1 knowledge drawer
+  When applying backfill with execute=true twice
+  Then the second run creates zero cards
+  And card, link, and event counts do not increase
+
+Scenario: invalid evidence refs are reported without aborting card insert
+  Test:
+    Package: mempal
+    Filter: test_knowledge_card_backfill_apply_reports_invalid_evidence_refs
+  Given one ready Stage-1 knowledge drawer with one valid evidence ref and one invalid ref
+  When applying backfill with execute=true
+  Then the card is created
+  And the valid evidence link is created
+  And the invalid ref appears in link_errors
+
+Scenario: CLI backfill-apply defaults to dry-run
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_backfill_apply_defaults_to_dry_run
+  Given one ready Stage-1 knowledge drawer
+  When running `mempal knowledge-card backfill-apply`
+  Then stdout says `dry_run=true`
+  And no knowledge card is written
+
+Scenario: CLI backfill-apply execute JSON supports filters
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_backfill_apply_execute_json_filters
+  Given ready Stage-1 knowledge drawers across multiple fields
+  When running `mempal knowledge-card backfill-apply --execute --field rust --format json`
+  Then the JSON output reports created_count=1
+  And only the matching field is materialized as a card
+
+Scenario: command rejects unsupported format
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_backfill_apply_rejects_invalid_format
+  Given an initialized mempal home
+  When running `mempal knowledge-card backfill-apply --format yaml`
+  Then the command exits non-zero
+  And stderr says the format is unsupported
+
+## Out of Scope
+
+- Do not delete or rewrite Stage-1 knowledge drawers.
+- Do not migrate vectors.
+- Do not write the JSONL audit log.
+- Do not add MCP tools.
+- Do not add REST endpoints.
+- Do not change search results.
+- Do not change context assembly.
+- Do not change wake-up.
+- Do not change Stage-1 lifecycle commands.
+
+## Constraints
+
+- Execute mode must use deterministic prospective card ids from P36.
+- Apply must never operate on skipped or already-existing candidates.
+- Card creation and event creation for a single candidate should be transactional.
+- Link failures must be observable but must not roll back the already-created card.

--- a/src/knowledge_card_backfill.rs
+++ b/src/knowledge_card_backfill.rs
@@ -2,7 +2,11 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::core::db::{Database, DbError};
-use crate::core::types::{Drawer, KnowledgeCardFilter};
+use crate::core::types::{
+    Drawer, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
+    KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+};
+use crate::core::utils::current_timestamp;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KnowledgeCardBackfillReport {
@@ -35,6 +39,32 @@ pub enum KnowledgeCardBackfillStatus {
     AlreadyExists,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeCardBackfillApplyOptions {
+    pub execute: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeCardBackfillApplyResult {
+    pub dry_run: bool,
+    pub ready_count: usize,
+    pub skipped_count: usize,
+    pub already_exists_count: usize,
+    pub created_count: usize,
+    pub linked_count: usize,
+    pub event_count: usize,
+    pub link_errors: Vec<KnowledgeCardBackfillLinkError>,
+    pub candidates: Vec<KnowledgeCardBackfillCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnowledgeCardBackfillLinkError {
+    pub card_id: String,
+    pub evidence_drawer_id: String,
+    pub role: String,
+    pub error: String,
+}
+
 pub fn build_backfill_report(
     db: &Database,
     filter: &KnowledgeCardFilter,
@@ -63,6 +93,71 @@ pub fn build_backfill_report(
     })
 }
 
+pub fn apply_backfill(
+    db: &Database,
+    filter: &KnowledgeCardFilter,
+    options: KnowledgeCardBackfillApplyOptions,
+) -> Result<KnowledgeCardBackfillApplyResult, DbError> {
+    let drawers = db.list_knowledge_drawers_for_card_backfill(filter)?;
+    let mut candidates = Vec::with_capacity(drawers.len());
+    let mut ready_count = 0;
+    let mut skipped_count = 0;
+    let mut already_exists_count = 0;
+    let mut created_count = 0;
+    let mut linked_count = 0;
+    let mut event_count = 0;
+    let mut link_errors = Vec::new();
+
+    for drawer in drawers {
+        let candidate = classify_drawer(db, drawer.clone())?;
+        match candidate.status {
+            KnowledgeCardBackfillStatus::Ready => {
+                ready_count += 1;
+                if options.execute {
+                    let card_id = candidate.prospective_card_id.clone();
+                    create_card_and_event(db, &drawer, &card_id)?;
+                    created_count += 1;
+                    event_count += 1;
+                    for (role, evidence_drawer_id) in evidence_refs_by_role(&drawer) {
+                        let link = KnowledgeEvidenceLink {
+                            id: prospective_link_id(&card_id, &evidence_drawer_id, &role),
+                            card_id: card_id.clone(),
+                            evidence_drawer_id: evidence_drawer_id.clone(),
+                            role: role.clone(),
+                            note: Some(format!("backfilled from {}", drawer.id)),
+                            created_at: current_timestamp(),
+                        };
+                        match db.insert_knowledge_evidence_link(&link) {
+                            Ok(()) => linked_count += 1,
+                            Err(error) => link_errors.push(KnowledgeCardBackfillLinkError {
+                                card_id: card_id.clone(),
+                                evidence_drawer_id: evidence_drawer_id.clone(),
+                                role: evidence_role_slug(&role).to_string(),
+                                error: error.to_string(),
+                            }),
+                        }
+                    }
+                }
+            }
+            KnowledgeCardBackfillStatus::Skipped => skipped_count += 1,
+            KnowledgeCardBackfillStatus::AlreadyExists => already_exists_count += 1,
+        }
+        candidates.push(candidate);
+    }
+
+    Ok(KnowledgeCardBackfillApplyResult {
+        dry_run: !options.execute,
+        ready_count,
+        skipped_count,
+        already_exists_count,
+        created_count,
+        linked_count,
+        event_count,
+        link_errors,
+        candidates,
+    })
+}
+
 pub fn prospective_card_id(source_drawer_id: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"knowledge-card-backfill-v1");
@@ -70,6 +165,23 @@ pub fn prospective_card_id(source_drawer_id: &str) -> String {
     hasher.update(source_drawer_id.as_bytes());
     let digest = format!("{:x}", hasher.finalize());
     format!("card_{}", &digest[..16])
+}
+
+fn prospective_link_id(
+    card_id: &str,
+    evidence_drawer_id: &str,
+    role: &KnowledgeEvidenceRole,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"knowledge-card-backfill-link-v1");
+    hasher.update([0]);
+    hasher.update(card_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(evidence_drawer_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(evidence_role_slug(role).as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("link_{}", &digest[..16])
 }
 
 fn classify_drawer(
@@ -109,6 +221,100 @@ fn classify_drawer(
     })
 }
 
+fn create_card_and_event(db: &Database, drawer: &Drawer, card_id: &str) -> Result<(), DbError> {
+    let now = current_timestamp();
+    let card = KnowledgeCard {
+        id: card_id.to_string(),
+        statement: drawer.statement.clone().unwrap_or_default(),
+        content: drawer.content.clone(),
+        tier: drawer.tier.clone().expect("ready candidate must have tier"),
+        status: drawer
+            .status
+            .clone()
+            .expect("ready candidate must have status"),
+        domain: drawer.domain.clone(),
+        field: drawer.field.clone(),
+        anchor_kind: drawer.anchor_kind.clone(),
+        anchor_id: drawer.anchor_id.clone(),
+        parent_anchor_id: drawer.parent_anchor_id.clone(),
+        scope_constraints: drawer.scope_constraints.clone(),
+        trigger_hints: drawer.trigger_hints.clone(),
+        created_at: now.clone(),
+        updated_at: now.clone(),
+    };
+    let event = KnowledgeCardEvent {
+        id: prospective_created_event_id(card_id),
+        card_id: card_id.to_string(),
+        event_type: KnowledgeEventType::Created,
+        from_status: None,
+        to_status: drawer.status.clone(),
+        reason: format!("backfilled from Stage-1 knowledge drawer {}", drawer.id),
+        actor: Some("mempal".to_string()),
+        metadata: Some(serde_json::json!({
+            "source_drawer_id": drawer.id,
+            "source_file": drawer.source_file,
+        })),
+        created_at: now,
+    };
+
+    db.conn().execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
+    let result = db
+        .insert_knowledge_card(&card)
+        .and_then(|()| db.append_knowledge_event(&event));
+    match result {
+        Ok(()) => {
+            db.conn().execute_batch("COMMIT")?;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = db.conn().execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
+}
+
+fn prospective_created_event_id(card_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"knowledge-card-backfill-created-event-v1");
+    hasher.update([0]);
+    hasher.update(card_id.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("event_{}", &digest[..16])
+}
+
+fn evidence_refs_by_role(drawer: &Drawer) -> Vec<(KnowledgeEvidenceRole, String)> {
+    let mut refs = Vec::new();
+    refs.extend(
+        drawer
+            .supporting_refs
+            .iter()
+            .cloned()
+            .map(|id| (KnowledgeEvidenceRole::Supporting, id)),
+    );
+    refs.extend(
+        drawer
+            .verification_refs
+            .iter()
+            .cloned()
+            .map(|id| (KnowledgeEvidenceRole::Verification, id)),
+    );
+    refs.extend(
+        drawer
+            .counterexample_refs
+            .iter()
+            .cloned()
+            .map(|id| (KnowledgeEvidenceRole::Counterexample, id)),
+    );
+    refs.extend(
+        drawer
+            .teaching_refs
+            .iter()
+            .cloned()
+            .map(|id| (KnowledgeEvidenceRole::Teaching, id)),
+    );
+    refs
+}
+
 fn skip_reasons(drawer: &Drawer) -> Vec<String> {
     let mut reasons = Vec::new();
     if drawer
@@ -133,6 +339,15 @@ fn skip_reasons(drawer: &Drawer) -> Vec<String> {
         reasons.push("missing anchor_id".to_string());
     }
     reasons
+}
+
+fn evidence_role_slug(value: &KnowledgeEvidenceRole) -> &'static str {
+    match value {
+        KnowledgeEvidenceRole::Supporting => "supporting",
+        KnowledgeEvidenceRole::Verification => "verification",
+        KnowledgeEvidenceRole::Counterexample => "counterexample",
+        KnowledgeEvidenceRole::Teaching => "teaching",
+    }
 }
 
 fn memory_domain_slug(value: &crate::core::types::MemoryDomain) -> &'static str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,10 @@ use mempal::ingest::{
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
 use mempal::knowledge_anchor::{PublishAnchorRequest, publish_anchor};
-use mempal::knowledge_card_backfill::{KnowledgeCardBackfillReport, build_backfill_report};
+use mempal::knowledge_card_backfill::{
+    KnowledgeCardBackfillApplyOptions, KnowledgeCardBackfillApplyResult,
+    KnowledgeCardBackfillReport, apply_backfill, build_backfill_report,
+};
 use mempal::knowledge_distill::{DistillPlan, DistillRequest, commit_distill, prepare_distill};
 use mempal::knowledge_gate::{
     GateReport, PromotionPolicyEntry, evaluate_gate_by_id, promotion_policy,
@@ -457,6 +460,24 @@ enum KnowledgeCardCommands {
         anchor_kind: Option<String>,
         #[arg(long = "anchor-id")]
         anchor_id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    BackfillApply {
+        #[arg(long)]
+        tier: Option<String>,
+        #[arg(long)]
+        status: Option<String>,
+        #[arg(long)]
+        domain: Option<String>,
+        #[arg(long)]
+        field: Option<String>,
+        #[arg(long = "anchor-kind")]
+        anchor_kind: Option<String>,
+        #[arg(long = "anchor-id")]
+        anchor_id: Option<String>,
+        #[arg(long)]
+        execute: bool,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -1817,6 +1838,28 @@ fn knowledge_card_command(db: &Database, command: KnowledgeCardCommands) -> Resu
                 .context("failed to build knowledge card backfill plan")?;
             print_knowledge_card_backfill_report(&report, &format)?;
         }
+        KnowledgeCardCommands::BackfillApply {
+            tier,
+            status,
+            domain,
+            field,
+            anchor_kind,
+            anchor_id,
+            execute,
+            format,
+        } => {
+            let filter = KnowledgeCardFilter {
+                tier: tier.as_deref().map(parse_knowledge_tier).transpose()?,
+                status: status.as_deref().map(parse_knowledge_status).transpose()?,
+                domain: domain.as_deref().map(parse_domain).transpose()?,
+                field,
+                anchor_kind: anchor_kind.as_deref().map(parse_anchor_kind).transpose()?,
+                anchor_id,
+            };
+            let result = apply_backfill(db, &filter, KnowledgeCardBackfillApplyOptions { execute })
+                .context("failed to apply knowledge card backfill")?;
+            print_knowledge_card_backfill_apply_result(&result, &format)?;
+        }
     }
 
     Ok(())
@@ -1965,6 +2008,59 @@ fn print_knowledge_card_backfill_report(
             Ok(())
         }
         other => bail!("unsupported knowledge-card backfill-plan format: {other}"),
+    }
+}
+
+fn print_knowledge_card_backfill_apply_result(
+    result: &KnowledgeCardBackfillApplyResult,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!(
+                "dry_run={} ready={} skipped={} already_exists={} created_count={} linked_count={} event_count={} link_errors={}",
+                result.dry_run,
+                result.ready_count,
+                result.skipped_count,
+                result.already_exists_count,
+                result.created_count,
+                result.linked_count,
+                result.event_count,
+                result.link_errors.len()
+            );
+            if result.candidates.is_empty() {
+                println!("no knowledge drawers");
+            } else {
+                for candidate in &result.candidates {
+                    println!(
+                        "{} -> {} status={:?}",
+                        candidate.source_drawer_id, candidate.prospective_card_id, candidate.status
+                    );
+                    if !candidate.reasons.is_empty() {
+                        println!("  reasons: {}", candidate.reasons.join("; "));
+                    }
+                    if let Some(statement) = candidate.statement.as_deref() {
+                        println!("  statement: {statement}");
+                    }
+                }
+            }
+            for error in &result.link_errors {
+                println!(
+                    "link_error card_id={} evidence_drawer_id={} role={} error={}",
+                    error.card_id, error.evidence_drawer_id, error.role, error.error
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(result)
+                    .context("failed to serialize knowledge card backfill apply result")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card backfill-apply format: {other}"),
     }
 }
 

--- a/tests/knowledge_card_backfill.rs
+++ b/tests/knowledge_card_backfill.rs
@@ -4,11 +4,12 @@ use std::process::{Command, Output};
 
 use mempal::core::db::Database;
 use mempal::core::types::{
-    AnchorKind, Drawer, KnowledgeCard, KnowledgeCardFilter, KnowledgeStatus, KnowledgeTier,
-    MemoryDomain, MemoryKind, SourceType,
+    AnchorKind, Drawer, KnowledgeCard, KnowledgeCardFilter, KnowledgeEventType,
+    KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, SourceType,
 };
 use mempal::knowledge_card_backfill::{
-    KnowledgeCardBackfillStatus, build_backfill_report, prospective_card_id,
+    KnowledgeCardBackfillApplyOptions, KnowledgeCardBackfillStatus, apply_backfill,
+    build_backfill_report, prospective_card_id,
 };
 use serde_json::Value;
 use tempfile::TempDir;
@@ -72,8 +73,46 @@ fn knowledge_drawer(id: &str, field: &str) -> Drawer {
     }
 }
 
+fn evidence_drawer(id: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: format!("Evidence for {id}."),
+        wing: "mempal".to_string(),
+        room: Some("evidence".to_string()),
+        source_file: Some(format!("evidence://{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 3,
+        memory_kind: MemoryKind::Evidence,
+        domain: MemoryDomain::Project,
+        field: "rust".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        provenance: None,
+        statement: None,
+        tier: None,
+        status: None,
+        supporting_refs: Vec::new(),
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
 fn insert_drawer(db: &Database, drawer: Drawer) {
     db.insert_drawer(&drawer).expect("insert drawer");
+}
+
+fn table_count(db: &Database, table_name: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) FROM {table_name}");
+    db.conn()
+        .query_row(&sql, [], |row| row.get(0))
+        .expect("table count")
 }
 
 fn insert_existing_card(db: &Database, source_drawer_id: &str) {
@@ -159,6 +198,147 @@ fn test_knowledge_card_backfill_report_has_no_db_side_effects() {
 }
 
 #[test]
+fn test_knowledge_card_backfill_apply_dry_run_has_no_side_effects() {
+    let (_home, db) = setup_home();
+    insert_drawer(&db, evidence_drawer("drawer_evidence"));
+    insert_drawer(&db, knowledge_drawer("drawer_ready", "rust"));
+    let drawer_count = db.drawer_count().expect("drawer count");
+    let card_count = db.knowledge_card_count().expect("card count");
+    let link_count = table_count(&db, "knowledge_evidence_links");
+    let event_count = table_count(&db, "knowledge_events");
+
+    let result = apply_backfill(
+        &db,
+        &KnowledgeCardFilter::default(),
+        KnowledgeCardBackfillApplyOptions { execute: false },
+    )
+    .expect("apply dry run");
+
+    assert!(result.dry_run);
+    assert_eq!(result.ready_count, 1);
+    assert_eq!(result.created_count, 0);
+    assert_eq!(result.linked_count, 0);
+    assert_eq!(result.event_count, 0);
+    assert!(result.link_errors.is_empty());
+    assert_eq!(db.drawer_count().expect("drawer count"), drawer_count);
+    assert_eq!(db.knowledge_card_count().expect("card count"), card_count);
+    assert_eq!(table_count(&db, "knowledge_evidence_links"), link_count);
+    assert_eq!(table_count(&db, "knowledge_events"), event_count);
+}
+
+#[test]
+fn test_knowledge_card_backfill_apply_execute_creates_card_links_event() {
+    let (_home, db) = setup_home();
+    for id in [
+        "drawer_supporting",
+        "drawer_verification",
+        "drawer_counterexample",
+        "drawer_teaching",
+    ] {
+        insert_drawer(&db, evidence_drawer(id));
+    }
+    let mut drawer = knowledge_drawer("drawer_ready", "rust");
+    drawer.supporting_refs = vec!["drawer_supporting".to_string()];
+    drawer.verification_refs = vec!["drawer_verification".to_string()];
+    drawer.counterexample_refs = vec!["drawer_counterexample".to_string()];
+    drawer.teaching_refs = vec!["drawer_teaching".to_string()];
+    insert_drawer(&db, drawer);
+
+    let result = apply_backfill(
+        &db,
+        &KnowledgeCardFilter::default(),
+        KnowledgeCardBackfillApplyOptions { execute: true },
+    )
+    .expect("apply execute");
+
+    let card_id = prospective_card_id("drawer_ready");
+    assert!(!result.dry_run);
+    assert_eq!(result.created_count, 1);
+    assert_eq!(result.linked_count, 4);
+    assert_eq!(result.event_count, 1);
+    assert!(result.link_errors.is_empty());
+    let card = db
+        .get_knowledge_card(&card_id)
+        .expect("get card")
+        .expect("card exists");
+    assert_eq!(card.statement, "Statement for drawer_ready.");
+
+    let mut roles = db
+        .knowledge_evidence_links(&card_id)
+        .expect("links")
+        .into_iter()
+        .map(|link| link.role)
+        .collect::<Vec<_>>();
+    roles.sort_by_key(|role| format!("{role:?}"));
+    assert_eq!(
+        roles,
+        vec![
+            KnowledgeEvidenceRole::Counterexample,
+            KnowledgeEvidenceRole::Supporting,
+            KnowledgeEvidenceRole::Teaching,
+            KnowledgeEvidenceRole::Verification,
+        ]
+    );
+
+    let events = db.knowledge_events(&card_id).expect("events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, KnowledgeEventType::Created);
+}
+
+#[test]
+fn test_knowledge_card_backfill_apply_execute_is_idempotent() {
+    let (_home, db) = setup_home();
+    insert_drawer(&db, evidence_drawer("drawer_evidence"));
+    insert_drawer(&db, knowledge_drawer("drawer_ready", "rust"));
+
+    let first = apply_backfill(
+        &db,
+        &KnowledgeCardFilter::default(),
+        KnowledgeCardBackfillApplyOptions { execute: true },
+    )
+    .expect("first apply");
+    let link_count = table_count(&db, "knowledge_evidence_links");
+    let event_count = table_count(&db, "knowledge_events");
+
+    let second = apply_backfill(
+        &db,
+        &KnowledgeCardFilter::default(),
+        KnowledgeCardBackfillApplyOptions { execute: true },
+    )
+    .expect("second apply");
+
+    assert_eq!(first.created_count, 1);
+    assert_eq!(second.created_count, 0);
+    assert_eq!(second.already_exists_count, 1);
+    assert_eq!(table_count(&db, "knowledge_evidence_links"), link_count);
+    assert_eq!(table_count(&db, "knowledge_events"), event_count);
+}
+
+#[test]
+fn test_knowledge_card_backfill_apply_reports_invalid_evidence_refs() {
+    let (_home, db) = setup_home();
+    insert_drawer(&db, evidence_drawer("drawer_evidence"));
+    let mut drawer = knowledge_drawer("drawer_ready", "rust");
+    drawer.supporting_refs = vec!["drawer_evidence".to_string(), "drawer_missing".to_string()];
+    insert_drawer(&db, drawer);
+
+    let result = apply_backfill(
+        &db,
+        &KnowledgeCardFilter::default(),
+        KnowledgeCardBackfillApplyOptions { execute: true },
+    )
+    .expect("apply execute");
+
+    let card_id = prospective_card_id("drawer_ready");
+    assert_eq!(result.created_count, 1);
+    assert_eq!(result.linked_count, 1);
+    assert_eq!(result.link_errors.len(), 1);
+    assert_eq!(result.link_errors[0].card_id, card_id);
+    assert_eq!(result.link_errors[0].evidence_drawer_id, "drawer_missing");
+    assert!(db.get_knowledge_card(&card_id).expect("get card").is_some());
+}
+
+#[test]
 fn test_cli_knowledge_card_backfill_plan_plain() {
     let (home, db) = setup_home();
     insert_drawer(&db, knowledge_drawer("drawer_ready", "rust"));
@@ -174,6 +354,70 @@ fn test_cli_knowledge_card_backfill_plan_plain() {
     assert!(stdout.contains("ready=1 skipped=1 already_exists=1"));
     assert!(stdout.contains("drawer_ready"));
     assert!(stdout.contains(&prospective_card_id("drawer_ready")));
+}
+
+#[test]
+fn test_cli_knowledge_card_backfill_apply_defaults_to_dry_run() {
+    let (home, db) = setup_home();
+    insert_drawer(&db, evidence_drawer("drawer_evidence"));
+    insert_drawer(&db, knowledge_drawer("drawer_ready", "rust"));
+
+    let output = run_mempal(home.path(), &["knowledge-card", "backfill-apply"]);
+
+    assert!(output.status.success(), "{}", stderr_text(&output));
+    let stdout = stdout_text(&output);
+    assert!(stdout.contains("dry_run=true"));
+    assert!(stdout.contains("created_count=0"));
+    assert_eq!(db.knowledge_card_count().expect("card count"), 0);
+}
+
+#[test]
+fn test_cli_knowledge_card_backfill_apply_execute_json_filters() {
+    let (home, db) = setup_home();
+    insert_drawer(&db, evidence_drawer("drawer_evidence"));
+    insert_drawer(&db, knowledge_drawer("drawer_rust", "rust"));
+    insert_drawer(&db, knowledge_drawer("drawer_docs", "docs"));
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "backfill-apply",
+            "--execute",
+            "--field",
+            "rust",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(output.status.success(), "{}", stderr_text(&output));
+    let value: Value = serde_json::from_slice(&output.stdout).expect("parse json");
+    assert_eq!(value["dry_run"], false);
+    assert_eq!(value["created_count"], 1);
+    assert_eq!(value["linked_count"], 1);
+    assert!(
+        db.get_knowledge_card(&prospective_card_id("drawer_rust"))
+            .expect("get rust card")
+            .is_some()
+    );
+    assert!(
+        db.get_knowledge_card(&prospective_card_id("drawer_docs"))
+            .expect("get docs card")
+            .is_none()
+    );
+}
+
+#[test]
+fn test_cli_knowledge_card_backfill_apply_rejects_invalid_format() {
+    let (home, _db) = setup_home();
+
+    let output = run_mempal(
+        home.path(),
+        &["knowledge-card", "backfill-apply", "--format", "yaml"],
+    );
+    assert!(!output.status.success());
+    assert!(stderr_text(&output).contains("unsupported knowledge-card backfill-apply format"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add P37 spec and implementation plan for explicit knowledge card backfill apply.
- Add core `apply_backfill` with dry-run/execute behavior, deterministic card ids, transactional card+created-event creation, evidence-role linking, observable link errors, and idempotent reruns.
- Add CLI `mempal knowledge-card backfill-apply` with safe default dry-run, `--execute`, filters, and plain/JSON output.
- Add core and CLI tests for dry-run, execute, idempotency, invalid evidence refs, filters, and invalid format.

## Verification

- `agent-spec parse specs/p37-knowledge-card-backfill-apply.spec.md`
- `agent-spec lint specs/p37-knowledge-card-backfill-apply.spec.md --min-score 0.7`
- `cargo fmt --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
