### PR TITLE
feat: add knowledge card runtime lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,11 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p35-knowledge-card-mcp-read.spec.md` | 完成 | Phase-2 knowledge card MCP 只读入口：`mempal_knowledge_cards` list/get/events，不开放写操作 |
 | `specs/p36-knowledge-card-backfill-report.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 只读 backfill-plan report；dry-run，不迁移 |
 | `specs/p37-knowledge-card-backfill-apply.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 显式 backfill apply：默认 dry-run，`--execute` 创建 cards/links/events |
+| `specs/p38-knowledge-card-gate.spec.md` | 完成 | Phase-2 knowledge card gate：按 role-separated evidence links 评估提升门槛 |
+| `specs/p39-knowledge-card-lifecycle-cli.spec.md` | 完成 | Phase-2 knowledge card CLI lifecycle：gate-enforced promote + evidence-backed demote |
+| `specs/p40-mcp-knowledge-card-lifecycle.spec.md` | 完成 | `mempal_knowledge_cards` 扩展 gate/promote/demote actions |
+| `specs/p41-knowledge-card-runtime-boundary.spec.md` | 完成 | 固化 Phase-2 card runtime boundary：cards 已治理，但尚非默认 context/search source |
+| `specs/p42-mind-model-completion-audit.spec.md` | 完成 | MIND-MODEL P42 baseline completion audit + future work 明确化 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -130,6 +135,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md` — P35 knowledge card MCP read（已完成）
 - `docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md` — P36 knowledge card backfill report（已完成）
 - `docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md` — P37 knowledge card backfill apply（已完成）
+- `docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md` — P38-P42 knowledge card runtime baseline（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,11 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p35-knowledge-card-mcp-read.spec.md` | 完成 | Phase-2 knowledge card MCP 只读入口：`mempal_knowledge_cards` list/get/events，不开放写操作 |
 | `specs/p36-knowledge-card-backfill-report.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 只读 backfill-plan report；dry-run，不迁移 |
 | `specs/p37-knowledge-card-backfill-apply.spec.md` | 完成 | Stage-1 knowledge drawer -> Phase-2 card 显式 backfill apply：默认 dry-run，`--execute` 创建 cards/links/events |
