### PR TITLE
docs: add knowledge card retrieval contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p40-mcp-knowledge-card-lifecycle.spec.md` | 完成 | `mempal_knowledge_cards` 扩展 gate/promote/demote actions |
 | `specs/p41-knowledge-card-runtime-boundary.spec.md` | 完成 | 固化 Phase-2 card runtime boundary：cards 已治理，但尚非默认 context/search source |
 | `specs/p42-mind-model-completion-audit.spec.md` | 完成 | MIND-MODEL P42 baseline completion audit + future work 明确化 |
+| `specs/p43-knowledge-card-retrieval-contract.spec.md` | 完成 | Phase-2 card retrieval contract：定义 card result + evidence citation 形状，不改默认 runtime 行为 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -136,6 +137,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md` — P36 knowledge card backfill report（已完成）
 - `docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md` — P37 knowledge card backfill apply（已完成）
 - `docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md` — P38-P42 knowledge card runtime baseline（已完成）
+- `docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md` — P43 knowledge card retrieval contract（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p40-mcp-knowledge-card-lifecycle.spec.md` | 完成 | `mempal_knowledge_cards` 扩展 gate/promote/demote actions |
 | `specs/p41-knowledge-card-runtime-boundary.spec.md` | 完成 | 固化 Phase-2 card runtime boundary：cards 已治理，但尚非默认 context/search source |
 | `specs/p42-mind-model-completion-audit.spec.md` | 完成 | MIND-MODEL P42 baseline completion audit + future work 明确化 |
+| `specs/p43-knowledge-card-retrieval-contract.spec.md` | 完成 | Phase-2 card retrieval contract：定义 card result + evidence citation 形状，不改默认 runtime 行为 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -134,6 +135,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p36-knowledge-card-backfill-report-implementation.md` — P36 knowledge card backfill report（已完成）
 - `docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md` — P37 knowledge card backfill apply（已完成）
 - `docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md` — P38-P42 knowledge card runtime baseline（已完成）
+- `docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md` — P43 knowledge card retrieval contract（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -979,6 +979,36 @@ context/search source. At P42, `mempal context`, `mempal_context`, and
 `mempal_search` remain drawer/citation based because cards do not yet have a
 dedicated retrieval strategy or vector indexing policy.
 
+### Phase-2 Card Retrieval Contract
+
+P43 defines the contract for future card-aware runtime consumption without
+implementing retrieval behavior yet.
+
+A card retrieval item is a governed knowledge result, not a raw drawer result.
+The minimum returned card fields are: `card_id`, `statement`, `content`, `tier`,
+`status`, `domain`, `field`, `anchor_kind`, and `anchor_id`.
+
+Each card retrieval item must expose role-separated evidence citations derived
+from `knowledge_evidence_links`. The minimum evidence citation fields are:
+`evidence_drawer_id`, `role`, and `source_file`.
+
+Default runtime eligibility is status-gated:
+
+- `promoted` and `canonical` cards are runtime-eligible by default
+- `candidate`, `demoted`, and `retired` cards are excluded by default
+
+This preserves the governance boundary:
+
+- card records carry distilled belief
+- linked evidence drawers remain the citation root
+- inactive card states remain inspectable but are not injected into ordinary
+  runtime context
+
+P43 does not change `mempal context` or `mempal_context` behavior.
+P43 does not change `mempal_search` behavior.
+Card embeddings, ranking strategy, and card-aware context/search surfaces are
+deferred to later specs.
+
 ## Decision on Bootstrap vs Final Architecture
 
 Current recommendation:

--- a/docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md
+++ b/docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md
@@ -1,0 +1,22 @@
+# P43 Knowledge Card Retrieval Contract Plan
+
+**Goal:** Define how Phase-2 knowledge cards should be consumed as runtime
+retrieval results before adding any card-aware context/search behavior.
+
+## Steps
+
+- [x] Add P43 task contract.
+- [x] Update MIND-MODEL design with the card retrieval contract.
+- [x] Update AGENTS / CLAUDE inventories.
+- [x] Run spec parse/lint and documentation checks.
+
+## Verification
+
+```bash
+agent-spec parse specs/p43-knowledge-card-retrieval-contract.spec.md
+agent-spec lint specs/p43-knowledge-card-retrieval-contract.spec.md --min-score 0.7
+rg -n "card_id.*statement.*content|evidence_drawer_id.*role.*source_file" docs/MIND-MODEL-DESIGN.md
+rg -n "promoted.*canonical|candidate.*demoted.*retired" docs/MIND-MODEL-DESIGN.md
+rg -n "P43 does not change.*mempal context|P43 does not change.*mempal_search" docs/MIND-MODEL-DESIGN.md
+rg -n "p43-knowledge-card-retrieval-contract" AGENTS.md CLAUDE.md
+```

