### PR TITLE
feat: add card-aware context opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p41-knowledge-card-runtime-boundary.spec.md` | 完成 | 固化 Phase-2 card runtime boundary：cards 已治理，但尚非默认 context/search source |
 | `specs/p42-mind-model-completion-audit.spec.md` | 完成 | MIND-MODEL P42 baseline completion audit + future work 明确化 |
 | `specs/p43-knowledge-card-retrieval-contract.spec.md` | 完成 | Phase-2 card retrieval contract：定义 card result + evidence citation 形状，不改默认 runtime 行为 |
+| `specs/p44-card-context-assembler.spec.md` | 完成 | `mempal context` / `mempal_context` 显式 `include_cards`：按 P43 contract 注入 active cards + evidence citations |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -138,6 +139,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md` — P37 knowledge card backfill apply（已完成）
 - `docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md` — P38-P42 knowledge card runtime baseline（已完成）
 - `docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md` — P43 knowledge card retrieval contract（已完成）
+- `docs/plans/2026-04-28-p44-card-context-assembler.md` — P44 card-aware context assembler（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p41-knowledge-card-runtime-boundary.spec.md` | 完成 | 固化 Phase-2 card runtime boundary：cards 已治理，但尚非默认 context/search source |
 | `specs/p42-mind-model-completion-audit.spec.md` | 完成 | MIND-MODEL P42 baseline completion audit + future work 明确化 |
 | `specs/p43-knowledge-card-retrieval-contract.spec.md` | 完成 | Phase-2 card retrieval contract：定义 card result + evidence citation 形状，不改默认 runtime 行为 |
+| `specs/p44-card-context-assembler.spec.md` | 完成 | `mempal context` / `mempal_context` 显式 `include_cards`：按 P43 contract 注入 active cards + evidence citations |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -136,6 +137,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p37-knowledge-card-backfill-apply-implementation.md` — P37 knowledge card backfill apply（已完成）
 - `docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md` — P38-P42 knowledge card runtime baseline（已完成）
 - `docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md` — P43 knowledge card retrieval contract（已完成）
+- `docs/plans/2026-04-28-p44-card-context-assembler.md` — P44 card-aware context assembler（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1009,6 +1009,20 @@ P43 does not change `mempal_search` behavior.
 Card embeddings, ranking strategy, and card-aware context/search surfaces are
 deferred to later specs.
 
+P44 adds the first explicit card-aware context surface:
+
+- `mempal context --include-cards`
+- `mempal_context` with `include_cards=true`
+
+This remains opt-in. Default context assembly is still drawer-only. When enabled,
+active Phase-2 cards are appended inside the existing
+`dao_tian -> dao_ren -> shu -> qi` sections and expose `card_id` plus
+role-separated `evidence_citations`. Each citation keeps the evidence drawer as
+the citation root through `evidence_drawer_id`, `role`, and `source_file`.
+
+P44 does not change `mempal_search`, does not add card embeddings, and does not
+make cards the default runtime source.
+
 ## Decision on Bootstrap vs Final Architecture
 
 Current recommendation:
@@ -1073,7 +1087,8 @@ The remaining work is intentionally explicit:
 
 - define whether card retrieval uses card-level embeddings, linked evidence
   retrieval, or a hybrid of both
-- add a card-aware context source only after the retrieval strategy is specified
+- decide whether card-aware context should eventually become default after more
+  runtime evidence
 - decide whether Phase-2 card lifecycle should write JSONL audit entries in
   addition to append-only `knowledge_events`
 - integrate external `research-rs` outputs as evidence/candidate insights

