### PR TITLE
feat: add linked-evidence card retrieval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p42-mind-model-completion-audit.spec.md` | 完成 | MIND-MODEL P42 baseline completion audit + future work 明确化 |
 | `specs/p43-knowledge-card-retrieval-contract.spec.md` | 完成 | Phase-2 card retrieval contract：定义 card result + evidence citation 形状，不改默认 runtime 行为 |
 | `specs/p44-card-context-assembler.spec.md` | 完成 | `mempal context` / `mempal_context` 显式 `include_cards`：按 P43 contract 注入 active cards + evidence citations |
+| `specs/p45-card-linked-evidence-retrieval.spec.md` | 完成 | `mempal knowledge-card retrieve` / `mempal_knowledge_cards action=retrieve`：通过 linked evidence 检索 active cards，不改默认 search |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -140,6 +141,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md` — P38-P42 knowledge card runtime baseline（已完成）
 - `docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md` — P43 knowledge card retrieval contract（已完成）
 - `docs/plans/2026-04-28-p44-card-context-assembler.md` — P44 card-aware context assembler（已完成）
+- `docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md` — P45 card linked-evidence retrieval（已完成）
 
 ### Spec 使用方式
 
@@ -166,7 +168,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
-| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26） |
+| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26/P44） |
 | `mempal_field_taxonomy` | read-only Stage-1 field taxonomy guidance：推荐 `field` 值但不限制自定义字段（P28） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_policy` | read-only Stage-1 promotion policy：列出 `dao_tian/dao_ren/shu/qi` 提升阈值（P27） |
@@ -174,6 +176,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
+| `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p42-mind-model-completion-audit.spec.md` | 完成 | MIND-MODEL P42 baseline completion audit + future work 明确化 |
 | `specs/p43-knowledge-card-retrieval-contract.spec.md` | 完成 | Phase-2 card retrieval contract：定义 card result + evidence citation 形状，不改默认 runtime 行为 |
 | `specs/p44-card-context-assembler.spec.md` | 完成 | `mempal context` / `mempal_context` 显式 `include_cards`：按 P43 contract 注入 active cards + evidence citations |
+| `specs/p45-card-linked-evidence-retrieval.spec.md` | 完成 | `mempal knowledge-card retrieve` / `mempal_knowledge_cards action=retrieve`：通过 linked evidence 检索 active cards，不改默认 search |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -138,6 +139,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-27-p38-p42-knowledge-card-runtime-implementation.md` — P38-P42 knowledge card runtime baseline（已完成）
 - `docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md` — P43 knowledge card retrieval contract（已完成）
 - `docs/plans/2026-04-28-p44-card-context-assembler.md` — P44 card-aware context assembler（已完成）
+- `docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md` — P45 card linked-evidence retrieval（已完成）
 
 ### Spec 使用方式
 
@@ -164,7 +166,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
-| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26） |
+| `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26/P44） |
 | `mempal_field_taxonomy` | read-only Stage-1 field taxonomy guidance：推荐 `field` 值但不限制自定义字段（P28） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_policy` | read-only Stage-1 promotion policy：列出 `dao_tian/dao_ren/shu/qi` 提升阈值（P27） |
@@ -172,6 +174,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_promote` | gate-enforced knowledge lifecycle promotion（P23） |
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
+| `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -976,8 +976,9 @@ Implemented Phase-2 surface at P42 baseline:
 
 Phase-2 cards are governed objects, but they are not yet the default
 context/search source. At P42, `mempal context`, `mempal_context`, and
-`mempal_search` remain drawer/citation based because cards do not yet have a
-dedicated retrieval strategy or vector indexing policy.
+`mempal_search` remains drawer/citation based. Cards now have an explicit
+linked-evidence retrieval path, but they are still not returned by default
+search.
 
 ### Phase-2 Card Retrieval Contract
 
@@ -1022,6 +1023,20 @@ the citation root through `evidence_drawer_id`, `role`, and `source_file`.
 
 P44 does not change `mempal_search`, does not add card embeddings, and does not
 make cards the default runtime source.
+
+P45 chooses the first card retrieval strategy:
+
+- `mempal knowledge-card retrieve <query>`
+- `mempal_knowledge_cards` with `action="retrieve"`
+
+The strategy is linked-evidence-first. It searches evidence drawers through the
+existing BM25+vector drawer search path, follows `knowledge_evidence_links`, and
+returns active cards linked to matched evidence. Returned card items include the
+card record, a score derived from matched evidence, and role-separated evidence
+citations with `evidence_drawer_id`, `role`, `source_file`, and score.
+
+P45 intentionally does not add card embeddings, does not add card vector
+storage, and does not make `mempal_search` return cards.
 
 ## Decision on Bootstrap vs Final Architecture
 
@@ -1085,10 +1100,10 @@ Proceed with the following assumptions unless future evidence rejects them:
 
 The remaining work is intentionally explicit:
 
-- define whether card retrieval uses card-level embeddings, linked evidence
-  retrieval, or a hybrid of both
 - decide whether card-aware context should eventually become default after more
   runtime evidence
+- decide whether a later retrieval phase needs card-level embeddings in addition
+  to P45 linked-evidence retrieval
 - decide whether Phase-2 card lifecycle should write JSONL audit entries in
   addition to append-only `knowledge_events`
 - integrate external `research-rs` outputs as evidence/candidate insights