--- a/specs/p43-knowledge-card-retrieval-contract.spec.md
+++ b/specs/p43-knowledge-card-retrieval-contract.spec.md
@@ -1,0 +1,84 @@
+spec: task
+name: "P43: knowledge card retrieval contract"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, retrieval, phase-2]
+---
+
+## Intent
+
+P43 defines the read contract for consuming Phase-2 knowledge cards at runtime
+without changing default search or context behavior. The contract clarifies what
+a card retrieval result must contain, how linked evidence citations are exposed,
+and which card statuses are eligible for runtime use.
+
+## Decisions
+
+- Define a card retrieval item as a governed knowledge result, not a raw drawer result.
+- Each retrieval item must include `card_id`, `statement`, `content`, `tier`, `status`, `domain`, `field`, `anchor_kind`, and `anchor_id`.
+- Each retrieval item must expose role-separated evidence citations from `knowledge_evidence_links`.
+- Evidence citations must include `evidence_drawer_id`, `role`, and the evidence drawer's `source_file`.
+- Runtime-eligible card statuses are only `promoted` and `canonical` by default.
+- `candidate`, `demoted`, and `retired` cards must not be returned by default runtime retrieval.
+- P43 is contract-only: do not change `mempal context`, `mempal_context`, or `mempal_search` default behavior.
+- P43 does not define card embeddings; retrieval ranking strategy is deferred to later implementation specs.
+
+## Acceptance Criteria
+
+Scenario: contract defines card retrieval item fields
+  Test:
+    Package: mempal
+    Filter: rg -n "card_id.*statement.*content|evidence_drawer_id.*role.*source_file" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the Phase-2 retrieval contract section
+  Then it lists the required card fields
+  And it lists the required evidence citation fields
+
+Scenario: contract defines default runtime status eligibility
+  Test:
+    Package: mempal
+    Filter: rg -n "promoted.*canonical|candidate.*demoted.*retired" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the Phase-2 retrieval contract section
+  Then it states that promoted and canonical cards are runtime-eligible by default
+  And it states that candidate, demoted, and retired cards are excluded by default
+
+Scenario: contract keeps default context and search unchanged
+  Test:
+    Package: mempal
+    Filter: rg -n "P43 does not change.*mempal context|P43 does not change.*mempal_search" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the Phase-2 retrieval contract section
+  Then it explicitly says P43 does not change default context or search behavior
+
+Scenario: inventory includes P43 contract
+  Test:
+    Package: mempal
+    Filter: rg -n "p43-knowledge-card-retrieval-contract" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P43
+  Then both inventories list it as a contract-only completed spec
+
+Scenario: no card runtime implementation is added in P43
+  Test:
+    Package: mempal
+    Filter: git diff --name-only main...HEAD
+  Given the P43 branch
+  When reviewing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+  And no Rust source or test file is changed
+
+## Out of Scope
+
+- Do not implement card retrieval APIs.
+- Do not add card embeddings.
+- Do not change `mempal context`.
+- Do not change `mempal_context`.
+- Do not change `mempal_search`.
+- Do not change MCP tools.
+- Do not change REST endpoints.
+
+## Constraints
+
+- The contract must preserve evidence drawers as the citation root.
+- The contract must not imply cards replace drawers as default runtime source.
+- The contract must leave ranking strategy to later specs.


### PR DESCRIPTION
## Summary

- Add P43 task contract for Phase-2 knowledge card retrieval.
- Document required card retrieval fields and role-separated evidence citation fields.
- Define default runtime eligibility: `promoted` / `canonical` only.
- Explicitly keep `mempal context`, `mempal_context`, and `mempal_search` unchanged.
- Update AGENTS / CLAUDE inventories and add implementation plan.

## Verification

- `agent-spec parse specs/p43-knowledge-card-retrieval-contract.spec.md`
- `agent-spec lint specs/p43-knowledge-card-retrieval-contract.spec.md --min-score 0.7`
- `rg -n "card_id.*statement.*content|evidence_drawer_id.*role.*source_file" docs/MIND-MODEL-DESIGN.md`
- `rg -n "promoted.*canonical|candidate.*demoted.*retired" docs/MIND-MODEL-DESIGN.md`
- `rg -n "P43 does not change.*mempal context|P43 does not change.*mempal_search" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p43-knowledge-card-retrieval-contract" AGENTS.md CLAUDE.md`
- `git diff --name-only main...HEAD`