--- a/docs/plans/2026-04-28-p44-card-context-assembler.md
+++ b/docs/plans/2026-04-28-p44-card-context-assembler.md
@@ -1,0 +1,27 @@
+# P44 Card-Aware Context Assembler Plan
+
+**Goal:** Add explicit opt-in card context items while preserving default
+drawer-only runtime context.
+
+## Steps
+
+- [x] Add P44 task contract.
+- [x] Extend context request/items with optional card metadata and citations.
+- [x] Add card assembly under existing tier sections behind `include_cards`.
+- [x] Wire CLI `--include-cards`.
+- [x] Wire MCP `include_cards`.
+- [x] Add core, CLI, and MCP tests.
+- [x] Update MIND-MODEL / AGENTS / CLAUDE inventories.
+- [x] Run spec lint, formatting, checks, clippy, and tests.
+
+## Verification
+
+```bash
+agent-spec parse specs/p44-card-context-assembler.spec.md
+agent-spec lint specs/p44-card-context-assembler.spec.md --min-score 0.7
+cargo fmt --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p44-card-context-assembler.spec.md
+++ b/specs/p44-card-context-assembler.spec.md
@@ -1,0 +1,79 @@
+spec: task
+name: "P44: card-aware context assembler"
+inherits: project
+tags: [memory, mind-model, knowledge-cards, context, phase-2]
+---
+
+## Intent
+
+P44 adds an explicit opt-in path for `mempal context` and `mempal_context` to
+include Phase-2 knowledge cards according to the P43 retrieval contract. Default
+context behavior remains drawer-only.
+
+## Decisions
+
+- Add `include_cards` to the core context request, CLI, and MCP request.
+- Default `include_cards` is false for CLI and MCP.
+- When enabled, only `promoted` and `canonical` cards are included.
+- Card context items include `card_id` and role-separated evidence citations.
+- Card evidence citations include `evidence_drawer_id`, `role`, and `source_file`.
+- Cards are appended within the existing `dao_tian -> dao_ren -> shu -> qi` sections.
+- P44 does not add card embeddings or semantic card ranking.
+- P44 does not change `mempal_search`.
+
+## Acceptance Criteria
+
+Scenario: default context remains drawer-only
+  Test:
+    Package: mempal
+    Filter: test_context_omits_cards_by_default
+  Given a matching active knowledge card
+  When assembling context without include_cards
+  Then no context item contains card_id
+
+Scenario: include_cards adds active cards with evidence citations
+  Test:
+    Package: mempal
+    Filter: test_context_include_cards_adds_active_card_citations
+  Given active and inactive cards with evidence links
+  When assembling context with include_cards=true
+  Then only active cards are included
+  And each card item includes evidence citation fields
+
+Scenario: CLI include-cards JSON exposes card metadata
+  Test:
+    Package: mempal
+    Filter: test_cli_context_include_cards_json
+  Given a matching promoted card with evidence
+  When running `mempal context <query> --include-cards --format json`
+  Then JSON includes card_id and evidence_citations
+
+Scenario: MCP include_cards exposes card metadata
+  Test:
+    Package: mempal
+    Filter: test_mcp_context_include_cards_appends_card_items
+  Given a matching promoted card with evidence
+  When calling `mempal_context` with include_cards=true
+  Then response includes a card context item with evidence citations
+
+Scenario: search remains unchanged
+  Test:
+    Package: mempal
+    Filter: rg -n "include_cards" src/search tests/search_neighbors.rs
+  Given P44 changes
+  When searching search implementation files
+  Then include_cards is absent from search code
+
+## Out of Scope
+
+- Do not add card embeddings.
+- Do not add card semantic ranking.
+- Do not change `mempal_search`.
+- Do not make cards default context source.
+- Do not remove Stage-1 drawer context.
+
+## Constraints
+
+- Evidence drawers remain the citation root.
+- Existing context JSON fields must remain backward compatible.
+- Card items must not include candidate, demoted, or retired cards by default.

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,8 +11,9 @@ use crate::core::{
     db::Database,
     db::DbError,
     types::{
-        AnchorKind, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, RouteDecision,
-        SearchResult, TriggerHints,
+        AnchorKind, KnowledgeCard, KnowledgeCardFilter, KnowledgeEvidenceLink,
+        KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
+        RouteDecision, SearchResult, TriggerHints,
     },
 };
 use crate::embed::{EmbedError, Embedder};
@@ -32,6 +33,8 @@ pub enum ContextError {
     Search(#[source] SearchError),
     #[error("failed to load context drawer metadata")]
     LoadDrawer(#[source] DbError),
+    #[error("failed to load context card metadata")]
+    LoadCard(#[source] DbError),
 }
 
 #[derive(Debug, Clone)]
@@ -41,6 +44,7 @@ pub struct ContextRequest {
     pub field: String,
     pub cwd: PathBuf,
     pub include_evidence: bool,
+    pub include_cards: bool,
     pub max_items: usize,
     pub dao_tian_limit: usize,
 }
@@ -72,6 +76,8 @@ pub struct ContextItem {
     pub source_file: String,
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tier: Option<KnowledgeTier>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<KnowledgeStatus>,
@@ -81,6 +87,15 @@ pub struct ContextItem {
     pub parent_anchor_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trigger_hints: Option<TriggerHints>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub evidence_citations: Vec<ContextEvidenceCitation>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextEvidenceCitation {
+    pub evidence_drawer_id: String,
+    pub role: KnowledgeEvidenceRole,
+    pub source_file: String,
 }
 
 #[derive(Debug, Clone)]
@@ -100,6 +115,13 @@ struct CandidateQuery<'a> {
     tier: Option<KnowledgeTier>,
     status: Option<KnowledgeStatus>,
     top_k: usize,
+}
+
+struct CardAppendState<'a> {
+    seen: &'a mut BTreeSet<String>,
+    items: &'a mut Vec<ContextItem>,
+    remaining: &'a mut usize,
+    tier_remaining: &'a mut usize,
 }
 
 pub async fn assemble_context<E: Embedder + ?Sized>(
@@ -184,10 +206,43 @@ pub fn assemble_context_with_vector(
             }
         }
         if !items.is_empty() {
+            if request.include_cards && remaining > 0 {
+                append_card_context_items(
+                    db,
+                    &request,
+                    &anchors,
+                    tier,
+                    CardAppendState {
+                        seen: &mut seen,
+                        items: &mut items,
+                        remaining: &mut remaining,
+                        tier_remaining: &mut tier_remaining,
+                    },
+                )?;
+            }
             sections.push(ContextSection {
                 name: tier_slug(tier).to_string(),
                 items,
             });
+        } else if request.include_cards && remaining > 0 {
+            append_card_context_items(
+                db,
+                &request,
+                &anchors,
+                tier,
+                CardAppendState {
+                    seen: &mut seen,
+                    items: &mut items,
+                    remaining: &mut remaining,
+                    tier_remaining: &mut tier_remaining,
+                },
+            )?;
+            if !items.is_empty() {
+                sections.push(ContextSection {
+                    name: tier_slug(tier).to_string(),
+                    items,
+                });
+            }
         }
     }
 
@@ -345,6 +400,88 @@ fn context_item_from_result(db: &Database, result: SearchResult) -> Result<Conte
         anchor_id: result.anchor_id,
         parent_anchor_id: result.parent_anchor_id,
         trigger_hints,
+        card_id: None,
+        evidence_citations: Vec::new(),
+    })
+}
+
+fn append_card_context_items(
+    db: &Database,
+    request: &ContextRequest,
+    anchors: &[AnchorCandidate],
+    tier: &KnowledgeTier,
+    state: CardAppendState<'_>,
+) -> Result<()> {
+    for anchor in anchors {
+        if *state.remaining == 0 || *state.tier_remaining == 0 {
+            break;
+        }
+        for status in active_statuses() {
+            if *state.remaining == 0 || *state.tier_remaining == 0 {
+                break;
+            }
+            let cards = db
+                .list_knowledge_cards(&KnowledgeCardFilter {
+                    tier: Some(tier.clone()),
+                    status: Some(status.clone()),
+                    domain: Some(anchor.domain.clone()),
+                    field: Some(request.field.clone()),
+                    anchor_kind: Some(anchor.anchor_kind.clone()),
+                    anchor_id: Some(anchor.anchor_id.clone()),
+                })
+                .map_err(ContextError::LoadCard)?;
+            for card in cards {
+                if *state.remaining == 0 || *state.tier_remaining == 0 {
+                    break;
+                }
+                let seen_key = format!("card:{}", card.id);
+                if !state.seen.insert(seen_key) {
+                    continue;
+                }
+                state.items.push(context_item_from_card(db, card)?);
+                *state.remaining -= 1;
+                *state.tier_remaining -= 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn context_item_from_card(db: &Database, card: KnowledgeCard) -> Result<ContextItem> {
+    let evidence_citations = db
+        .knowledge_evidence_links(&card.id)
+        .map_err(ContextError::LoadCard)?
+        .into_iter()
+        .map(|link| evidence_citation_from_link(db, link))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(ContextItem {
+        drawer_id: card.id.clone(),
+        source_file: format!("knowledge-card://{}", card.id),
+        text: card.statement.clone(),
+        card_id: Some(card.id),
+        tier: Some(card.tier),
+        status: Some(card.status),
+        anchor_kind: card.anchor_kind,
+        anchor_id: card.anchor_id,
+        parent_anchor_id: card.parent_anchor_id,
+        trigger_hints: card.trigger_hints,
+        evidence_citations,
+    })
+}
+
+fn evidence_citation_from_link(
+    db: &Database,
+    link: KnowledgeEvidenceLink,
+) -> Result<ContextEvidenceCitation> {
+    let source_file = db
+        .get_drawer(&link.evidence_drawer_id)
+        .map_err(ContextError::LoadDrawer)?
+        .and_then(|drawer| drawer.source_file)
+        .unwrap_or_else(|| format!("drawer://{}", link.evidence_drawer_id));
+    Ok(ContextEvidenceCitation {
+        evidence_drawer_id: link.evidence_drawer_id,
+        role: link.role,
+        source_file,
     })
 }
 

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -47,10 +47,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 3b. USE MIND-MODEL CONTEXT FOR GUIDANCE
    When you need ordered operating guidance rather than raw evidence search,
    call mempal_context. It assembles typed knowledge in the intended runtime
-   order: dao_tian -> dao_ren -> shu -> qi, with evidence opt-in. Use this
-   before choosing a workflow or skill when the user asks "how should we
-   approach this?" or when a task benefits from high-level principles plus
-   concrete tool bindings.
+   order: dao_tian -> dao_ren -> shu -> qi, with evidence and Phase-2 card
+   context opt-in. Use this before choosing a workflow or skill when the user
+   asks "how should we approach this?" or when a task benefits from high-level
+   principles plus concrete tool bindings.
    dao_tian is intentionally sparse in runtime context: by default at most one
    dao_tian item is injected. Set dao_tian_limit=0 when universal principles
    are not needed, or raise it only when explicitly reasoning about
@@ -212,7 +212,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
-  mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi)
+  mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi; evidence/cards opt-in)
   mempal_field_taxonomy — read-only recommended mind-model field values
   mempal_knowledge_distill — create candidate knowledge from evidence refs
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,8 @@ enum Commands {
         format: String,
         #[arg(long)]
         include_evidence: bool,
+        #[arg(long)]
+        include_cards: bool,
         #[arg(long, default_value_t = 12)]
         max_items: usize,
         #[arg(long = "dao-tian-limit", default_value_t = 1)]
@@ -683,6 +685,7 @@ async fn run() -> Result<()> {
             cwd,
             format,
             include_evidence,
+            include_cards,
             max_items,
             dao_tian_limit,
         } => {
@@ -696,6 +699,7 @@ async fn run() -> Result<()> {
                     cwd,
                     format,
                     include_evidence,
+                    include_cards,
                     max_items,
                     dao_tian_limit,
                 },
@@ -750,6 +754,7 @@ struct ContextCommandArgs {
     cwd: Option<PathBuf>,
     format: String,
     include_evidence: bool,
+    include_cards: bool,
     max_items: usize,
     dao_tian_limit: usize,
 }
@@ -968,6 +973,7 @@ async fn context_command(db: &Database, config: &Config, args: ContextCommandArg
             field: args.field,
             cwd,
             include_evidence: args.include_evidence,
+            include_cards: args.include_cards,
             max_items: args.max_items,
             dao_tian_limit: args.dao_tian_limit,
         },
@@ -1010,6 +1016,9 @@ fn print_context_plain(pack: &ContextPack) {
             println!("- {}", item.text);
             println!("  source: {}", item.source_file);
             println!("  drawer: {}", item.drawer_id);
+            if let Some(card_id) = item.card_id.as_deref() {
+                println!("  card: {card_id}");
+            }
             println!(
                 "  anchor: {} {}",
                 anchor_kind_slug(&item.anchor_kind),
@@ -1028,6 +1037,14 @@ fn print_context_plain(pack: &ContextPack) {
                     trigger_hints.intent_tags.join(","),
                     trigger_hints.workflow_bias.join(","),
                     trigger_hints.tool_needs.join(",")
+                );
+            }
+            for citation in &item.evidence_citations {
+                println!(
+                    "  evidence: {} role={} source={}",
+                    citation.evidence_drawer_id,
+                    knowledge_evidence_role_slug(&citation.role),
+                    citation.source_file
                 );
             }
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -710,7 +710,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_context",
-        description = "Assemble a mind-model runtime context pack from typed memory. Use this when you need ordered guidance rather than raw search results: dao_tian -> dao_ren -> shu -> qi, with evidence opt-in. Returns source-backed items with drawer_id/source_file citations and trigger_hints metadata, but never executes skills."
+        description = "Assemble a mind-model runtime context pack from typed memory. Use this when you need ordered guidance rather than raw search results: dao_tian -> dao_ren -> shu -> qi, with evidence and Phase-2 knowledge cards opt-in. Returns source-backed items with citations and trigger_hints metadata, but never executes skills."
     )]
     async fn mempal_context(
         &self,
@@ -764,6 +764,7 @@ impl MempalMcpServer {
                     .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
                 cwd,
                 include_evidence: request.include_evidence.unwrap_or(false),
+                include_cards: request.include_cards.unwrap_or(false),
                 max_items,
                 dao_tian_limit,
             },
@@ -1863,7 +1864,8 @@ fn context_error(error: crate::context::ContextError) -> ErrorData {
         crate::context::ContextError::EmbedQuery(_)
         | crate::context::ContextError::MissingQueryVector
         | crate::context::ContextError::Search(_)
-        | crate::context::ContextError::LoadDrawer(_) => {
+        | crate::context::ContextError::LoadDrawer(_)
+        | crate::context::ContextError::LoadCard(_) => {
             ErrorData::internal_error(format!("context assembly failed: {error}"), None)
         }
     }
@@ -2552,6 +2554,62 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["qi", "evidence"]);
         assert_eq!(response.sections[1].items[0].drawer_id, "drawer_evidence");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_include_cards_appends_card_items() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_card_evidence",
+            "card evidence",
+            "mempal",
+            Some("context"),
+            "/tmp/card-evidence.md",
+            2,
+        );
+        let mut card = knowledge_card(
+            "card_context",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "general",
+        );
+        card.anchor_id = anchor::LEGACY_REPO_ANCHOR_ID.to_string();
+        insert_knowledge_card(&db_path, card);
+        insert_knowledge_card_link(
+            &db_path,
+            "link_card_context_supporting",
+            "card_context",
+            "drawer_card_evidence",
+            KnowledgeEvidenceRole::Supporting,
+        );
+
+        let response = server
+            .context_json_for_test(serde_json::json!({
+                "query": "card context",
+                "include_cards": true
+            }))
+            .await
+            .expect("context should succeed");
+        let card = response
+            .sections
+            .iter()
+            .flat_map(|section| section.items.iter())
+            .find(|item| item.card_id.as_deref() == Some("card_context"))
+            .expect("card context item");
+
+        assert_eq!(card.drawer_id, "card_context");
+        assert_eq!(card.source_file, "knowledge-card://card_context");
+        assert_eq!(card.evidence_citations.len(), 1);
+        assert_eq!(
+            card.evidence_citations[0].evidence_drawer_id,
+            "drawer_card_evidence"
+        );
+        assert_eq!(card.evidence_citations[0].role, "supporting");
+        assert_eq!(
+            card.evidence_citations[0].source_file,
+            "/tmp/card-evidence.md"
+        );
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -71,6 +71,7 @@ pub struct ContextRequest {
     pub domain: Option<String>,
     pub cwd: Option<String>,
     pub include_evidence: Option<bool>,
+    pub include_cards: Option<bool>,
     pub max_items: Option<usize>,
     /// Maximum number of `dao_tian` items to include. Defaults to 1; 0 disables
     /// the `dao_tian` section while preserving lower-tier context.
@@ -422,6 +423,8 @@ pub struct ContextItemDto {
     pub source_file: String,
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tier: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
@@ -431,6 +434,15 @@ pub struct ContextItemDto {
     pub parent_anchor_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trigger_hints: Option<TriggerHintsDto>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub evidence_citations: Vec<ContextEvidenceCitationDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ContextEvidenceCitationDto {
+    pub evidence_drawer_id: String,
+    pub role: String,
+    pub source_file: String,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -937,6 +949,7 @@ impl From<ContextItem> for ContextItemDto {
             drawer_id: value.drawer_id,
             source_file: value.source_file,
             text: value.text,
+            card_id: value.card_id,
             tier: value
                 .tier
                 .as_ref()
@@ -951,6 +964,15 @@ impl From<ContextItem> for ContextItemDto {
             anchor_id: value.anchor_id,
             parent_anchor_id: value.parent_anchor_id,
             trigger_hints: value.trigger_hints.map(TriggerHintsDto::from),
+            evidence_citations: value
+                .evidence_citations
+                .into_iter()
+                .map(|citation| ContextEvidenceCitationDto {
+                    evidence_drawer_id: citation.evidence_drawer_id,
+                    role: knowledge_evidence_role_slug(&citation.role).to_string(),
+                    source_file: citation.source_file,
+                })
+                .collect(),
         }
     }
 }
@@ -1110,6 +1132,15 @@ fn knowledge_status_slug(value: &KnowledgeStatus) -> &'static str {
         KnowledgeStatus::Canonical => "canonical",
         KnowledgeStatus::Demoted => "demoted",
         KnowledgeStatus::Retired => "retired",
+    }
+}
+
+fn knowledge_evidence_role_slug(value: &crate::core::types::KnowledgeEvidenceRole) -> &'static str {
+    match value {
+        crate::core::types::KnowledgeEvidenceRole::Supporting => "supporting",
+        crate::core::types::KnowledgeEvidenceRole::Verification => "verification",
+        crate::core::types::KnowledgeEvidenceRole::Counterexample => "counterexample",
+        crate::core::types::KnowledgeEvidenceRole::Teaching => "teaching",
     }
 }
 

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -10,8 +10,8 @@ use mempal::context::{ContextRequest, assemble_context};
 use mempal::core::anchor;
 use mempal::core::db::Database;
 use mempal::core::types::{
-    AnchorKind, Drawer, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance,
-    SourceType, TriggerHints,
+    AnchorKind, Drawer, KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+    KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, SourceType, TriggerHints,
 };
 use mempal::embed::Embedder;
 use serde_json::{Value, json};
@@ -69,9 +69,56 @@ fn default_request(query: &str, cwd: &Path) -> ContextRequest {
         field: "general".to_string(),
         cwd: cwd.to_path_buf(),
         include_evidence: false,
+        include_cards: false,
         max_items: 12,
         dao_tian_limit: 1,
     }
+}
+
+fn knowledge_card(
+    id: &str,
+    tier: KnowledgeTier,
+    status: KnowledgeStatus,
+    statement: &str,
+) -> KnowledgeCard {
+    KnowledgeCard {
+        id: id.to_string(),
+        statement: statement.to_string(),
+        content: format!("Card content for {id}."),
+        tier,
+        status,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        scope_constraints: None,
+        trigger_hints: None,
+        created_at: "1710000000".to_string(),
+        updated_at: "1710000000".to_string(),
+    }
+}
+
+fn insert_card(db: &Database, card: &KnowledgeCard) {
+    db.insert_knowledge_card(card).expect("insert card");
+}
+
+fn insert_card_link(
+    db: &Database,
+    id: &str,
+    card_id: &str,
+    evidence_drawer_id: &str,
+    role: KnowledgeEvidenceRole,
+) {
+    db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+        id: id.to_string(),
+        card_id: card_id.to_string(),
+        evidence_drawer_id: evidence_drawer_id.to_string(),
+        role,
+        note: None,
+        created_at: "1710000000".to_string(),
+    })
+    .expect("insert card link");
 }
 
 fn knowledge_drawer(
@@ -531,6 +578,110 @@ async fn test_context_omits_evidence_by_default() {
 }
 
 #[tokio::test]
+async fn test_context_omits_cards_by_default() {
+    let (tmp, db) = new_db();
+    insert_card(
+        &db,
+        &knowledge_card(
+            "card_promoted",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Use card context only when requested.",
+        ),
+    );
+
+    let pack = assemble_context(
+        &db,
+        &embedder(),
+        default_request("card context", tmp.path()),
+    )
+    .await
+    .expect("assemble context");
+
+    assert!(
+        pack.sections
+            .iter()
+            .flat_map(|section| section.items.iter())
+            .all(|item| item.card_id.is_none())
+    );
+}
+
+#[tokio::test]
+async fn test_context_include_cards_adds_active_card_citations() {
+    let (tmp, db) = new_db();
+    insert_fixture(
+        &db,
+        &evidence_drawer("drawer_card_evidence", "card evidence source"),
+    );
+    for (id, status) in [
+        ("card_promoted", KnowledgeStatus::Promoted),
+        ("card_canonical", KnowledgeStatus::Canonical),
+        ("card_candidate", KnowledgeStatus::Candidate),
+        ("card_demoted", KnowledgeStatus::Demoted),
+        ("card_retired", KnowledgeStatus::Retired),
+    ] {
+        insert_card(
+            &db,
+            &knowledge_card(
+                id,
+                KnowledgeTier::Shu,
+                status,
+                &format!("Statement for {id}."),
+            ),
+        );
+    }
+    insert_card_link(
+        &db,
+        "link_card_promoted_supporting",
+        "card_promoted",
+        "drawer_card_evidence",
+        KnowledgeEvidenceRole::Supporting,
+    );
+    let mut request = default_request("card", tmp.path());
+    request.include_cards = true;
+
+    let pack = assemble_context(&db, &embedder(), request)
+        .await
+        .expect("assemble context");
+    let card_items = pack
+        .sections
+        .iter()
+        .flat_map(|section| section.items.iter())
+        .filter(|item| item.card_id.is_some())
+        .collect::<Vec<_>>();
+    let card_ids = card_items
+        .iter()
+        .filter_map(|item| item.card_id.as_deref())
+        .collect::<Vec<_>>();
+
+    assert!(card_ids.contains(&"card_promoted"));
+    assert!(card_ids.contains(&"card_canonical"));
+    assert!(!card_ids.contains(&"card_candidate"));
+    assert!(!card_ids.contains(&"card_demoted"));
+    assert!(!card_ids.contains(&"card_retired"));
+
+    let promoted = card_items
+        .iter()
+        .find(|item| item.card_id.as_deref() == Some("card_promoted"))
+        .expect("promoted card item");
+    assert_eq!(promoted.drawer_id, "card_promoted");
+    assert_eq!(promoted.source_file, "knowledge-card://card_promoted");
+    assert_eq!(promoted.evidence_citations.len(), 1);
+    assert_eq!(
+        promoted.evidence_citations[0].evidence_drawer_id,
+        "drawer_card_evidence"
+    );
+    assert_eq!(
+        promoted.evidence_citations[0].role,
+        KnowledgeEvidenceRole::Supporting
+    );
+    assert_eq!(
+        promoted.evidence_citations[0].source_file,
+        "tests://context/drawer_card_evidence"
+    );
+}
+
+#[tokio::test]
 async fn test_context_include_evidence_adds_evidence_section_after_qi() {
     let (tmp, db) = new_db();
     insert_fixture(
@@ -561,6 +712,53 @@ async fn test_context_include_evidence_adds_evidence_section_after_qi() {
         .find(|section| section.name == "evidence")
         .expect("evidence section");
     assert_eq!(evidence.items[0].text, "observed failure");
+}
+
+#[test]
+fn test_cli_context_include_cards_json() {
+    let (tmp, db) = setup_cli_home();
+    insert_fixture(
+        &db,
+        &evidence_drawer("drawer_card_evidence", "card evidence source"),
+    );
+    insert_card(
+        &db,
+        &knowledge_card(
+            "card_cli_context",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Use card-aware context explicitly.",
+        ),
+    );
+    insert_card_link(
+        &db,
+        "link_card_cli_context_supporting",
+        "card_cli_context",
+        "drawer_card_evidence",
+        KnowledgeEvidenceRole::Supporting,
+    );
+
+    let value = run_context_json(tmp.path(), "card-aware", &["--include-cards"]);
+    let items = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .collect::<Vec<_>>();
+    let card = items
+        .iter()
+        .find(|item| item["card_id"] == "card_cli_context")
+        .expect("card item");
+    assert_eq!(card["text"], "Use card-aware context explicitly.");
+    assert_eq!(
+        card["evidence_citations"][0]["evidence_drawer_id"],
+        "drawer_card_evidence"
+    );
+    assert_eq!(card["evidence_citations"][0]["role"], "supporting");
+    assert_eq!(
+        card["evidence_citations"][0]["source_file"],
+        "tests://context/drawer_card_evidence"
+    );
 }
 
 #[test]

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -255,6 +255,7 @@ async fn default_context_ids(db: &Database, cwd: &Path, query: &str) -> Vec<Stri
             field: anchor::DEFAULT_FIELD.to_string(),
             cwd: cwd.to_path_buf(),
             include_evidence: false,
+            include_cards: false,
             max_items: 12,
             dao_tian_limit: 1,
         },


### PR DESCRIPTION
## Summary

- Add P44 spec and implementation plan for opt-in card-aware context assembly.
- Add `mempal context --include-cards` and MCP `mempal_context.include_cards`.
- Append active knowledge cards (`promoted`, `canonical`) inside existing tier sections while preserving evidence citations.
- Keep default context drawer-only and keep `mempal_search` unchanged.

## Verification

- `agent-spec parse specs/p44-card-context-assembler.spec.md`
- `agent-spec lint specs/p44-card-context-assembler.spec.md --min-score 0.7`
- `cargo fmt`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --test context_assembler`
- `cargo test test_mcp_context_include_cards_appends_card_items`
- `cargo test`