--- a/docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md
+++ b/docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md
@@ -1,0 +1,28 @@
+# P45 Card Linked-Evidence Retrieval Plan
+
+**Goal:** Add an explicit Phase-2 card retrieval surface that finds active
+knowledge cards through matched evidence drawers, without changing default
+search or adding card embeddings.
+
+## Checklist
+
+- [x] Add P45 task contract.
+- [x] Add core retrieval model and linked-evidence search implementation.
+- [x] Add CLI `knowledge-card retrieve`.
+- [x] Add MCP `mempal_knowledge_cards` action `retrieve`.
+- [x] Update MIND-MODEL and inventory docs.
+- [x] Run spec lint, formatting, checks, clippy, and tests.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p45-card-linked-evidence-retrieval.spec.md
+agent-spec lint specs/p45-card-linked-evidence-retrieval.spec.md --min-score 0.7
+cargo fmt
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --test knowledge_card_retrieval
+cargo test test_mcp_knowledge_cards_retrieve_action
+cargo test
+```

--- a/specs/p45-card-linked-evidence-retrieval.spec.md
+++ b/specs/p45-card-linked-evidence-retrieval.spec.md
@@ -1,0 +1,94 @@
+spec: task
+name: "P45: card linked-evidence retrieval"
+inherits: project
+tags: [rust, cli, mcp, mind-model, knowledge-card]
+---
+
+## Intent
+
+P43 defined the Phase-2 card retrieval result shape and P44 added opt-in card-aware
+context assembly. P45 chooses the first explicit card retrieval strategy:
+retrieve active knowledge cards through their linked evidence drawers, reusing the
+existing drawer BM25+vector search path instead of adding card embeddings.
+
+## Decisions
+
+- Retrieval strategy is linked-evidence-first: search evidence drawers, then return active cards linked to matched evidence.
+- Active cards are `promoted` and `canonical`; `candidate`, `demoted`, and `retired` are excluded by default.
+- Add explicit CLI surface `mempal knowledge-card retrieve <query>`.
+- Add MCP surface through `mempal_knowledge_cards` with `action="retrieve"`.
+- Retrieval results include the card plus matched evidence citations with `evidence_drawer_id`, `role`, `source_file`, and score.
+- Do not change `mempal_search` default behavior and do not add card embedding storage.
+
+## Boundaries
+
+### Allowed Changes
+- src/core/db.rs
+- src/core/protocol.rs
+- src/core/types.rs
+- src/knowledge_card_retrieval.rs
+- src/lib.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/knowledge_card_retrieval.rs
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- docs/plans/**
+
+### Forbidden
+- Do not add new runtime dependencies.
+- Do not add card vector tables or card embedding writes.
+- Do not make `mempal_search` return cards.
+- Do not make card-aware context the default.
+
+## Acceptance Criteria
+
+Scenario: CLI retrieve returns active cards through linked evidence
+  Test: test_cli_knowledge_card_retrieve_json_returns_active_card
+  Given an evidence drawer that matches the query
+  And a promoted card linked to that evidence drawer
+  When running `mempal knowledge-card retrieve <query> --format json`
+  Then the JSON result contains the promoted card
+  And the result contains an evidence citation with `evidence_drawer_id`, `role`, `source_file`, and score
+
+Scenario: CLI retrieve excludes inactive cards
+  Test: test_card_retrieve_excludes_candidate_cards
+  Given matching evidence linked to both promoted and candidate cards
+  When retrieving cards
+  Then only the promoted card is returned
+
+Scenario: MCP retrieve action returns the same shape
+  Test: test_mcp_knowledge_cards_retrieve_action
+  Given the MCP entry point in `src/mcp/server.rs`
+  And an active card linked to matching evidence
+  And the action value is `retrieve`
+  When calling `mempal_knowledge_cards` with `action="retrieve"`
+  Then the response contains retrieved card results with evidence citations
+
+Scenario: Retrieval does not mutate storage
+  Test: test_card_retrieve_has_no_db_side_effects
+  Given existing cards and evidence links
+  When retrieving cards
+  Then drawer, card, link, and event counts are unchanged
+
+Scenario: Retrieval does not alter default search behavior
+  Test: test_card_retrieve_does_not_change_mempal_search
+  Given a card linked to matching evidence
+  When running normal drawer search
+  Then results contain drawer ids only and no knowledge card id
+
+Scenario: Invalid retrieve top_k is rejected
+  Test: test_cli_knowledge_card_retrieve_rejects_zero_top_k
+  Given the CLI entry point in `src/main.rs`
+  When running `mempal knowledge-card retrieve <query> --top-k 0`
+  Then the command fails
+  And stderr says `--top-k must be greater than 0`
+
+## Out of Scope
+
+- Card-level vector embeddings.
+- Returning cards from default `mempal_search`.
+- Making card-aware context default.
+- Automatic promotion or lifecycle mutation.

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1005,6 +1005,26 @@ impl Database {
         Ok(rows)
     }
 
+    pub fn knowledge_evidence_links_for_drawer(
+        &self,
+        evidence_drawer_id: &str,
+    ) -> Result<Vec<KnowledgeEvidenceLink>, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT id, card_id, evidence_drawer_id, role, note, created_at
+            FROM knowledge_evidence_links
+            WHERE evidence_drawer_id = ?1
+            ORDER BY created_at, id
+            "#,
+        )?;
+        let rows = statement
+            .query_map([evidence_drawer_id], |row| {
+                knowledge_evidence_link_from_row(row).map_err(row_decode_error)
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     pub fn append_knowledge_event(&self, event: &KnowledgeCardEvent) -> Result<(), DbError> {
         self.conn.execute(
             r#"

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -204,10 +204,11 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 
 16. INSPECT AND GOVERN PHASE-2 KNOWLEDGE CARDS
    Use mempal_knowledge_cards to inspect Phase-2 knowledge card records and
-   append-only event history. It also supports governed card lifecycle actions:
-   gate is read-only, promote requires verification evidence and a passing gate,
-   and demote requires counterexample evidence. It does not create cards, search,
-   assemble context, or backfill drawers.
+   append-only event history. It also supports linked-evidence retrieval of
+   active cards and governed card lifecycle actions: gate is read-only, promote
+   requires verification evidence and a passing gate, and demote requires
+   counterexample evidence. It does not create cards, replace mempal_search,
+   assemble default context, or backfill drawers.
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
@@ -217,7 +218,7 @@ TOOLS:
   mempal_knowledge_distill — create candidate knowledge from evidence refs
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
-  mempal_knowledge_cards — Phase-2 knowledge card list/get/events/gate/promote/demote
+  mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/knowledge_card_retrieval.rs
+++ b/src/knowledge_card_retrieval.rs
@@ -1,0 +1,271 @@
+#![warn(clippy::all)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::core::{
+    anchor,
+    db::{Database, DbError},
+    types::{
+        AnchorKind, KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus,
+        MemoryDomain, MemoryKind, RouteDecision,
+    },
+};
+use crate::embed::{EmbedError, Embedder};
+use crate::search::{SearchError, SearchFilters, SearchOptions, search_with_vector_options};
+
+pub type Result<T> = std::result::Result<T, KnowledgeCardRetrievalError>;
+
+#[derive(Debug, Error)]
+pub enum KnowledgeCardRetrievalError {
+    #[error("failed to derive retrieval anchors")]
+    DeriveAnchor(#[from] anchor::AnchorError),
+    #[error("failed to embed card retrieval query")]
+    EmbedQuery(#[source] EmbedError),
+    #[error("embedder returned no card retrieval query vector")]
+    MissingQueryVector,
+    #[error("failed to search linked evidence")]
+    SearchEvidence(#[source] SearchError),
+    #[error("failed to load card retrieval metadata")]
+    LoadMetadata(#[source] DbError),
+}
+
+#[derive(Debug, Clone)]
+pub struct KnowledgeCardRetrievalRequest {
+    pub query: String,
+    pub domain: MemoryDomain,
+    pub field: String,
+    pub cwd: PathBuf,
+    pub top_k: usize,
+    pub evidence_top_k: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RetrievedKnowledgeCard {
+    pub card: KnowledgeCard,
+    pub evidence_citations: Vec<RetrievedEvidenceCitation>,
+    pub score: f32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RetrievedEvidenceCitation {
+    pub evidence_drawer_id: String,
+    pub role: KnowledgeEvidenceRole,
+    pub source_file: String,
+    pub score: f32,
+}
+
+#[derive(Debug, Clone)]
+struct AnchorCandidate {
+    anchor_kind: AnchorKind,
+    anchor_id: String,
+    domain: MemoryDomain,
+}
+
+pub async fn retrieve_knowledge_cards<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    request: KnowledgeCardRetrievalRequest,
+) -> Result<Vec<RetrievedKnowledgeCard>> {
+    if request.top_k == 0 {
+        return Ok(Vec::new());
+    }
+    let query_vector = embedder
+        .embed(&[request.query.as_str()])
+        .await
+        .map_err(KnowledgeCardRetrievalError::EmbedQuery)?
+        .into_iter()
+        .next()
+        .ok_or(KnowledgeCardRetrievalError::MissingQueryVector)?;
+    retrieve_knowledge_cards_with_vector(db, request, &query_vector)
+}
+
+pub fn retrieve_knowledge_cards_with_vector(
+    db: &Database,
+    request: KnowledgeCardRetrievalRequest,
+    query_vector: &[f32],
+) -> Result<Vec<RetrievedKnowledgeCard>> {
+    if request.top_k == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut by_card = BTreeMap::<String, RetrievedKnowledgeCard>::new();
+    let route = RouteDecision {
+        wing: None,
+        room: None,
+        confidence: 0.0,
+        reason: "knowledge card linked-evidence retrieval".to_string(),
+    };
+
+    for anchor in retrieval_anchors(&request)? {
+        let filters = SearchFilters {
+            memory_kind: Some(memory_kind_slug(&MemoryKind::Evidence).to_string()),
+            domain: Some(domain_slug(&anchor.domain).to_string()),
+            field: Some(request.field.clone()),
+            tier: None,
+            status: None,
+            anchor_kind: Some(anchor_kind_slug(&anchor.anchor_kind).to_string()),
+        };
+        let evidence_results = search_with_vector_options(
+            db,
+            &request.query,
+            query_vector,
+            route.clone(),
+            SearchOptions {
+                filters,
+                with_neighbors: false,
+            },
+            request.evidence_top_k.max(request.top_k),
+        )
+        .map_err(KnowledgeCardRetrievalError::SearchEvidence)?;
+
+        for evidence in evidence_results {
+            if evidence.anchor_id != anchor.anchor_id {
+                continue;
+            }
+            let links = db
+                .knowledge_evidence_links_for_drawer(&evidence.drawer_id)
+                .map_err(KnowledgeCardRetrievalError::LoadMetadata)?;
+            for link in links {
+                let Some(card) = db
+                    .get_knowledge_card(&link.card_id)
+                    .map_err(KnowledgeCardRetrievalError::LoadMetadata)?
+                else {
+                    continue;
+                };
+                if !card_is_retrievable(&card, &request, &anchor) {
+                    continue;
+                }
+                let citation =
+                    citation_from_link(&link, &evidence.source_file, evidence.similarity);
+                match by_card.get_mut(&card.id) {
+                    Some(existing) => {
+                        if citation.score > existing.score {
+                            existing.score = citation.score;
+                        }
+                        existing.evidence_citations.push(citation);
+                    }
+                    None => {
+                        by_card.insert(
+                            card.id.clone(),
+                            RetrievedKnowledgeCard {
+                                card,
+                                score: citation.score,
+                                evidence_citations: vec![citation],
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    let mut results = by_card.into_values().collect::<Vec<_>>();
+    results.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.card.id.cmp(&right.card.id))
+    });
+    results.truncate(request.top_k);
+    Ok(results)
+}
+
+fn retrieval_anchors(request: &KnowledgeCardRetrievalRequest) -> Result<Vec<AnchorCandidate>> {
+    let derived = anchor::derive_anchor_from_cwd(Some(&request.cwd))?;
+    let mut anchors = Vec::new();
+    anchors.push(AnchorCandidate {
+        anchor_kind: AnchorKind::Worktree,
+        anchor_id: derived.anchor_id,
+        domain: request.domain.clone(),
+    });
+
+    let repo_anchor_id = derived
+        .parent_anchor_id
+        .unwrap_or_else(|| anchor::LEGACY_REPO_ANCHOR_ID.to_string());
+    anchors.push(AnchorCandidate {
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: repo_anchor_id,
+        domain: request.domain.clone(),
+    });
+    anchors.push(AnchorCandidate {
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        domain: request.domain.clone(),
+    });
+    anchors.push(AnchorCandidate {
+        anchor_kind: AnchorKind::Global,
+        anchor_id: "global://default".to_string(),
+        domain: MemoryDomain::Global,
+    });
+
+    let mut seen = BTreeMap::new();
+    Ok(anchors
+        .into_iter()
+        .filter(|anchor| {
+            seen.insert(
+                (
+                    anchor_kind_slug(&anchor.anchor_kind).to_string(),
+                    anchor.anchor_id.clone(),
+                ),
+                (),
+            )
+            .is_none()
+        })
+        .collect())
+}
+
+fn card_is_retrievable(
+    card: &KnowledgeCard,
+    request: &KnowledgeCardRetrievalRequest,
+    anchor: &AnchorCandidate,
+) -> bool {
+    matches!(
+        card.status,
+        KnowledgeStatus::Canonical | KnowledgeStatus::Promoted
+    ) && card.domain == anchor.domain
+        && card.field == request.field
+        && card.anchor_kind == anchor.anchor_kind
+        && card.anchor_id == anchor.anchor_id
+}
+
+fn citation_from_link(
+    link: &KnowledgeEvidenceLink,
+    source_file: &str,
+    score: f32,
+) -> RetrievedEvidenceCitation {
+    RetrievedEvidenceCitation {
+        evidence_drawer_id: link.evidence_drawer_id.clone(),
+        role: link.role.clone(),
+        source_file: source_file.to_string(),
+        score,
+    }
+}
+
+fn memory_kind_slug(value: &MemoryKind) -> &'static str {
+    match value {
+        MemoryKind::Evidence => "evidence",
+        MemoryKind::Knowledge => "knowledge",
+    }
+}
+
+fn domain_slug(value: &MemoryDomain) -> &'static str {
+    match value {
+        MemoryDomain::Project => "project",
+        MemoryDomain::Agent => "agent",
+        MemoryDomain::Skill => "skill",
+        MemoryDomain::Global => "global",
+    }
+}
+
+fn anchor_kind_slug(value: &AnchorKind) -> &'static str {
+    match value {
+        AnchorKind::Global => "global",
+        AnchorKind::Repo => "repo",
+        AnchorKind::Worktree => "worktree",
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ingest;
 pub mod knowledge_anchor;
 pub mod knowledge_card_backfill;
 pub mod knowledge_card_lifecycle;
+pub mod knowledge_card_retrieval;
 pub mod knowledge_distill;
 pub mod knowledge_gate;
 pub mod knowledge_lifecycle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ use mempal::knowledge_card_lifecycle::{
     DemoteCardOutcome, DemoteCardRequest, KnowledgeCardGateReport, PromoteCardOutcome,
     PromoteCardRequest, demote_card, evaluate_card_gate_by_id, promote_card,
 };
+use mempal::knowledge_card_retrieval::{
+    KnowledgeCardRetrievalRequest, RetrievedKnowledgeCard, retrieve_knowledge_cards,
+};
 use mempal::knowledge_distill::{DistillPlan, DistillRequest, commit_distill, prepare_distill};
 use mempal::knowledge_gate::{
     GateReport, PromotionPolicyEntry, evaluate_gate_by_id, promotion_policy,
@@ -421,6 +424,21 @@ enum KnowledgeCardCommands {
         #[arg(long, default_value = "plain")]
         format: String,
     },
+    Retrieve {
+        query: String,
+        #[arg(long, default_value = "project")]
+        domain: String,
+        #[arg(long, default_value = "general")]
+        field: String,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+        #[arg(long = "top-k", default_value_t = 5)]
+        top_k: usize,
+        #[arg(long = "evidence-top-k", default_value_t = 20)]
+        evidence_top_k: usize,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     Link {
         card_id: String,
         evidence_drawer_id: String,
@@ -718,7 +736,7 @@ async fn run() -> Result<()> {
         } => reindex_command(&db, &config, stale, force, dry_run).await,
         Commands::Kg { command } => kg_command(&db, command),
         Commands::Knowledge { command } => knowledge_command(&db, &config, command).await,
-        Commands::KnowledgeCard { command } => knowledge_card_command(&db, command),
+        Commands::KnowledgeCard { command } => knowledge_card_command(&db, &config, command).await,
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::FieldTaxonomy { format } => field_taxonomy_command(&format),
@@ -1694,7 +1712,11 @@ async fn knowledge_command(
     Ok(())
 }
 
-fn knowledge_card_command(db: &Database, command: KnowledgeCardCommands) -> Result<()> {
+async fn knowledge_card_command(
+    db: &Database,
+    config: &Config,
+    command: KnowledgeCardCommands,
+) -> Result<()> {
     match command {
         KnowledgeCardCommands::Create {
             id,
@@ -1790,6 +1812,37 @@ fn knowledge_card_command(db: &Database, command: KnowledgeCardCommands) -> Resu
                 .list_knowledge_cards(&filter)
                 .context("failed to list knowledge cards")?;
             print_knowledge_cards(&cards, &format)?;
+        }
+        KnowledgeCardCommands::Retrieve {
+            query,
+            domain,
+            field,
+            cwd,
+            top_k,
+            evidence_top_k,
+            format,
+        } => {
+            if top_k == 0 {
+                bail!("--top-k must be greater than 0");
+            }
+            let domain = parse_domain(&domain)?;
+            let cwd = cwd.unwrap_or(env::current_dir().context("failed to read current dir")?);
+            let embedder = build_embedder(config).await?;
+            let results = retrieve_knowledge_cards(
+                db,
+                &*embedder,
+                KnowledgeCardRetrievalRequest {
+                    query,
+                    domain,
+                    field,
+                    cwd,
+                    top_k,
+                    evidence_top_k,
+                },
+            )
+            .await
+            .context("failed to retrieve knowledge cards")?;
+            print_retrieved_knowledge_cards(&results, &format)?;
         }
         KnowledgeCardCommands::Link {
             card_id,
@@ -2063,6 +2116,49 @@ fn print_knowledge_card(card: &KnowledgeCard, format: &str) -> Result<()> {
             Ok(())
         }
         other => bail!("unsupported knowledge-card format: {other}"),
+    }
+}
+
+fn print_retrieved_knowledge_cards(results: &[RetrievedKnowledgeCard], format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            if results.is_empty() {
+                println!("no retrieved knowledge cards");
+                return Ok(());
+            }
+            for result in results {
+                let card = &result.card;
+                println!(
+                    "{} score={:.6} tier={} status={} domain={} field={}",
+                    card.id,
+                    result.score,
+                    knowledge_tier_slug(&card.tier),
+                    knowledge_status_slug(&card.status),
+                    domain_slug(&card.domain),
+                    card.field
+                );
+                println!("statement: {}", card.statement);
+                for citation in &result.evidence_citations {
+                    println!(
+                        "evidence: {} role={} source={} score={:.6}",
+                        citation.evidence_drawer_id,
+                        knowledge_evidence_role_slug(&citation.role),
+                        citation.source_file,
+                        citation.score
+                    );
+                }
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(results)
+                    .context("failed to serialize retrieved knowledge cards")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported knowledge-card retrieve format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -31,6 +31,9 @@ use crate::knowledge_card_lifecycle::{
     DemoteCardRequest as CoreDemoteCardRequest, PromoteCardRequest as CorePromoteCardRequest,
     demote_card, evaluate_card_gate_by_id, promote_card,
 };
+use crate::knowledge_card_retrieval::{
+    KnowledgeCardRetrievalRequest as CoreCardRetrievalRequest, retrieve_knowledge_cards_with_vector,
+};
 use crate::knowledge_distill::{
     DistillPlan, DistillRequest as CoreDistillRequest, commit_distill, prepare_distill,
 };
@@ -58,9 +61,9 @@ use super::tools::{
     KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
-    ScopeCount, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
-    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
-    TunnelsRequest, TunnelsResponse,
+    RetrievedKnowledgeCardDto, ScopeCount, SearchRequest, SearchResponse, SearchResultDto,
+    StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto,
+    TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -860,7 +863,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_knowledge_cards",
-        description = "Phase-2 knowledge card inspection and governed lifecycle. Actions: list/get/events/gate/promote/demote. Gate is read-only; promote/demote require evidence refs and append knowledge_events transactionally."
+        description = "Phase-2 knowledge card inspection, linked-evidence retrieval, and governed lifecycle. Actions: list/get/retrieve/events/gate/promote/demote. Retrieve searches linked evidence and returns active cards with citations; promote/demote require evidence refs and append knowledge_events transactionally."
     )]
     async fn mempal_knowledge_cards(
         &self,
@@ -868,10 +871,10 @@ impl MempalMcpServer {
     ) -> std::result::Result<Json<KnowledgeCardsResponse>, ErrorData> {
         let action = trim_to_option(Some(request.action.as_str()))
             .ok_or_else(|| ErrorData::invalid_params("action must not be empty", None))?;
-        let db = self.open_db()?;
 
         match action {
             "list" => {
+                let db = self.open_db()?;
                 let filter = KnowledgeCardFilter {
                     tier: parse_tier(request.tier.as_deref())?,
                     status: parse_status(request.status.as_deref())?,
@@ -888,6 +891,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(KnowledgeCardsResponse {
                     cards: cards.into_iter().map(KnowledgeCardDto::from).collect(),
+                    retrieved: Vec::new(),
                     events: Vec::new(),
                     gate: None,
                     promote: None,
@@ -895,6 +899,7 @@ impl MempalMcpServer {
                 }))
             }
             "get" => {
+                let db = self.open_db()?;
                 let card_id = required_string(request.card_id.as_deref(), "card_id")?;
                 let card = db
                     .get_knowledge_card(card_id)
@@ -912,6 +917,72 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(KnowledgeCardsResponse {
                     cards: vec![KnowledgeCardDto::from(card)],
+                    retrieved: Vec::new(),
+                    events: Vec::new(),
+                    gate: None,
+                    promote: None,
+                    demote: None,
+                }))
+            }
+            "retrieve" => {
+                let query = required_string(request.query.as_deref(), "query")?.to_string();
+                let top_k = request.top_k.unwrap_or(5);
+                if top_k == 0 {
+                    return Err(ErrorData::invalid_params(
+                        "top_k must be greater than 0",
+                        None,
+                    ));
+                }
+                let domain =
+                    parse_domain(request.domain.as_deref())?.unwrap_or(MemoryDomain::Project);
+                let field = trim_to_owned(request.field.as_deref())
+                    .unwrap_or_else(|| "general".to_string());
+                let cwd = request
+                    .cwd
+                    .as_deref()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| {
+                        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+                    });
+                let embedder = self.embedder_factory.build().await.map_err(|error| {
+                    ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
+                })?;
+                let query_vector = embedder
+                    .embed(&[query.as_str()])
+                    .await
+                    .map_err(|error| {
+                        ErrorData::internal_error(format!("embedding failed: {error}"), None)
+                    })?
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| {
+                        ErrorData::internal_error("embedder returned no query vector", None)
+                    })?;
+                let db = self.open_db()?;
+                let retrieved = retrieve_knowledge_cards_with_vector(
+                    &db,
+                    CoreCardRetrievalRequest {
+                        query,
+                        domain,
+                        field,
+                        cwd,
+                        top_k,
+                        evidence_top_k: request.evidence_top_k.unwrap_or(top_k * 4),
+                    },
+                    &query_vector,
+                )
+                .map_err(|error| {
+                    ErrorData::internal_error(
+                        format!("failed to retrieve knowledge cards: {error}"),
+                        None,
+                    )
+                })?;
+                Ok(Json(KnowledgeCardsResponse {
+                    cards: Vec::new(),
+                    retrieved: retrieved
+                        .into_iter()
+                        .map(RetrievedKnowledgeCardDto::from)
+                        .collect(),
                     events: Vec::new(),
                     gate: None,
                     promote: None,
@@ -919,6 +990,7 @@ impl MempalMcpServer {
                 }))
             }
             "events" => {
+                let db = self.open_db()?;
                 let card_id = required_string(request.card_id.as_deref(), "card_id")?;
                 let events = db.knowledge_events(card_id).map_err(|error| {
                     ErrorData::internal_error(
@@ -928,6 +1000,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(KnowledgeCardsResponse {
                     cards: Vec::new(),
+                    retrieved: Vec::new(),
                     events: events
                         .into_iter()
                         .map(KnowledgeCardEventDto::from)
@@ -938,6 +1011,7 @@ impl MempalMcpServer {
                 }))
             }
             "gate" => {
+                let db = self.open_db()?;
                 let card_id = required_string(request.card_id.as_deref(), "card_id")?;
                 let report = evaluate_card_gate_by_id(
                     &db,
@@ -949,6 +1023,7 @@ impl MempalMcpServer {
                 .map_err(knowledge_card_lifecycle_error)?;
                 Ok(Json(KnowledgeCardsResponse {
                     cards: Vec::new(),
+                    retrieved: Vec::new(),
                     events: Vec::new(),
                     gate: Some(report.into()),
                     promote: None,
@@ -956,6 +1031,7 @@ impl MempalMcpServer {
                 }))
             }
             "promote" => {
+                let db = self.open_db()?;
                 let card_id = required_string(request.card_id.as_deref(), "card_id")?;
                 let status = required_string(request.status.as_deref(), "status")?.to_string();
                 let reason = required_string(request.reason.as_deref(), "reason")?.to_string();
@@ -975,6 +1051,7 @@ impl MempalMcpServer {
                 .map_err(knowledge_card_lifecycle_error)?;
                 Ok(Json(KnowledgeCardsResponse {
                     cards: Vec::new(),
+                    retrieved: Vec::new(),
                     events: Vec::new(),
                     gate: None,
                     promote: Some(outcome.into()),
@@ -982,6 +1059,7 @@ impl MempalMcpServer {
                 }))
             }
             "demote" => {
+                let db = self.open_db()?;
                 let card_id = required_string(request.card_id.as_deref(), "card_id")?;
                 let status = required_string(request.status.as_deref(), "status")?.to_string();
                 let reason = required_string(request.reason.as_deref(), "reason")?.to_string();
@@ -1001,6 +1079,7 @@ impl MempalMcpServer {
                 .map_err(knowledge_card_lifecycle_error)?;
                 Ok(Json(KnowledgeCardsResponse {
                     cards: Vec::new(),
+                    retrieved: Vec::new(),
                     events: Vec::new(),
                     gate: None,
                     promote: None,
@@ -1009,7 +1088,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported knowledge cards action: {other}; actions are list, get, events, gate, promote, demote"
+                    "unsupported knowledge cards action: {other}; actions are list, get, retrieve, events, gate, promote, demote"
                 ),
                 None,
             )),
@@ -3006,7 +3085,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("actions are list, get, events, gate, promote, demote")
+                .contains("actions are list, get, retrieve, events, gate, promote, demote")
         );
 
         let after = {
@@ -3122,8 +3201,9 @@ mod tests {
             .find(|tool| tool.name == "mempal_knowledge_cards")
             .expect("mempal_knowledge_cards tool exists");
         let description = tool.description.as_deref().unwrap_or_default();
-        assert!(description.contains("Phase-2 knowledge card inspection and governed lifecycle"));
-        assert!(description.contains("Actions: list/get/events/gate/promote/demote"));
+        assert!(description.contains("Phase-2 knowledge card inspection"));
+        assert!(description.contains("linked-evidence retrieval"));
+        assert!(description.contains("Actions: list/get/retrieve/events/gate/promote/demote"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_knowledge_cards"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("Phase-2 knowledge card"));
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -9,6 +9,7 @@ use crate::knowledge_anchor::PublishAnchorOutcome;
 use crate::knowledge_card_lifecycle::{
     DemoteCardOutcome, KnowledgeCardGateReport, PromoteCardOutcome,
 };
+use crate::knowledge_card_retrieval::{RetrievedEvidenceCitation, RetrievedKnowledgeCard};
 use crate::knowledge_distill::DistillOutcome;
 use crate::knowledge_gate::{GateReport, PromotionPolicyEntry};
 use crate::knowledge_lifecycle::{DemoteOutcome, PromoteOutcome};
@@ -269,6 +270,7 @@ pub struct KnowledgePolicyEntryDto {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct KnowledgeCardsRequest {
     pub action: String,
+    pub query: Option<String>,
     pub card_id: Option<String>,
     pub target_status: Option<String>,
     pub reviewer: Option<String>,
@@ -284,11 +286,16 @@ pub struct KnowledgeCardsRequest {
     pub field: Option<String>,
     pub anchor_kind: Option<String>,
     pub anchor_id: Option<String>,
+    pub cwd: Option<String>,
+    pub top_k: Option<usize>,
+    pub evidence_top_k: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct KnowledgeCardsResponse {
     pub cards: Vec<KnowledgeCardDto>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub retrieved: Vec<RetrievedKnowledgeCardDto>,
     pub events: Vec<KnowledgeCardEventDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gate: Option<KnowledgeCardGateDto>,
@@ -314,6 +321,21 @@ pub struct KnowledgeCardDto {
     pub trigger_hints: Option<TriggerHintsDto>,
     pub created_at: String,
     pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RetrievedKnowledgeCardDto {
+    pub card: KnowledgeCardDto,
+    pub evidence_citations: Vec<RetrievedEvidenceCitationDto>,
+    pub score: f32,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RetrievedEvidenceCitationDto {
+    pub evidence_drawer_id: String,
+    pub role: String,
+    pub source_file: String,
+    pub score: f32,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -1004,6 +1026,31 @@ impl From<KnowledgeCard> for KnowledgeCardDto {
             trigger_hints: value.trigger_hints.map(TriggerHintsDto::from),
             created_at: value.created_at,
             updated_at: value.updated_at,
+        }
+    }
+}
+
+impl From<RetrievedKnowledgeCard> for RetrievedKnowledgeCardDto {
+    fn from(value: RetrievedKnowledgeCard) -> Self {
+        Self {
+            card: KnowledgeCardDto::from(value.card),
+            evidence_citations: value
+                .evidence_citations
+                .into_iter()
+                .map(RetrievedEvidenceCitationDto::from)
+                .collect(),
+            score: value.score,
+        }
+    }
+}
+
+impl From<RetrievedEvidenceCitation> for RetrievedEvidenceCitationDto {
+    fn from(value: RetrievedEvidenceCitation) -> Self {
+        Self {
+            evidence_drawer_id: value.evidence_drawer_id,
+            role: knowledge_evidence_role_slug(&value.role).to_string(),
+            source_file: value.source_file,
+            score: value.score,
         }
     }
 }

--- a/tests/knowledge_card_retrieval.rs
+++ b/tests/knowledge_card_retrieval.rs
@@ -1,0 +1,451 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use std::thread;
+
+use async_trait::async_trait;
+use mempal::core::anchor;
+use mempal::core::db::Database;
+use mempal::core::types::{
+    AnchorKind, Drawer, KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+    KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, SourceType,
+};
+use mempal::embed::{Embedder, EmbedderFactory};
+use mempal::knowledge_card_retrieval::{KnowledgeCardRetrievalRequest, retrieve_knowledge_cards};
+use mempal::mcp::MempalMcpServer;
+use mempal::search::{SearchOptions, search_with_options};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+struct StubEmbedder {
+    vector: Vec<f32>,
+}
+
+#[derive(Clone)]
+struct StubEmbedderFactory {
+    vector: Vec<f32>,
+}
+
+#[async_trait]
+impl Embedder for StubEmbedder {
+    async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| self.vector.clone()).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "stub"
+    }
+}
+
+#[async_trait]
+impl EmbedderFactory for StubEmbedderFactory {
+    async fn build(&self) -> mempal::embed::Result<Box<dyn Embedder>> {
+        Ok(Box::new(StubEmbedder {
+            vector: self.vector.clone(),
+        }))
+    }
+}
+
+fn vector() -> Vec<f32> {
+    vec![0.25; 384]
+}
+
+fn embedder() -> StubEmbedder {
+    StubEmbedder { vector: vector() }
+}
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_db() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    (tmp, db)
+}
+
+fn setup_cli_home() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_dir = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_dir).expect("create .mempal");
+    let db = Database::open(&mempal_dir.join("palace.db")).expect("open cli db");
+    (tmp, db)
+}
+
+fn evidence_drawer(id: &str, content: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("retrieval".to_string()),
+        source_file: Some(format!("tests://retrieval/{id}.md")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 3,
+        memory_kind: MemoryKind::Evidence,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        provenance: Some(Provenance::Human),
+        statement: None,
+        tier: None,
+        status: None,
+        supporting_refs: Vec::new(),
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn card(id: &str, status: KnowledgeStatus, statement: &str) -> KnowledgeCard {
+    KnowledgeCard {
+        id: id.to_string(),
+        statement: statement.to_string(),
+        content: format!("Card content for {id}."),
+        tier: KnowledgeTier::Shu,
+        status,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        scope_constraints: None,
+        trigger_hints: None,
+        created_at: "1710000000".to_string(),
+        updated_at: "1710000000".to_string(),
+    }
+}
+
+fn insert_evidence(db: &Database, drawer: &Drawer) {
+    db.insert_drawer(drawer).expect("insert drawer");
+    db.insert_vector(&drawer.id, &vector())
+        .expect("insert vector");
+}
+
+fn insert_card(db: &Database, card: &KnowledgeCard) {
+    db.insert_knowledge_card(card).expect("insert card");
+}
+
+fn insert_link(db: &Database, id: &str, card_id: &str, evidence_drawer_id: &str) {
+    db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+        id: id.to_string(),
+        card_id: card_id.to_string(),
+        evidence_drawer_id: evidence_drawer_id.to_string(),
+        role: KnowledgeEvidenceRole::Supporting,
+        note: None,
+        created_at: "1710000000".to_string(),
+    })
+    .expect("insert link");
+}
+
+fn request(query: &str, cwd: &Path) -> KnowledgeCardRetrievalRequest {
+    KnowledgeCardRetrievalRequest {
+        query: query.to_string(),
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        cwd: cwd.to_path_buf(),
+        top_k: 5,
+        evidence_top_k: 10,
+    }
+}
+
+fn start_openai_embedding_stub(
+    expected_query: &str,
+    vector: Vec<f32>,
+) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding stub");
+    listener
+        .set_nonblocking(true)
+        .expect("set embedding stub nonblocking");
+    let address = listener.local_addr().expect("local addr");
+    let expected_query = expected_query.to_string();
+
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = (0..50)
+            .find_map(|_| match listener.accept() {
+                Ok(pair) => Some(pair),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(std::time::Duration::from_millis(20));
+                    None
+                }
+                Err(error) => panic!("embedding stub accept failed: {error}"),
+            })
+            .expect("embedding stub timed out waiting for request");
+        let mut request = [0_u8; 8192];
+        let bytes_read = stream.read(&mut request).expect("read embedding request");
+        let request_text = String::from_utf8_lossy(&request[..bytes_read]);
+        let body = request_text
+            .split("\r\n\r\n")
+            .nth(1)
+            .expect("embedding request body");
+        let payload: Value = serde_json::from_str(body).expect("parse embedding request body");
+        assert_eq!(payload["input"], json!([expected_query]));
+        let response_body = json!({
+            "data": [{ "embedding": vector }]
+        })
+        .to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write embedding response");
+    });
+
+    (format!("http://{address}/v1/embeddings"), handle)
+}
+
+fn write_cli_api_config(home: &Path, endpoint: &str) {
+    fs::write(
+        home.join(".mempal").join("config.toml"),
+        format!(
+            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+        ),
+    )
+    .expect("write cli config");
+}
+
+fn run_cli_retrieve_json(home: &Path, query: &str) -> Value {
+    let (endpoint, handle) = start_openai_embedding_stub(query, vector());
+    write_cli_api_config(home, &endpoint);
+    let output = Command::new(mempal_bin())
+        .args([
+            "knowledge-card",
+            "retrieve",
+            query,
+            "--format",
+            "json",
+            "--top-k",
+            "5",
+        ])
+        .env("HOME", home)
+        .output()
+        .expect("run retrieve");
+    assert!(
+        output.status.success(),
+        "retrieve command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    handle.join().expect("join embedding stub");
+    serde_json::from_slice(&output.stdout).expect("parse retrieve json")
+}
+
+#[test]
+fn test_cli_knowledge_card_retrieve_rejects_zero_top_k() {
+    let (tmp, _db) = setup_cli_home();
+    let output = Command::new(mempal_bin())
+        .args([
+            "knowledge-card",
+            "retrieve",
+            "alpha",
+            "--top-k",
+            "0",
+            "--format",
+            "json",
+        ])
+        .env("HOME", tmp.path())
+        .output()
+        .expect("run retrieve");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--top-k must be greater than 0"));
+}
+
+#[tokio::test]
+async fn test_cli_knowledge_card_retrieve_json_returns_active_card() {
+    let (tmp, db) = setup_cli_home();
+    insert_evidence(
+        &db,
+        &evidence_drawer(
+            "drawer_ev_active",
+            "alpha evidence supports a reusable method",
+        ),
+    );
+    insert_card(
+        &db,
+        &card(
+            "card_active",
+            KnowledgeStatus::Promoted,
+            "Alpha method should be reused.",
+        ),
+    );
+    insert_link(&db, "link_active", "card_active", "drawer_ev_active");
+
+    let value = run_cli_retrieve_json(tmp.path(), "alpha evidence");
+    assert_eq!(value[0]["card"]["id"], "card_active");
+    assert_eq!(
+        value[0]["evidence_citations"][0]["evidence_drawer_id"],
+        "drawer_ev_active"
+    );
+    assert_eq!(value[0]["evidence_citations"][0]["role"], "supporting");
+    assert_eq!(
+        value[0]["evidence_citations"][0]["source_file"],
+        "tests://retrieval/drawer_ev_active.md"
+    );
+    assert!(value[0]["evidence_citations"][0]["score"].is_number());
+}
+
+#[tokio::test]
+async fn test_card_retrieve_excludes_candidate_cards() {
+    let (tmp, db) = setup_db();
+    insert_evidence(&db, &evidence_drawer("drawer_ev", "alpha evidence"));
+    insert_card(
+        &db,
+        &card("card_promoted", KnowledgeStatus::Promoted, "Promoted card."),
+    );
+    insert_card(
+        &db,
+        &card(
+            "card_candidate",
+            KnowledgeStatus::Candidate,
+            "Candidate card.",
+        ),
+    );
+    insert_link(&db, "link_promoted", "card_promoted", "drawer_ev");
+    insert_link(&db, "link_candidate", "card_candidate", "drawer_ev");
+
+    let results = retrieve_knowledge_cards(&db, &embedder(), request("alpha", tmp.path()))
+        .await
+        .expect("retrieve cards");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].card.id, "card_promoted");
+}
+
+#[tokio::test]
+async fn test_mcp_knowledge_cards_retrieve_action() {
+    let (tmp, db) = setup_db();
+    let db_path = tmp.path().join("palace.db");
+    drop(db);
+    let db = Database::open(&db_path).expect("reopen db");
+    insert_evidence(&db, &evidence_drawer("drawer_ev_mcp", "alpha mcp evidence"));
+    insert_card(
+        &db,
+        &card(
+            "card_mcp",
+            KnowledgeStatus::Canonical,
+            "MCP card retrieval works.",
+        ),
+    );
+    insert_link(&db, "link_mcp", "card_mcp", "drawer_ev_mcp");
+    let server = MempalMcpServer::new_with_factory(
+        db_path,
+        Arc::new(StubEmbedderFactory { vector: vector() }),
+    );
+
+    let response = server
+        .knowledge_cards_json_for_test(json!({
+            "action": "retrieve",
+            "query": "alpha mcp",
+            "top_k": 3,
+            "cwd": tmp.path().to_string_lossy()
+        }))
+        .await
+        .expect("mcp retrieve");
+
+    assert_eq!(response.retrieved.len(), 1);
+    assert_eq!(response.retrieved[0].card.id, "card_mcp");
+    assert_eq!(
+        response.retrieved[0].evidence_citations[0].evidence_drawer_id,
+        "drawer_ev_mcp"
+    );
+}
+
+#[tokio::test]
+async fn test_card_retrieve_has_no_db_side_effects() {
+    let (tmp, db) = setup_db();
+    insert_evidence(&db, &evidence_drawer("drawer_ev_side", "alpha evidence"));
+    insert_card(
+        &db,
+        &card("card_side", KnowledgeStatus::Promoted, "Side effect card."),
+    );
+    insert_link(&db, "link_side", "card_side", "drawer_ev_side");
+    let drawer_count = db.drawer_count().expect("drawer count");
+    let card_count = db.knowledge_card_count().expect("card count");
+    let link_count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM knowledge_evidence_links", [], |row| {
+            row.get(0)
+        })
+        .expect("link count");
+    let event_count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM knowledge_events", [], |row| {
+            row.get(0)
+        })
+        .expect("event count");
+
+    let _results = retrieve_knowledge_cards(&db, &embedder(), request("alpha", tmp.path()))
+        .await
+        .expect("retrieve cards");
+
+    assert_eq!(db.drawer_count().expect("drawer count"), drawer_count);
+    assert_eq!(db.knowledge_card_count().expect("card count"), card_count);
+    let after_link_count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM knowledge_evidence_links", [], |row| {
+            row.get(0)
+        })
+        .expect("link count");
+    let after_event_count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM knowledge_events", [], |row| {
+            row.get(0)
+        })
+        .expect("event count");
+    assert_eq!(after_link_count, link_count);
+    assert_eq!(after_event_count, event_count);
+}
+
+#[tokio::test]
+async fn test_card_retrieve_does_not_change_mempal_search() {
+    let (_tmp, db) = setup_db();
+    insert_evidence(&db, &evidence_drawer("drawer_ev_search", "alpha evidence"));
+    insert_card(
+        &db,
+        &card(
+            "card_search",
+            KnowledgeStatus::Promoted,
+            "Search boundary card.",
+        ),
+    );
+    insert_link(&db, "link_search", "card_search", "drawer_ev_search");
+
+    let results = search_with_options(
+        &db,
+        &embedder(),
+        "alpha",
+        Some("mempal"),
+        Some("retrieval"),
+        SearchOptions::default(),
+        5,
+    )
+    .await
+    .expect("search");
+
+    assert!(
+        results
+            .iter()
+            .any(|result| result.drawer_id == "drawer_ev_search")
+    );
+    assert!(
+        results
+            .iter()
+            .all(|result| result.drawer_id != "card_search")
+    );
+}


### PR DESCRIPTION
## Summary

- Add P45 spec and plan for linked-evidence-first card retrieval.
- Add core `knowledge_card_retrieval` path that searches evidence drawers, follows `knowledge_evidence_links`, and returns active cards.
- Add CLI `mempal knowledge-card retrieve <query>`.
- Add MCP `mempal_knowledge_cards` action `retrieve`.
- Keep `mempal_search` drawer-only and avoid card embedding storage.

## Verification

- `agent-spec parse specs/p45-card-linked-evidence-retrieval.spec.md`
- `agent-spec lint specs/p45-card-linked-evidence-retrieval.spec.md --min-score 0.7`
- `cargo fmt`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --test knowledge_card_retrieval`
- `cargo test`