+| `specs/p38-knowledge-card-gate.spec.md` | 完成 | Phase-2 knowledge card gate：按 role-separated evidence links 评估提升门槛 |
+| `specs/p39-knowledge-card-lifecycle-cli.spec.md` | 完成 | Phase-2 knowledge card CLI lifecycle：gate-enforced promote + evidence-backed demote |
+| `specs/p40-mcp-knowledge-card-lifecycle.spec.md` | 完成 | `mempal_knowledge_cards` 扩展 gate/promote/demote actions |
+| `specs/p41-knowledge-card-runtime-boundary.spec.md` | 完成 | 固化 Phase-2 card runtime boundary：cards 已治理，但尚非默认 context/search source |
+| `specs/p42-mind-model-completion-audit.spec.md` | 完成 | MIND-MODEL P42 baseline completion audit + future work 明确化 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -128,6 +133,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p35-knowledge-card-mcp-read-implementation.md` — P35 knowledge card MCP read（已完成）
 - `docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md` — P36 knowledge card backfill report（已完成）
 - `docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md` — P37 knowledge card backfill apply（已完成）
+- `docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md` — P38-P42 knowledge card runtime baseline（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1,8 +1,29 @@
 # MIND MODEL DESIGN
 
 **Date**: 2026-04-21
-**Status**: Draft - discussion capture for review
+**Status**: P42 baseline implemented - future work remains explicit
 **Scope**: Capture the mind-model decisions discussed in this conversation and map them to a practical system design.
+
+## Implementation Checkpoint
+
+P42 baseline means the core mind-model architecture is implemented enough to
+operate as a governed memory system:
+
+- Stage 1 typed drawers separate raw evidence from governed knowledge.
+- `dao_tian -> dao_ren -> shu -> qi` runtime context assembly exists through
+  `mempal context` and `mempal_context`.
+- Stage 1 knowledge supports distill, gate, promote, demote, and outward anchor
+  publication through CLI and MCP surfaces.
+- Phase-2 `knowledge_cards`, `knowledge_evidence_links`, and
+  `knowledge_events` exist in the same SQLite `palace.db`.
+- Stage-1 knowledge drawers can be backfilled into Phase-2 cards through an
+  explicit dry-run-first apply command.
+- Phase-2 cards now have governed gate, promote, and demote lifecycle surfaces
+  in CLI and MCP.
+
+P42 baseline is not a claim that every future runtime integration is complete.
+It marks the point where the design is no longer only a discussion capture: the
+main storage, governance, and lifecycle surfaces exist and are test-backed.
 
 ## One-Sentence Thesis
 
@@ -933,6 +954,31 @@ Rationale:
 - using a second database or service would add operational complexity before the
   Phase-2 model has proven it needs independent scaling
 
+Implemented Phase-2 surface at P42 baseline:
+
+- `knowledge_cards`, `knowledge_evidence_links`, and `knowledge_events` are
+  schema v8 tables in `palace.db`
+- Rust core APIs can create/read/update/list cards, link evidence, and append
+  events
+- `mempal knowledge-card` exposes create/get/list/link/event/events
+- `mempal_knowledge_cards` exposes list/get/events to MCP-connected agents
+- `mempal knowledge-card backfill-plan` reports Stage-1 knowledge drawers that
+  are ready to become cards without writing
+- `mempal knowledge-card backfill-apply` defaults to dry-run and only writes
+  cards, links, and created events with `--execute`
+- `mempal knowledge-card gate` evaluates card readiness from role-separated
+  evidence links
+- `mempal knowledge-card promote` and `mempal knowledge-card demote` mutate
+  card status transactionally with role-specific evidence links and append-only
+  events
+- `mempal_knowledge_cards` also exposes `gate`, `promote`, and `demote` actions
+  over the same core lifecycle logic
+
+Phase-2 cards are governed objects, but they are not yet the default
+context/search source. At P42, `mempal context`, `mempal_context`, and
+`mempal_search` remain drawer/citation based because cards do not yet have a
+dedicated retrieval strategy or vector indexing policy.
+
 ## Decision on Bootstrap vs Final Architecture
 
 Current recommendation:
@@ -990,6 +1036,20 @@ Proceed with the following assumptions unless future evidence rejects them:
   `qi`; wake-up remains a refresh surface, not the typed assembler
 - the implementation should begin with drawer bootstrap and evolve into a
   dedicated knowledge model inside the same SQLite `palace.db`
+
+## Future Work After P42
+
+The remaining work is intentionally explicit:
+
+- define whether card retrieval uses card-level embeddings, linked evidence
+  retrieval, or a hybrid of both
+- add a card-aware context source only after the retrieval strategy is specified
+- decide whether Phase-2 card lifecycle should write JSONL audit entries in
+  addition to append-only `knowledge_events`
+- integrate external `research-rs` outputs as evidence/candidate insights
+  without letting research directly define `dao`
+- add evaluator-assisted promotion only behind deterministic gates and human
+  review rules for high-level knowledge
 
 ## Closing Summary
 

--- a/docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md
+++ b/docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md
@@ -1,0 +1,30 @@
+# P38-P42 Knowledge Card Runtime Implementation Plan
+
+**Goal:** Close the current MIND-MODEL baseline by giving Phase-2 knowledge cards
+readiness gates, governed lifecycle mutation, MCP access, and explicit runtime
+boundary documentation.
+
+## Steps
+
+- [x] Add P38-P42 task contracts.
+- [x] Add Phase-2 card gate core and CLI.
+- [x] Add Phase-2 card promote/demote core and CLI.
+- [x] Extend `mempal_knowledge_cards` with gate/promote/demote actions.
+- [x] Update protocol and MIND-MODEL runtime boundary docs.
+- [x] Update AGENTS / CLAUDE inventories.
+- [x] Run spec lint, formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p38-knowledge-card-gate.spec.md
+agent-spec parse specs/p39-knowledge-card-lifecycle-cli.spec.md
+agent-spec parse specs/p40-mcp-knowledge-card-lifecycle.spec.md
+agent-spec parse specs/p41-knowledge-card-runtime-boundary.spec.md
+agent-spec parse specs/p42-mind-model-completion-audit.spec.md
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p38-knowledge-card-gate.spec.md
+++ b/specs/p38-knowledge-card-gate.spec.md
@@ -1,0 +1,50 @@
+spec: task
+name: "P38: knowledge card gate"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, gate, phase-2]
+---
+
+## Intent
+
+P38 adds a Phase-2 promotion gate for `knowledge_cards` using their evidence
+links. This mirrors Stage-1 gate policy but reads `knowledge_evidence_links`
+instead of drawer ref arrays.
+
+## Decisions
+
+- Add a core `evaluate_card_gate_by_id` function.
+- Add CLI command `mempal knowledge-card gate`.
+- Gate is read-only and must not mutate cards, links, events, drawers, vectors, or audit logs.
+- Evidence counts come from `knowledge_evidence_links` grouped by role.
+- Reuse the Stage-1 threshold semantics for `dao_tian`, `dao_ren`, `shu`, and `qi`.
+
+## Acceptance Criteria
+
+Scenario: CLI card gate counts evidence links
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_gate_counts_links
+  Given one knowledge card with supporting and verification evidence links
+  When running `mempal knowledge-card gate <card_id> --target-status promoted --format json`
+  Then JSON reports the correct role counts
+  And allowed is true when the policy threshold is satisfied
+
+Scenario: MCP card gate is exposed through knowledge cards tool
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_cards_gate_and_lifecycle_actions
+  Given one knowledge card with insufficient evidence links
+  When calling `mempal_knowledge_cards` with action `gate`
+  Then the response includes a gate report
+  And no card status is mutated
+
+## Out of Scope
+
+- Do not add automatic promotion.
+- Do not change Stage-1 drawer gate behavior.
+- Do not change search or context assembly.
+
+## Constraints
+
+- Gate failures must be observable through reasons.
+- Unsupported target status values must fail deterministically.

--- a/specs/p39-knowledge-card-lifecycle-cli.spec.md
+++ b/specs/p39-knowledge-card-lifecycle-cli.spec.md
@@ -1,0 +1,59 @@
+spec: task
+name: "P39: knowledge card lifecycle CLI"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, lifecycle, phase-2]
+---
+
+## Intent
+
+P39 adds governed CLI lifecycle mutation for Phase-2 knowledge cards. Promote
+and demote operate on `knowledge_cards`, add role-specific evidence links, and
+append `knowledge_events`.
+
+## Decisions
+
+- Add CLI commands `mempal knowledge-card promote` and `mempal knowledge-card demote`.
+- Promotion requires at least one `--verification-ref`.
+- Demotion requires at least one `--evidence-ref`, linked as counterexample evidence.
+- Promotion is gate-enforced by default.
+- Card status update, new evidence links, and lifecycle event append are transactional.
+- Gate failure must not write links, events, or status changes.
+
+## Acceptance Criteria
+
+Scenario: CLI promote appends verification link and event
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_promote_gate_enforced_and_appends_event
+  Given a candidate `qi` card with supporting evidence
+  When promoting it with a verification evidence ref
+  Then the card status becomes promoted
+  And a promoted event is appended
+
+Scenario: CLI promote gate failure is atomic
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_promote_gate_failure_does_not_mutate
+  Given a card without enough supporting evidence
+  When promotion gate fails
+  Then card status, links, and events are unchanged
+
+Scenario: CLI demote appends counterexample link and event
+  Test:
+    Package: mempal
+    Filter: test_cli_knowledge_card_demote_links_counterexample_and_appends_event
+  Given a promoted card
+  When demoting it with counterexample evidence
+  Then the card status becomes demoted
+  And a demoted event is appended
+
+## Out of Scope
+
+- Do not delete cards.
+- Do not mutate Stage-1 knowledge drawers.
+- Do not write JSONL audit logs for Phase-2 card lifecycle.
+
+## Constraints
+
+- Evidence refs must point to existing evidence drawers.
+- Lifecycle events remain append-only.

--- a/specs/p40-mcp-knowledge-card-lifecycle.spec.md
+++ b/specs/p40-mcp-knowledge-card-lifecycle.spec.md
@@ -1,0 +1,57 @@
+spec: task
+name: "P40: MCP knowledge card lifecycle actions"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, mcp, phase-2]
+---
+
+## Intent
+
+P40 exposes Phase-2 knowledge card gate and lifecycle operations through the
+existing `mempal_knowledge_cards` MCP tool so agents can inspect and govern
+cards without shelling out.
+
+## Decisions
+
+- Extend `mempal_knowledge_cards` actions to `list/get/events/gate/promote/demote`.
+- Keep card creation out of MCP.
+- `gate` is read-only.
+- `promote` and `demote` reuse the same core logic as the CLI.
+- Tool description and embedded protocol must mention the new action set.
+
+## Acceptance Criteria
+
+Scenario: MCP card lifecycle actions mutate through shared core
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_cards_gate_and_lifecycle_actions
+  Given one card and evidence drawers
+  When MCP gate, promote, and demote actions are called
+  Then promote and demote update card lifecycle and append events
+
+Scenario: unknown MCP card action is rejected
+  Test:
+    Package: mempal
+    Filter: test_mcp_knowledge_cards_rejects_unknown_actions_without_mutation
+  Given an initialized server
+  When calling an unsupported card action
+  Then the request fails
+  And card rows are unchanged
+
+Scenario: MCP protocol advertises card lifecycle
+  Test:
+    Package: mempal
+    Filter: test_mcp_tool_registry_and_protocol_include_knowledge_cards_lifecycle
+  Given MCP tool registry
+  When inspecting `mempal_knowledge_cards`
+  Then description and protocol mention list/get/events/gate/promote/demote
+
+## Out of Scope
+
+- Do not add a separate MCP tool for cards.
+- Do not expose card creation via MCP.
+- Do not change REST.
+
+## Constraints
+
+- MCP and CLI lifecycle paths must share core functions.
+- MCP error mapping must distinguish invalid params from internal write failures.

--- a/specs/p41-knowledge-card-runtime-boundary.spec.md
+++ b/specs/p41-knowledge-card-runtime-boundary.spec.md
@@ -1,0 +1,46 @@
+spec: task
+name: "P41: knowledge card runtime boundary"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, runtime, phase-2]
+---
+
+## Intent
+
+P41 updates the runtime boundary documentation after Phase-2 cards gain gate and
+lifecycle operations. Runtime context and search remain Stage-1 drawer based
+until a dedicated card retrieval strategy is specified.
+
+## Decisions
+
+- Document that Phase-2 cards are governed objects, not yet the default context source.
+- Keep `mempal context` and `mempal_context` on Stage-1 typed drawers in P41.
+- Keep search results drawer/citation based in P41.
+- Add P41 inventory entries.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL design states current Phase-2 runtime boundary
+  Test:
+    Package: mempal
+    Filter: rg -n "Phase-2 cards are governed objects" docs/MIND-MODEL-DESIGN.md
+  Given MIND-MODEL-DESIGN
+  When reading the Phase 2 section
+  Then it states that cards are governed objects but not default context/search source
+
+Scenario: inventories include P41
+  Test:
+    Package: mempal
+    Filter: rg -n "p41-knowledge-card-runtime-boundary" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P41
+  Then both inventories list it as completed
+
+## Out of Scope
+
+- Do not change context assembly.
+- Do not change search.
+- Do not add card embeddings.
+
+## Constraints
+
+- Documentation must not imply automatic runtime use of card records.

--- a/specs/p42-mind-model-completion-audit.spec.md
+++ b/specs/p42-mind-model-completion-audit.spec.md
@@ -1,0 +1,53 @@
+spec: task
+name: "P42: mind model completion audit"
+inherits: project
+tags: [memory, mind-model, docs, audit]
+---
+
+## Intent
+
+P42 records the current completion state of the MIND-MODEL implementation after
+Phase-2 knowledge cards become governed through CLI and MCP lifecycle surfaces.
+
+## Decisions
+
+- Update `docs/MIND-MODEL-DESIGN.md` status from draft capture to implemented baseline.
+- Add an implementation checkpoint listing Stage-1 and Phase-2 completed surfaces.
+- State remaining future work explicitly instead of leaving the design open-ended.
+- Add P42 inventory entries.
+
+## Acceptance Criteria
+
+Scenario: design document has implementation checkpoint
+  Test:
+    Package: mempal
+    Filter: rg -n "Implementation Checkpoint|P42 baseline" docs/MIND-MODEL-DESIGN.md
+  Given MIND-MODEL-DESIGN
+  When reading the header and checkpoint
+  Then it records the P42 baseline state
+
+Scenario: future work remains explicit
+  Test:
+    Package: mempal
+    Filter: rg -n "Future Work After P42" docs/MIND-MODEL-DESIGN.md
+  Given MIND-MODEL-DESIGN
+  When reading the completion audit
+  Then remaining work is listed as future work
+
+Scenario: inventories include P42
+  Test:
+    Package: mempal
+    Filter: rg -n "p42-mind-model-completion-audit" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P42
+  Then both inventories list it as completed
+
+## Out of Scope
+
+- Do not claim the research-rs integration is implemented.
+- Do not claim cards are the default context source.
+- Do not add new runtime behavior.
+
+## Constraints
+
+- Completion means P42 implementation baseline, not the end of all possible future work.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -202,11 +202,12 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    updates only anchor metadata and audit history; it does not rewrite content,
    re-embed vectors, or change knowledge tier/status.
 
-16. INSPECT PHASE-2 KNOWLEDGE CARDS READ-ONLY
+16. INSPECT AND GOVERN PHASE-2 KNOWLEDGE CARDS
    Use mempal_knowledge_cards to inspect Phase-2 knowledge card records and
-   append-only event history. This tool is read-only: list/get/events are the
-   only supported actions. It does not create cards, link evidence, append
-   events, mutate lifecycle, search, assemble context, or backfill drawers.
+   append-only event history. It also supports governed card lifecycle actions:
+   gate is read-only, promote requires verification evidence and a passing gate,
+   and demote requires counterexample evidence. It does not create cards, search,
+   assemble context, or backfill drawers.
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
@@ -216,7 +217,7 @@ TOOLS:
   mempal_knowledge_distill — create candidate knowledge from evidence refs
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
-  mempal_knowledge_cards — read-only Phase-2 knowledge card list/get/events
+  mempal_knowledge_cards — Phase-2 knowledge card list/get/events/gate/promote/demote
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/knowledge_card_lifecycle.rs
+++ b/src/knowledge_card_lifecycle.rs
@@ -1,0 +1,592 @@
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::core::{
+    db::Database,
+    types::{
+        KnowledgeCard, KnowledgeCardEvent, KnowledgeEventType, KnowledgeEvidenceLink,
+        KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryKind,
+    },
+    utils::current_timestamp,
+};
+use crate::knowledge_gate::{GateEvidenceCounts, GateRequirements};
+
+struct CardLifecycleMutation {
+    old_status: KnowledgeStatus,
+    target_status: KnowledgeStatus,
+    event_type: KnowledgeEventType,
+    reason: String,
+    actor: Option<String>,
+    new_refs: Vec<String>,
+    link_role: KnowledgeEvidenceRole,
+    metadata: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KnowledgeCardGateReport {
+    pub card_id: String,
+    pub tier: String,
+    pub status: String,
+    pub target_status: String,
+    pub allowed: bool,
+    pub reasons: Vec<String>,
+    pub requirements: GateRequirements,
+    pub evidence_counts: GateEvidenceCounts,
+}
+
+#[derive(Debug, Clone)]
+pub struct PromoteCardRequest {
+    pub card_id: String,
+    pub status: String,
+    pub verification_refs: Vec<String>,
+    pub reason: String,
+    pub reviewer: Option<String>,
+    pub allow_counterexamples: bool,
+    pub enforce_gate: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DemoteCardRequest {
+    pub card_id: String,
+    pub status: String,
+    pub evidence_refs: Vec<String>,
+    pub reason: String,
+    pub reason_type: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PromoteCardOutcome {
+    pub card_id: String,
+    pub old_status: String,
+    pub new_status: String,
+    pub verification_refs: Vec<String>,
+    pub gate: Option<KnowledgeCardGateReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DemoteCardOutcome {
+    pub card_id: String,
+    pub old_status: String,
+    pub new_status: String,
+    pub counterexample_refs: Vec<String>,
+}
+
+pub fn evaluate_card_gate_by_id(
+    db: &Database,
+    card_id: &str,
+    target_status: Option<&str>,
+    reviewer: Option<&str>,
+    allow_counterexamples: bool,
+) -> Result<KnowledgeCardGateReport> {
+    let card = load_card(db, card_id)?;
+    let target_status = match target_status {
+        Some(value) => parse_status(value)?,
+        None => default_target_status(&card.tier),
+    };
+    validate_tier_status(&card.tier, &target_status)?;
+    let counts = evidence_counts(db, card_id)?;
+    evaluate_card_gate(
+        &card,
+        &target_status,
+        reviewer,
+        allow_counterexamples,
+        counts,
+    )
+}
+
+pub fn promote_card(db: &Database, request: PromoteCardRequest) -> Result<PromoteCardOutcome> {
+    let target_status = parse_status(&request.status)?;
+    if !matches!(
+        target_status,
+        KnowledgeStatus::Promoted | KnowledgeStatus::Canonical
+    ) {
+        bail!("promote status must be promoted or canonical");
+    }
+    validate_evidence_refs(db, &request.verification_refs)?;
+    let mut card = load_card(db, &request.card_id)?;
+    validate_tier_status(&card.tier, &target_status)?;
+    let old_status = card.status.clone();
+
+    let existing_links = db
+        .knowledge_evidence_links(&request.card_id)
+        .context("failed to list knowledge card evidence links")?;
+    let new_refs = missing_refs_for_role(
+        &existing_links,
+        &request.verification_refs,
+        &KnowledgeEvidenceRole::Verification,
+    );
+    let projected_counts = projected_counts(
+        counts_from_links(&existing_links),
+        &new_refs,
+        &KnowledgeEvidenceRole::Verification,
+    );
+    let gate = if request.enforce_gate {
+        let gate = evaluate_card_gate(
+            &card,
+            &target_status,
+            request.reviewer.as_deref(),
+            request.allow_counterexamples,
+            projected_counts,
+        )?;
+        if !gate.allowed {
+            bail!("promotion gate failed: {}", gate.reasons.join("; "));
+        }
+        Some(gate)
+    } else {
+        None
+    };
+
+    card.status = target_status.clone();
+    card.updated_at = current_timestamp();
+    apply_card_lifecycle(
+        db,
+        &card,
+        CardLifecycleMutation {
+            old_status: old_status.clone(),
+            target_status: target_status.clone(),
+            event_type: KnowledgeEventType::Promoted,
+            reason: request.reason.clone(),
+            actor: request.reviewer.clone(),
+            new_refs,
+            link_role: KnowledgeEvidenceRole::Verification,
+            metadata: serde_json::json!({
+                "verification_refs": request.verification_refs,
+                "gate_enforced": request.enforce_gate,
+            }),
+        },
+    )?;
+
+    Ok(PromoteCardOutcome {
+        card_id: request.card_id,
+        old_status: status_slug(&old_status).to_string(),
+        new_status: status_slug(&target_status).to_string(),
+        verification_refs: refs_for_role(
+            &db.knowledge_evidence_links(&card.id)
+                .context("failed to list knowledge card evidence links")?,
+            &KnowledgeEvidenceRole::Verification,
+        ),
+        gate,
+    })
+}
+
+pub fn demote_card(db: &Database, request: DemoteCardRequest) -> Result<DemoteCardOutcome> {
+    let target_status = parse_status(&request.status)?;
+    if !matches!(
+        target_status,
+        KnowledgeStatus::Demoted | KnowledgeStatus::Retired
+    ) {
+        bail!("demote status must be demoted or retired");
+    }
+    validate_demote_reason_type(&request.reason_type)?;
+    validate_evidence_refs(db, &request.evidence_refs)?;
+    let mut card = load_card(db, &request.card_id)?;
+    validate_tier_status(&card.tier, &target_status)?;
+    let old_status = card.status.clone();
+    let existing_links = db
+        .knowledge_evidence_links(&request.card_id)
+        .context("failed to list knowledge card evidence links")?;
+    let new_refs = missing_refs_for_role(
+        &existing_links,
+        &request.evidence_refs,
+        &KnowledgeEvidenceRole::Counterexample,
+    );
+
+    card.status = target_status.clone();
+    card.updated_at = current_timestamp();
+    let event_type = if matches!(target_status, KnowledgeStatus::Retired) {
+        KnowledgeEventType::Retired
+    } else {
+        KnowledgeEventType::Demoted
+    };
+    apply_card_lifecycle(
+        db,
+        &card,
+        CardLifecycleMutation {
+            old_status: old_status.clone(),
+            target_status: target_status.clone(),
+            event_type,
+            reason: request.reason.clone(),
+            actor: None,
+            new_refs,
+            link_role: KnowledgeEvidenceRole::Counterexample,
+            metadata: serde_json::json!({
+                "evidence_refs": request.evidence_refs,
+                "reason_type": request.reason_type,
+            }),
+        },
+    )?;
+
+    Ok(DemoteCardOutcome {
+        card_id: request.card_id,
+        old_status: status_slug(&old_status).to_string(),
+        new_status: status_slug(&target_status).to_string(),
+        counterexample_refs: refs_for_role(
+            &db.knowledge_evidence_links(&card.id)
+                .context("failed to list knowledge card evidence links")?,
+            &KnowledgeEvidenceRole::Counterexample,
+        ),
+    })
+}
+
+fn load_card(db: &Database, card_id: &str) -> Result<KnowledgeCard> {
+    db.get_knowledge_card(card_id)
+        .context("failed to look up knowledge card")?
+        .with_context(|| format!("knowledge card not found: {card_id}"))
+}
+
+fn evaluate_card_gate(
+    card: &KnowledgeCard,
+    target_status: &KnowledgeStatus,
+    reviewer: Option<&str>,
+    allow_counterexamples: bool,
+    evidence_counts: GateEvidenceCounts,
+) -> Result<KnowledgeCardGateReport> {
+    validate_tier_status(&card.tier, target_status)?;
+    let requirements = gate_requirements(&card.tier, target_status);
+    let mut reasons = Vec::new();
+    if evidence_counts.supporting < requirements.min_supporting_refs {
+        reasons.push(format!(
+            "supporting evidence refs below requirement: have {}, need {}",
+            evidence_counts.supporting, requirements.min_supporting_refs
+        ));
+    }
+    if evidence_counts.verification < requirements.min_verification_refs {
+        reasons.push(format!(
+            "verification evidence refs below requirement: have {}, need {}",
+            evidence_counts.verification, requirements.min_verification_refs
+        ));
+    }
+    if evidence_counts.teaching < requirements.min_teaching_refs {
+        reasons.push(format!(
+            "teaching evidence refs below requirement: have {}, need {}",
+            evidence_counts.teaching, requirements.min_teaching_refs
+        ));
+    }
+    if requirements.reviewer_required
+        && reviewer
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none()
+    {
+        reasons.push("reviewer is required for this gate".to_string());
+    }
+    if requirements.counterexamples_block
+        && evidence_counts.counterexample > 0
+        && !allow_counterexamples
+    {
+        reasons.push(format!(
+            "counterexample refs present: {}",
+            evidence_counts.counterexample
+        ));
+    }
+
+    Ok(KnowledgeCardGateReport {
+        card_id: card.id.clone(),
+        tier: tier_slug(&card.tier).to_string(),
+        status: status_slug(&card.status).to_string(),
+        target_status: status_slug(target_status).to_string(),
+        allowed: reasons.is_empty(),
+        reasons,
+        requirements,
+        evidence_counts,
+    })
+}
+
+fn apply_card_lifecycle(
+    db: &Database,
+    card: &KnowledgeCard,
+    mutation: CardLifecycleMutation,
+) -> Result<()> {
+    db.conn().execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
+    let result = (|| {
+        for evidence_drawer_id in &mutation.new_refs {
+            let link = KnowledgeEvidenceLink {
+                id: deterministic_link_id(&card.id, evidence_drawer_id, &mutation.link_role),
+                card_id: card.id.clone(),
+                evidence_drawer_id: evidence_drawer_id.clone(),
+                role: mutation.link_role.clone(),
+                note: Some(format!("linked during card lifecycle: {}", mutation.reason)),
+                created_at: current_timestamp(),
+            };
+            db.insert_knowledge_evidence_link(&link)
+                .context("failed to insert knowledge card evidence link")?;
+        }
+        db.update_knowledge_card(card)
+            .context("failed to update knowledge card")?;
+        let event = KnowledgeCardEvent {
+            id: deterministic_event_id(&card.id, &mutation.event_type, &mutation.reason),
+            card_id: card.id.clone(),
+            event_type: mutation.event_type,
+            from_status: Some(mutation.old_status),
+            to_status: Some(mutation.target_status),
+            reason: mutation.reason,
+            actor: mutation.actor,
+            metadata: Some(mutation.metadata),
+            created_at: current_timestamp(),
+        };
+        db.append_knowledge_event(&event)
+            .context("failed to append knowledge card event")?;
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => {
+            db.conn().execute_batch("COMMIT")?;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = db.conn().execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
+}
+
+fn evidence_counts(db: &Database, card_id: &str) -> Result<GateEvidenceCounts> {
+    let links = db
+        .knowledge_evidence_links(card_id)
+        .context("failed to list knowledge card evidence links")?;
+    Ok(counts_from_links(&links))
+}
+
+fn counts_from_links(links: &[KnowledgeEvidenceLink]) -> GateEvidenceCounts {
+    GateEvidenceCounts {
+        supporting: links
+            .iter()
+            .filter(|link| matches!(link.role, KnowledgeEvidenceRole::Supporting))
+            .count(),
+        counterexample: links
+            .iter()
+            .filter(|link| matches!(link.role, KnowledgeEvidenceRole::Counterexample))
+            .count(),
+        teaching: links
+            .iter()
+            .filter(|link| matches!(link.role, KnowledgeEvidenceRole::Teaching))
+            .count(),
+        verification: links
+            .iter()
+            .filter(|link| matches!(link.role, KnowledgeEvidenceRole::Verification))
+            .count(),
+    }
+}
+
+fn projected_counts(
+    mut counts: GateEvidenceCounts,
+    new_refs: &[String],
+    role: &KnowledgeEvidenceRole,
+) -> GateEvidenceCounts {
+    match role {
+        KnowledgeEvidenceRole::Supporting => counts.supporting += new_refs.len(),
+        KnowledgeEvidenceRole::Verification => counts.verification += new_refs.len(),
+        KnowledgeEvidenceRole::Counterexample => counts.counterexample += new_refs.len(),
+        KnowledgeEvidenceRole::Teaching => counts.teaching += new_refs.len(),
+    }
+    counts
+}
+
+fn missing_refs_for_role(
+    existing_links: &[KnowledgeEvidenceLink],
+    refs: &[String],
+    role: &KnowledgeEvidenceRole,
+) -> Vec<String> {
+    refs.iter()
+        .filter(|drawer_id| {
+            !existing_links
+                .iter()
+                .any(|link| link.role == *role && link.evidence_drawer_id == **drawer_id)
+        })
+        .cloned()
+        .collect()
+}
+
+fn refs_for_role(links: &[KnowledgeEvidenceLink], role: &KnowledgeEvidenceRole) -> Vec<String> {
+    links
+        .iter()
+        .filter(|link| link.role == *role)
+        .map(|link| link.evidence_drawer_id.clone())
+        .collect()
+}
+
+fn validate_evidence_refs(db: &Database, refs: &[String]) -> Result<()> {
+    if refs.is_empty() {
+        bail!("at least one evidence ref is required");
+    }
+    for drawer_id in refs {
+        if !drawer_id.starts_with("drawer_") {
+            bail!("evidence refs must contain drawer ids");
+        }
+        let drawer = db
+            .get_drawer(drawer_id)
+            .with_context(|| format!("failed to load evidence drawer {drawer_id}"))?
+            .with_context(|| format!("evidence drawer not found: {drawer_id}"))?;
+        if drawer.memory_kind != MemoryKind::Evidence {
+            bail!("evidence refs must point to evidence drawers");
+        }
+    }
+    Ok(())
+}
+
+fn parse_status(value: &str) -> Result<KnowledgeStatus> {
+    match value.trim() {
+        "candidate" => Ok(KnowledgeStatus::Candidate),
+        "promoted" => Ok(KnowledgeStatus::Promoted),
+        "canonical" => Ok(KnowledgeStatus::Canonical),
+        "demoted" => Ok(KnowledgeStatus::Demoted),
+        "retired" => Ok(KnowledgeStatus::Retired),
+        other => bail!("unsupported knowledge status: {other}"),
+    }
+}
+
+fn default_target_status(tier: &KnowledgeTier) -> KnowledgeStatus {
+    match tier {
+        KnowledgeTier::DaoTian => KnowledgeStatus::Canonical,
+        KnowledgeTier::DaoRen | KnowledgeTier::Shu | KnowledgeTier::Qi => KnowledgeStatus::Promoted,
+    }
+}
+
+fn validate_tier_status(tier: &KnowledgeTier, status: &KnowledgeStatus) -> Result<()> {
+    let allowed = match tier {
+        KnowledgeTier::DaoTian => &[KnowledgeStatus::Canonical, KnowledgeStatus::Demoted][..],
+        KnowledgeTier::DaoRen => &[
+            KnowledgeStatus::Candidate,
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+        KnowledgeTier::Shu => &[
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+        KnowledgeTier::Qi => &[
+            KnowledgeStatus::Candidate,
+            KnowledgeStatus::Promoted,
+            KnowledgeStatus::Demoted,
+            KnowledgeStatus::Retired,
+        ][..],
+    };
+
+    if allowed.contains(status) {
+        return Ok(());
+    }
+
+    match tier {
+        KnowledgeTier::DaoTian => bail!("dao_tian only allows canonical or demoted"),
+        KnowledgeTier::DaoRen => {
+            bail!("dao_ren only allows candidate, promoted, demoted, or retired")
+        }
+        KnowledgeTier::Shu => bail!("shu only allows promoted, demoted, or retired"),
+        KnowledgeTier::Qi => bail!("qi only allows candidate, promoted, demoted, or retired"),
+    }
+}
+
+fn validate_demote_reason_type(value: &str) -> Result<()> {
+    match value.trim() {
+        "contradicted" | "obsolete" | "superseded" | "out_of_scope" | "unsafe" => Ok(()),
+        other => bail!("unsupported demote reason_type: {other}"),
+    }
+}
+
+fn gate_requirements(tier: &KnowledgeTier, target_status: &KnowledgeStatus) -> GateRequirements {
+    match (tier, target_status) {
+        (KnowledgeTier::DaoTian, KnowledgeStatus::Canonical) => GateRequirements {
+            min_supporting_refs: 3,
+            min_verification_refs: 2,
+            min_teaching_refs: 1,
+            reviewer_required: true,
+            counterexamples_block: true,
+        },
+        (KnowledgeTier::DaoRen, KnowledgeStatus::Promoted) => GateRequirements {
+            min_supporting_refs: 2,
+            min_verification_refs: 1,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+        (KnowledgeTier::Shu | KnowledgeTier::Qi, KnowledgeStatus::Promoted) => GateRequirements {
+            min_supporting_refs: 1,
+            min_verification_refs: 1,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+        _ => GateRequirements {
+            min_supporting_refs: 0,
+            min_verification_refs: 0,
+            min_teaching_refs: 0,
+            reviewer_required: false,
+            counterexamples_block: true,
+        },
+    }
+}
+
+fn deterministic_link_id(
+    card_id: &str,
+    evidence_drawer_id: &str,
+    role: &KnowledgeEvidenceRole,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"knowledge-card-lifecycle-link-v1");
+    hasher.update([0]);
+    hasher.update(card_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(evidence_drawer_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(evidence_role_slug(role).as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("link_{}", &digest[..16])
+}
+
+fn deterministic_event_id(card_id: &str, event_type: &KnowledgeEventType, reason: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"knowledge-card-lifecycle-event-v1");
+    hasher.update([0]);
+    hasher.update(card_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(event_type_slug(event_type).as_bytes());
+    hasher.update([0]);
+    hasher.update(reason.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("event_{}", &digest[..16])
+}
+
+fn evidence_role_slug(value: &KnowledgeEvidenceRole) -> &'static str {
+    match value {
+        KnowledgeEvidenceRole::Supporting => "supporting",
+        KnowledgeEvidenceRole::Verification => "verification",
+        KnowledgeEvidenceRole::Counterexample => "counterexample",
+        KnowledgeEvidenceRole::Teaching => "teaching",
+    }
+}
+
+fn event_type_slug(value: &KnowledgeEventType) -> &'static str {
+    match value {
+        KnowledgeEventType::Created => "created",
+        KnowledgeEventType::Promoted => "promoted",
+        KnowledgeEventType::Demoted => "demoted",
+        KnowledgeEventType::Retired => "retired",
+        KnowledgeEventType::Linked => "linked",
+        KnowledgeEventType::Unlinked => "unlinked",
+        KnowledgeEventType::Updated => "updated",
+        KnowledgeEventType::PublishedAnchor => "published_anchor",
+    }
+}
+
+fn tier_slug(value: &KnowledgeTier) -> &'static str {
+    match value {
+        KnowledgeTier::Qi => "qi",
+        KnowledgeTier::Shu => "shu",
+        KnowledgeTier::DaoRen => "dao_ren",
+        KnowledgeTier::DaoTian => "dao_tian",
+    }
+}
+
+fn status_slug(value: &KnowledgeStatus) -> &'static str {
+    match value {
+        KnowledgeStatus::Candidate => "candidate",
+        KnowledgeStatus::Promoted => "promoted",
+        KnowledgeStatus::Canonical => "canonical",
+        KnowledgeStatus::Demoted => "demoted",
+        KnowledgeStatus::Retired => "retired",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod field_taxonomy;
 pub mod ingest;
 pub mod knowledge_anchor;
 pub mod knowledge_card_backfill;
+pub mod knowledge_card_lifecycle;
 pub mod knowledge_distill;
 pub mod knowledge_gate;
 pub mod knowledge_lifecycle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,10 @@ use mempal::knowledge_card_backfill::{
     KnowledgeCardBackfillApplyOptions, KnowledgeCardBackfillApplyResult,
     KnowledgeCardBackfillReport, apply_backfill, build_backfill_report,
 };
+use mempal::knowledge_card_lifecycle::{
+    DemoteCardOutcome, DemoteCardRequest, KnowledgeCardGateReport, PromoteCardOutcome,
+    PromoteCardRequest, demote_card, evaluate_card_gate_by_id, promote_card,
+};
 use mempal::knowledge_distill::{DistillPlan, DistillRequest, commit_distill, prepare_distill};
 use mempal::knowledge_gate::{
     GateReport, PromotionPolicyEntry, evaluate_gate_by_id, promotion_policy,
@@ -444,6 +448,47 @@ enum KnowledgeCardCommands {
     },
     Events {
         card_id: String,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Gate {
+        card_id: String,
+        #[arg(long = "target-status")]
+        target_status: Option<String>,
+        #[arg(long)]
+        reviewer: Option<String>,
+        #[arg(long, default_value_t = false)]
+        allow_counterexamples: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Promote {
+        card_id: String,
+        #[arg(long)]
+        status: String,
+        #[arg(long = "verification-ref")]
+        verification_refs: Vec<String>,
+        #[arg(long)]
+        reason: String,
+        #[arg(long)]
+        reviewer: Option<String>,
+        #[arg(long, default_value_t = false)]
+        allow_counterexamples: bool,
+        #[arg(long, default_value_t = true)]
+        enforce_gate: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Demote {
+        card_id: String,
+        #[arg(long)]
+        status: String,
+        #[arg(long = "evidence-ref")]
+        evidence_refs: Vec<String>,
+        #[arg(long)]
+        reason: String,
+        #[arg(long = "reason-type")]
+        reason_type: String,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -1817,6 +1862,69 @@ fn knowledge_card_command(db: &Database, command: KnowledgeCardCommands) -> Resu
                 .context("failed to list knowledge card events")?;
             print_knowledge_card_events(&events, &format)?;
         }
+        KnowledgeCardCommands::Gate {
+            card_id,
+            target_status,
+            reviewer,
+            allow_counterexamples,
+            format,
+        } => {
+            let report = evaluate_card_gate_by_id(
+                db,
+                &card_id,
+                target_status.as_deref(),
+                reviewer.as_deref(),
+                allow_counterexamples,
+            )
+            .context("failed to evaluate knowledge card gate")?;
+            print_knowledge_card_gate_report(&report, &format)?;
+        }
+        KnowledgeCardCommands::Promote {
+            card_id,
+            status,
+            verification_refs,
+            reason,
+            reviewer,
+            allow_counterexamples,
+            enforce_gate,
+            format,
+        } => {
+            let outcome = promote_card(
+                db,
+                PromoteCardRequest {
+                    card_id,
+                    status,
+                    verification_refs,
+                    reason,
+                    reviewer,
+                    allow_counterexamples,
+                    enforce_gate,
+                },
+            )
+            .context("failed to promote knowledge card")?;
+            print_knowledge_card_promote_outcome(&outcome, &format)?;
+        }
+        KnowledgeCardCommands::Demote {
+            card_id,
+            status,
+            evidence_refs,
+            reason,
+            reason_type,
+            format,
+        } => {
+            let outcome = demote_card(
+                db,
+                DemoteCardRequest {
+                    card_id,
+                    status,
+                    evidence_refs,
+                    reason,
+                    reason_type,
+                },
+            )
+            .context("failed to demote knowledge card")?;
+            print_knowledge_card_demote_outcome(&outcome, &format)?;
+        }
         KnowledgeCardCommands::BackfillPlan {
             tier,
             status,
@@ -1968,6 +2076,94 @@ fn print_knowledge_card_events(events: &[KnowledgeCardEvent], format: &str) -> R
             Ok(())
         }
         other => bail!("unsupported knowledge-card format: {other}"),
+    }
+}
+
+fn print_knowledge_card_gate_report(report: &KnowledgeCardGateReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("card_id={}", report.card_id);
+            println!("tier={}", report.tier);
+            println!("status={}", report.status);
+            println!("target_status={}", report.target_status);
+            println!("allowed={}", report.allowed);
+            println!(
+                "evidence_counts supporting={} verification={} teaching={} counterexample={}",
+                report.evidence_counts.supporting,
+                report.evidence_counts.verification,
+                report.evidence_counts.teaching,
+                report.evidence_counts.counterexample
+            );
+            println!(
+                "requirements supporting>={} verification>={} teaching>={} reviewer_required={} counterexamples_block={}",
+                report.requirements.min_supporting_refs,
+                report.requirements.min_verification_refs,
+                report.requirements.min_teaching_refs,
+                report.requirements.reviewer_required,
+                report.requirements.counterexamples_block
+            );
+            if !report.reasons.is_empty() {
+                println!("reasons={}", report.reasons.join("; "));
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize knowledge card gate report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card gate format: {other}"),
+    }
+}
+
+fn print_knowledge_card_promote_outcome(outcome: &PromoteCardOutcome, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!(
+                "card_id={} old_status={} new_status={} verification_refs={}",
+                outcome.card_id,
+                outcome.old_status,
+                outcome.new_status,
+                outcome.verification_refs.join(",")
+            );
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(outcome)
+                    .context("failed to serialize knowledge card promote outcome")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card promote format: {other}"),
+    }
+}
+
+fn print_knowledge_card_demote_outcome(outcome: &DemoteCardOutcome, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!(
+                "card_id={} old_status={} new_status={} counterexample_refs={}",
+                outcome.card_id,
+                outcome.old_status,
+                outcome.new_status,
+                outcome.counterexample_refs.join(",")
+            );
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(outcome)
+                    .context("failed to serialize knowledge card demote outcome")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card demote format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -27,6 +27,10 @@ use crate::ingest::{
     normalize::CURRENT_NORMALIZE_VERSION,
 };
 use crate::knowledge_anchor::{PublishAnchorRequest as CorePublishAnchorRequest, publish_anchor};
+use crate::knowledge_card_lifecycle::{
+    DemoteCardRequest as CoreDemoteCardRequest, PromoteCardRequest as CorePromoteCardRequest,
+    demote_card, evaluate_card_gate_by_id, promote_card,
+};
 use crate::knowledge_distill::{
     DistillPlan, DistillRequest as CoreDistillRequest, commit_distill, prepare_distill,
 };
@@ -855,7 +859,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_knowledge_cards",
-        description = "Read-only Phase-2 knowledge card inspection. Actions: list/get/events. Reads schema v8 knowledge_cards and knowledge_events only; does not create cards, link evidence, append events, mutate lifecycle, search, assemble context, or backfill."
+        description = "Phase-2 knowledge card inspection and governed lifecycle. Actions: list/get/events/gate/promote/demote. Gate is read-only; promote/demote require evidence refs and append knowledge_events transactionally."
     )]
     async fn mempal_knowledge_cards(
         &self,
@@ -884,6 +888,9 @@ impl MempalMcpServer {
                 Ok(Json(KnowledgeCardsResponse {
                     cards: cards.into_iter().map(KnowledgeCardDto::from).collect(),
                     events: Vec::new(),
+                    gate: None,
+                    promote: None,
+                    demote: None,
                 }))
             }
             "get" => {
@@ -905,6 +912,9 @@ impl MempalMcpServer {
                 Ok(Json(KnowledgeCardsResponse {
                     cards: vec![KnowledgeCardDto::from(card)],
                     events: Vec::new(),
+                    gate: None,
+                    promote: None,
+                    demote: None,
                 }))
             }
             "events" => {
@@ -921,11 +931,84 @@ impl MempalMcpServer {
                         .into_iter()
                         .map(KnowledgeCardEventDto::from)
                         .collect(),
+                    gate: None,
+                    promote: None,
+                    demote: None,
+                }))
+            }
+            "gate" => {
+                let card_id = required_string(request.card_id.as_deref(), "card_id")?;
+                let report = evaluate_card_gate_by_id(
+                    &db,
+                    card_id,
+                    request.target_status.as_deref(),
+                    request.reviewer.as_deref(),
+                    request.allow_counterexamples.unwrap_or(false),
+                )
+                .map_err(knowledge_card_lifecycle_error)?;
+                Ok(Json(KnowledgeCardsResponse {
+                    cards: Vec::new(),
+                    events: Vec::new(),
+                    gate: Some(report.into()),
+                    promote: None,
+                    demote: None,
+                }))
+            }
+            "promote" => {
+                let card_id = required_string(request.card_id.as_deref(), "card_id")?;
+                let status = required_string(request.status.as_deref(), "status")?.to_string();
+                let reason = required_string(request.reason.as_deref(), "reason")?.to_string();
+                let verification_refs = request.verification_refs.unwrap_or_default();
+                let outcome = promote_card(
+                    &db,
+                    CorePromoteCardRequest {
+                        card_id: card_id.to_string(),
+                        status,
+                        verification_refs,
+                        reason,
+                        reviewer: request.reviewer,
+                        allow_counterexamples: request.allow_counterexamples.unwrap_or(false),
+                        enforce_gate: request.enforce_gate.unwrap_or(true),
+                    },
+                )
+                .map_err(knowledge_card_lifecycle_error)?;
+                Ok(Json(KnowledgeCardsResponse {
+                    cards: Vec::new(),
+                    events: Vec::new(),
+                    gate: None,
+                    promote: Some(outcome.into()),
+                    demote: None,
+                }))
+            }
+            "demote" => {
+                let card_id = required_string(request.card_id.as_deref(), "card_id")?;
+                let status = required_string(request.status.as_deref(), "status")?.to_string();
+                let reason = required_string(request.reason.as_deref(), "reason")?.to_string();
+                let reason_type =
+                    required_string(request.reason_type.as_deref(), "reason_type")?.to_string();
+                let evidence_refs = request.evidence_refs.unwrap_or_default();
+                let outcome = demote_card(
+                    &db,
+                    CoreDemoteCardRequest {
+                        card_id: card_id.to_string(),
+                        status,
+                        evidence_refs,
+                        reason,
+                        reason_type,
+                    },
+                )
+                .map_err(knowledge_card_lifecycle_error)?;
+                Ok(Json(KnowledgeCardsResponse {
+                    cards: Vec::new(),
+                    events: Vec::new(),
+                    gate: None,
+                    promote: None,
+                    demote: Some(outcome.into()),
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported knowledge cards action: {other}; read-only actions are list, get, events"
+                    "unsupported knowledge cards action: {other}; actions are list, get, events, gate, promote, demote"
                 ),
                 None,
             )),
@@ -1748,6 +1831,18 @@ fn knowledge_lifecycle_error(error: anyhow::Error) -> ErrorData {
     ErrorData::invalid_params(message, None)
 }
 
+fn knowledge_card_lifecycle_error(error: anyhow::Error) -> ErrorData {
+    let message = error.to_string();
+    if message.contains("failed to update")
+        || message.contains("failed to insert")
+        || message.contains("failed to append")
+        || message.contains("failed to list")
+    {
+        return ErrorData::internal_error(message, None);
+    }
+    ErrorData::invalid_params(message, None)
+}
+
 fn knowledge_anchor_error(error: anyhow::Error) -> ErrorData {
     let message = error.to_string();
     if message.contains("failed to update")
@@ -1885,6 +1980,7 @@ mod tests {
     use super::*;
     use crate::core::types::{
         BootstrapEvidenceArgs, KnowledgeCard, KnowledgeCardEvent, KnowledgeEventType,
+        KnowledgeEvidenceLink, KnowledgeEvidenceRole,
     };
     use crate::embed::Embedder;
 
@@ -2002,6 +2098,25 @@ mod tests {
             created_at: created_at.to_string(),
         })
         .expect("append knowledge card event");
+    }
+
+    fn insert_knowledge_card_link(
+        db_path: &Path,
+        id: &str,
+        card_id: &str,
+        evidence_drawer_id: &str,
+        role: KnowledgeEvidenceRole,
+    ) {
+        let db = Database::open(db_path).expect("open db");
+        db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+            id: id.to_string(),
+            card_id: card_id.to_string(),
+            evidence_drawer_id: evidence_drawer_id.to_string(),
+            role,
+            note: None,
+            created_at: "1713000000".to_string(),
+        })
+        .expect("insert knowledge card link");
     }
 
     fn insert_drawer(
@@ -2815,7 +2930,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mcp_knowledge_cards_rejects_write_actions() {
+    async fn test_mcp_knowledge_cards_rejects_unknown_actions_without_mutation() {
         let (_tempdir, db_path, server) = setup_server();
         let before = {
             let db = Database::open(&db_path).expect("open db");
@@ -2829,8 +2944,12 @@ mod tests {
                 "action": "create"
             }))
             .await
-            .expect_err("write action should be rejected");
-        assert!(error.to_string().contains("read-only actions"));
+            .expect_err("unknown action should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("actions are list, get, events, gate, promote, demote")
+        );
 
         let after = {
             let db = Database::open(&db_path).expect("open db");
@@ -2841,8 +2960,103 @@ mod tests {
         assert_eq!(before, after);
     }
 
+    #[tokio::test]
+    async fn test_mcp_knowledge_cards_gate_and_lifecycle_actions() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_knowledge_card(
+            &db_path,
+            knowledge_card(
+                "card_lifecycle",
+                KnowledgeTier::Qi,
+                KnowledgeStatus::Candidate,
+                "rust",
+            ),
+        );
+        insert_drawer(
+            &db_path,
+            "drawer_supporting",
+            "supporting evidence",
+            "mempal",
+            Some("phase2"),
+            "/tmp/supporting.md",
+            2,
+        );
+        insert_drawer(
+            &db_path,
+            "drawer_verification",
+            "verification evidence",
+            "mempal",
+            Some("phase2"),
+            "/tmp/verification.md",
+            2,
+        );
+        insert_drawer(
+            &db_path,
+            "drawer_counterexample",
+            "counterexample evidence",
+            "mempal",
+            Some("phase2"),
+            "/tmp/counterexample.md",
+            2,
+        );
+        insert_knowledge_card_link(
+            &db_path,
+            "link_supporting",
+            "card_lifecycle",
+            "drawer_supporting",
+            KnowledgeEvidenceRole::Supporting,
+        );
+
+        let gate = server
+            .knowledge_cards_json_for_test(serde_json::json!({
+                "action": "gate",
+                "card_id": "card_lifecycle",
+                "target_status": "promoted"
+            }))
+            .await
+            .expect("gate card");
+        assert!(!gate.gate.expect("gate").allowed);
+
+        let promoted = server
+            .knowledge_cards_json_for_test(serde_json::json!({
+                "action": "promote",
+                "card_id": "card_lifecycle",
+                "status": "promoted",
+                "verification_refs": ["drawer_verification"],
+                "reason": "verified through MCP"
+            }))
+            .await
+            .expect("promote card");
+        assert_eq!(promoted.promote.expect("promote").new_status, "promoted");
+
+        let demoted = server
+            .knowledge_cards_json_for_test(serde_json::json!({
+                "action": "demote",
+                "card_id": "card_lifecycle",
+                "status": "demoted",
+                "evidence_refs": ["drawer_counterexample"],
+                "reason": "contradicted through MCP",
+                "reason_type": "contradicted"
+            }))
+            .await
+            .expect("demote card");
+        assert_eq!(demoted.demote.expect("demote").new_status, "demoted");
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(
+            db.get_knowledge_card("card_lifecycle")
+                .expect("get card")
+                .expect("card exists")
+                .status,
+            KnowledgeStatus::Demoted
+        );
+        assert_eq!(
+            db.knowledge_events("card_lifecycle").expect("events").len(),
+            2
+        );
+    }
+
     #[test]
-    fn test_mcp_tool_registry_and_protocol_include_knowledge_cards_readonly() {
+    fn test_mcp_tool_registry_and_protocol_include_knowledge_cards_lifecycle() {
         let (_tempdir, _db_path, server) = setup_server();
         let tools = server.tool_router.list_all();
         let tool = tools
@@ -2850,12 +3064,10 @@ mod tests {
             .find(|tool| tool.name == "mempal_knowledge_cards")
             .expect("mempal_knowledge_cards tool exists");
         let description = tool.description.as_deref().unwrap_or_default();
-        assert!(description.contains("Read-only Phase-2 knowledge card inspection"));
-        assert!(description.contains("Actions: list/get/events"));
+        assert!(description.contains("Phase-2 knowledge card inspection and governed lifecycle"));
+        assert!(description.contains("Actions: list/get/events/gate/promote/demote"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_cards"));
-        assert!(
-            crate::core::protocol::MEMORY_PROTOCOL.contains("read-only Phase-2 knowledge card")
-        );
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("Phase-2 knowledge card"));
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -6,6 +6,9 @@ use crate::core::types::{
 };
 use crate::field_taxonomy::FieldTaxonomyEntry;
 use crate::knowledge_anchor::PublishAnchorOutcome;
+use crate::knowledge_card_lifecycle::{
+    DemoteCardOutcome, KnowledgeCardGateReport, PromoteCardOutcome,
+};
 use crate::knowledge_distill::DistillOutcome;
 use crate::knowledge_gate::{GateReport, PromotionPolicyEntry};
 use crate::knowledge_lifecycle::{DemoteOutcome, PromoteOutcome};
@@ -266,6 +269,14 @@ pub struct KnowledgePolicyEntryDto {
 pub struct KnowledgeCardsRequest {
     pub action: String,
     pub card_id: Option<String>,
+    pub target_status: Option<String>,
+    pub reviewer: Option<String>,
+    pub allow_counterexamples: Option<bool>,
+    pub verification_refs: Option<Vec<String>>,
+    pub evidence_refs: Option<Vec<String>>,
+    pub reason: Option<String>,
+    pub reason_type: Option<String>,
+    pub enforce_gate: Option<bool>,
     pub tier: Option<String>,
     pub status: Option<String>,
     pub domain: Option<String>,
@@ -278,6 +289,12 @@ pub struct KnowledgeCardsRequest {
 pub struct KnowledgeCardsResponse {
     pub cards: Vec<KnowledgeCardDto>,
     pub events: Vec<KnowledgeCardEventDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gate: Option<KnowledgeCardGateDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub promote: Option<KnowledgeCardPromoteDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub demote: Option<KnowledgeCardDemoteDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -309,6 +326,35 @@ pub struct KnowledgeCardEventDto {
     pub actor: Option<String>,
     pub metadata: Option<serde_json::Value>,
     pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeCardGateDto {
+    pub card_id: String,
+    pub tier: String,
+    pub status: String,
+    pub target_status: String,
+    pub allowed: bool,
+    pub reasons: Vec<String>,
+    pub requirements: KnowledgeGateRequirementsDto,
+    pub evidence_counts: KnowledgeGateEvidenceCountsDto,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeCardPromoteDto {
+    pub card_id: String,
+    pub old_status: String,
+    pub new_status: String,
+    pub verification_refs: Vec<String>,
+    pub gate: Option<KnowledgeCardGateDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct KnowledgeCardDemoteDto {
+    pub card_id: String,
+    pub old_status: String,
+    pub new_status: String,
+    pub counterexample_refs: Vec<String>,
 }
 
 impl From<Vec<PromotionPolicyEntry>> for KnowledgePolicyResponse {
@@ -960,6 +1006,55 @@ impl From<KnowledgeCardEvent> for KnowledgeCardEventDto {
             actor: value.actor,
             metadata: value.metadata,
             created_at: value.created_at,
+        }
+    }
+}
+
+impl From<KnowledgeCardGateReport> for KnowledgeCardGateDto {
+    fn from(value: KnowledgeCardGateReport) -> Self {
+        Self {
+            card_id: value.card_id,
+            tier: value.tier,
+            status: value.status,
+            target_status: value.target_status,
+            allowed: value.allowed,
+            reasons: value.reasons,
+            requirements: KnowledgeGateRequirementsDto {
+                min_supporting_refs: value.requirements.min_supporting_refs,
+                min_verification_refs: value.requirements.min_verification_refs,
+                min_teaching_refs: value.requirements.min_teaching_refs,
+                reviewer_required: value.requirements.reviewer_required,
+                counterexamples_block: value.requirements.counterexamples_block,
+            },
+            evidence_counts: KnowledgeGateEvidenceCountsDto {
+                supporting: value.evidence_counts.supporting,
+                counterexample: value.evidence_counts.counterexample,
+                teaching: value.evidence_counts.teaching,
+                verification: value.evidence_counts.verification,
+            },
+        }
+    }
+}
+
+impl From<PromoteCardOutcome> for KnowledgeCardPromoteDto {
+    fn from(value: PromoteCardOutcome) -> Self {
+        Self {
+            card_id: value.card_id,
+            old_status: value.old_status,
+            new_status: value.new_status,
+            verification_refs: value.verification_refs,
+            gate: value.gate.map(KnowledgeCardGateDto::from),
+        }
+    }
+}
+
+impl From<DemoteCardOutcome> for KnowledgeCardDemoteDto {
+    fn from(value: DemoteCardOutcome) -> Self {
+        Self {
+            card_id: value.card_id,
+            old_status: value.old_status,
+            new_status: value.new_status,
+            counterexample_refs: value.counterexample_refs,
         }
     }
 }

--- a/tests/knowledge_card_cli.rs
+++ b/tests/knowledge_card_cli.rs
@@ -4,8 +4,8 @@ use std::process::{Command, Output};
 
 use mempal::core::db::Database;
 use mempal::core::types::{
-    AnchorKind, BootstrapEvidenceArgs, Drawer, KnowledgeCard, KnowledgeStatus, KnowledgeTier,
-    MemoryDomain, MemoryKind, SourceType,
+    AnchorKind, BootstrapEvidenceArgs, Drawer, KnowledgeCard, KnowledgeEvidenceLink,
+    KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, SourceType,
 };
 use serde_json::Value;
 use tempfile::TempDir;
@@ -66,6 +66,24 @@ fn insert_evidence_drawer(db: &Database, id: &str) {
         importance: 0,
     }))
     .expect("insert evidence drawer");
+}
+
+fn insert_link(
+    db: &Database,
+    id: &str,
+    card_id: &str,
+    evidence_drawer_id: &str,
+    role: KnowledgeEvidenceRole,
+) {
+    db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+        id: id.to_string(),
+        card_id: card_id.to_string(),
+        evidence_drawer_id: evidence_drawer_id.to_string(),
+        role,
+        note: None,
+        created_at: "1710000000".to_string(),
+    })
+    .expect("insert link");
 }
 
 fn insert_knowledge_drawer(db: &Database, id: &str) {
@@ -326,6 +344,214 @@ fn test_cli_knowledge_card_event_append_and_list_json() {
     assert_eq!(array[0]["event_type"], "created");
     assert_eq!(array[0]["reason"], "seeded");
     assert_eq!(array[0]["actor"], "codex");
+}
+
+#[test]
+fn test_cli_knowledge_card_gate_counts_links() {
+    let (home, db) = setup_home();
+    insert_card(
+        &db,
+        card(
+            "card_gate",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "rust",
+        ),
+    );
+    insert_evidence_drawer(&db, "drawer_supporting");
+    insert_evidence_drawer(&db, "drawer_verification");
+    insert_link(
+        &db,
+        "link_supporting",
+        "card_gate",
+        "drawer_supporting",
+        KnowledgeEvidenceRole::Supporting,
+    );
+    insert_link(
+        &db,
+        "link_verification",
+        "card_gate",
+        "drawer_verification",
+        KnowledgeEvidenceRole::Verification,
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "gate",
+            "card_gate",
+            "--target-status",
+            "promoted",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(output.status.success(), "{}", stderr_text(&output));
+    let value: Value = serde_json::from_slice(&output.stdout).expect("parse gate json");
+    assert_eq!(value["card_id"], "card_gate");
+    assert_eq!(value["allowed"], true);
+    assert_eq!(value["evidence_counts"]["supporting"], 1);
+    assert_eq!(value["evidence_counts"]["verification"], 1);
+}
+
+#[test]
+fn test_cli_knowledge_card_promote_gate_enforced_and_appends_event() {
+    let (home, db) = setup_home();
+    insert_card(
+        &db,
+        card(
+            "card_promote",
+            KnowledgeTier::Qi,
+            KnowledgeStatus::Candidate,
+            "rust",
+        ),
+    );
+    insert_evidence_drawer(&db, "drawer_supporting");
+    insert_evidence_drawer(&db, "drawer_verification");
+    insert_link(
+        &db,
+        "link_supporting",
+        "card_promote",
+        "drawer_supporting",
+        KnowledgeEvidenceRole::Supporting,
+    );
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "promote",
+            "card_promote",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_verification",
+            "--reason",
+            "verified in CLI test",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(output.status.success(), "{}", stderr_text(&output));
+    let value: Value = serde_json::from_slice(&output.stdout).expect("parse promote json");
+    assert_eq!(value["old_status"], "candidate");
+    assert_eq!(value["new_status"], "promoted");
+    let db_card = db
+        .get_knowledge_card("card_promote")
+        .expect("get card")
+        .expect("card exists");
+    assert_eq!(db_card.status, KnowledgeStatus::Promoted);
+    let events = db.knowledge_events("card_promote").expect("events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0].event_type,
+        mempal::core::types::KnowledgeEventType::Promoted
+    );
+}
+
+#[test]
+fn test_cli_knowledge_card_promote_gate_failure_does_not_mutate() {
+    let (home, db) = setup_home();
+    insert_card(
+        &db,
+        card(
+            "card_blocked",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "rust",
+        ),
+    );
+    insert_evidence_drawer(&db, "drawer_verification");
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "promote",
+            "card_blocked",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            "drawer_verification",
+            "--reason",
+            "missing supporting evidence",
+        ],
+    );
+
+    assert!(!output.status.success());
+    assert!(stderr_text(&output).contains("promotion gate failed"));
+    let db_card = db
+        .get_knowledge_card("card_blocked")
+        .expect("get card")
+        .expect("card exists");
+    assert_eq!(db_card.status, KnowledgeStatus::Promoted);
+    assert_eq!(
+        db.knowledge_evidence_links("card_blocked")
+            .expect("links")
+            .len(),
+        0
+    );
+    assert_eq!(
+        db.knowledge_events("card_blocked").expect("events").len(),
+        0
+    );
+}
+
+#[test]
+fn test_cli_knowledge_card_demote_links_counterexample_and_appends_event() {
+    let (home, db) = setup_home();
+    insert_card(
+        &db,
+        card(
+            "card_demote",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "rust",
+        ),
+    );
+    insert_evidence_drawer(&db, "drawer_counterexample");
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "demote",
+            "card_demote",
+            "--status",
+            "demoted",
+            "--evidence-ref",
+            "drawer_counterexample",
+            "--reason",
+            "contradicted by runtime evidence",
+            "--reason-type",
+            "contradicted",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(output.status.success(), "{}", stderr_text(&output));
+    let value: Value = serde_json::from_slice(&output.stdout).expect("parse demote json");
+    assert_eq!(value["old_status"], "promoted");
+    assert_eq!(value["new_status"], "demoted");
+    let db_card = db
+        .get_knowledge_card("card_demote")
+        .expect("get card")
+        .expect("card exists");
+    assert_eq!(db_card.status, KnowledgeStatus::Demoted);
+    assert_eq!(
+        db.knowledge_evidence_links("card_demote").expect("links")[0].role,
+        KnowledgeEvidenceRole::Counterexample
+    );
+    let events = db.knowledge_events("card_demote").expect("events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0].event_type,
+        mempal::core::types::KnowledgeEventType::Demoted
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add P38-P42 specs and implementation plan.
- Add Phase-2 knowledge card gate evaluation from role-separated evidence links.
- Add CLI `knowledge-card gate/promote/demote`.
- Make promote/demote transactional with evidence links and append-only card events.
- Extend `mempal_knowledge_cards` MCP actions to `list/get/events/gate/promote/demote`.
- Update MCP protocol and MIND-MODEL docs to mark P42 baseline and keep card retrieval/context as explicit future work.

## Verification

- `agent-spec parse specs/p38-knowledge-card-gate.spec.md`
- `agent-spec parse specs/p39-knowledge-card-lifecycle-cli.spec.md`
- `agent-spec parse specs/p40-mcp-knowledge-card-lifecycle.spec.md`
- `agent-spec parse specs/p41-knowledge-card-runtime-boundary.spec.md`
- `agent-spec parse specs/p42-mind-model-completion-audit.spec.md`
- `agent-spec lint specs/p38-knowledge-card-gate.spec.md --min-score 0.7`
- `agent-spec lint specs/p39-knowledge-card-lifecycle-cli.spec.md --min-score 0.7`
- `agent-spec lint specs/p40-mcp-knowledge-card-lifecycle.spec.md --min-score 0.7`
- `agent-spec lint specs/p41-knowledge-card-runtime-boundary.spec.md --min-score 0.7`
- `agent-spec lint specs/p42-mind-model-completion-audit.spec.md --min-score 0.7`
- `cargo fmt --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
