### PR TITLE
docs: define card context default policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p43-knowledge-card-retrieval-contract.spec.md` | 完成 | Phase-2 card retrieval contract：定义 card result + evidence citation 形状，不改默认 runtime 行为 |
 | `specs/p44-card-context-assembler.spec.md` | 完成 | `mempal context` / `mempal_context` 显式 `include_cards`：按 P43 contract 注入 active cards + evidence citations |
 | `specs/p45-card-linked-evidence-retrieval.spec.md` | 完成 | `mempal knowledge-card retrieve` / `mempal_knowledge_cards action=retrieve`：通过 linked evidence 检索 active cards，不改默认 search |
+| `specs/p46-card-context-default-policy.spec.md` | 完成 | P46 card context default policy：card-aware context 继续 opt-in；未来默认启用必须有 runtime evidence 和 rollback criteria |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -142,6 +143,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md` — P43 knowledge card retrieval contract（已完成）
 - `docs/plans/2026-04-28-p44-card-context-assembler.md` — P44 card-aware context assembler（已完成）
 - `docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md` — P45 card linked-evidence retrieval（已完成）
+- `docs/plans/2026-04-28-p46-card-context-default-policy.md` — P46 card context default policy（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p43-knowledge-card-retrieval-contract.spec.md` | 完成 | Phase-2 card retrieval contract：定义 card result + evidence citation 形状，不改默认 runtime 行为 |
 | `specs/p44-card-context-assembler.spec.md` | 完成 | `mempal context` / `mempal_context` 显式 `include_cards`：按 P43 contract 注入 active cards + evidence citations |
 | `specs/p45-card-linked-evidence-retrieval.spec.md` | 完成 | `mempal knowledge-card retrieve` / `mempal_knowledge_cards action=retrieve`：通过 linked evidence 检索 active cards，不改默认 search |
+| `specs/p46-card-context-default-policy.spec.md` | 完成 | P46 card context default policy：card-aware context 继续 opt-in；未来默认启用必须有 runtime evidence 和 rollback criteria |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -140,6 +141,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p43-knowledge-card-retrieval-contract.md` — P43 knowledge card retrieval contract（已完成）
 - `docs/plans/2026-04-28-p44-card-context-assembler.md` — P44 card-aware context assembler（已完成）
 - `docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md` — P45 card linked-evidence retrieval（已完成）
+- `docs/plans/2026-04-28-p46-card-context-default-policy.md` — P46 card context default policy（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1038,6 +1038,30 @@ citations with `evidence_drawer_id`, `role`, `source_file`, and score.
 P45 intentionally does not add card embeddings, does not add card vector
 storage, and does not make `mempal_search` return cards.
 
+P46 keeps card-aware context opt-in. The default context remains drawer-only for
+both `mempal context` and `mempal_context`; operators must still pass
+`--include-cards` or `include_cards=true` to inject Phase-2 cards into the
+typed context pack.
+
+This is a deliberate default policy, not an unfinished implementation gap.
+Cards are now retrievable and context-injectable, but default runtime context is
+a high-trust path. It should not silently switch from drawer-backed active
+knowledge to mixed drawer/card guidance until real runtime evidence shows the
+change improves agent behavior without weakening citations.
+
+Evidence required before default enablement:
+
+- repeated runtime traces where card-aware context causes better skill/tool
+  selection than drawer-only context
+- no observed citation loss: every default card item must preserve linked
+  evidence citations as the citation root
+- no material context bloat: card items must not crowd out higher-priority
+  `dao_tian`, `dao_ren`, `shu`, or `qi` guidance
+- no lifecycle confusion: inactive cards must remain excluded and demoted cards
+  must not re-enter default context through linked evidence
+- explicit rollback criteria: a future default-on spec must define how to return
+  to drawer-only defaults if card injection degrades runtime behavior
+
 ## Decision on Bootstrap vs Final Architecture
 
 Current recommendation:
@@ -1100,8 +1124,6 @@ Proceed with the following assumptions unless future evidence rejects them:
 
 The remaining work is intentionally explicit:
 
-- decide whether card-aware context should eventually become default after more
-  runtime evidence
 - decide whether a later retrieval phase needs card-level embeddings in addition
   to P45 linked-evidence retrieval
 - decide whether Phase-2 card lifecycle should write JSONL audit entries in

--- a/docs/plans/2026-04-28-p46-card-context-default-policy.md
+++ b/docs/plans/2026-04-28-p46-card-context-default-policy.md
@@ -1,0 +1,24 @@
+# P46 Card Context Default Policy Plan
+
+**Goal:** Resolve the next MIND-MODEL future-work item by keeping card-aware
+context opt-in and defining the evidence required before any future default
+enablement.
+
+## Checklist
+
+- [x] Add P46 task contract.
+- [x] Update MIND-MODEL with the default-context policy and future evidence gate.
+- [x] Update AGENTS/CLAUDE inventories.
+- [x] Run spec lint and docs-only verification.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p46-card-context-default-policy.spec.md
+agent-spec lint specs/p46-card-context-default-policy.spec.md --min-score 0.7
+rg -n "P46 keeps card-aware context opt-in|default context remains drawer-only" docs/MIND-MODEL-DESIGN.md
+rg -n "Evidence required before default enablement|rollback criteria|context bloat" docs/MIND-MODEL-DESIGN.md
+rg -n "p46-card-context-default-policy|P46 card context default policy" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/specs/p46-card-context-default-policy.spec.md
+++ b/specs/p46-card-context-default-policy.spec.md
@@ -1,0 +1,82 @@
+spec: task
+name: "P46: card context default policy"
+inherits: project
+tags: [mind-model, knowledge-card, runtime-policy]
+---
+
+## Intent
+
+P44 made card-aware context available as an explicit opt-in and P45 added
+linked-evidence card retrieval. P46 resolves the next MIND-MODEL decision point:
+card-aware context must not become default yet; future default enablement requires
+explicit runtime evidence and a separate implementation spec.
+
+## Decisions
+
+- Keep `mempal context` default drawer-only.
+- Keep `mempal_context` default `include_cards=false`.
+- Card-aware context remains opt-in through `--include-cards` or `include_cards=true`.
+- Future default enablement requires evidence that cards improve runtime behavior without citation loss or context bloat.
+- Default enablement must be a separate spec and must include rollback criteria.
+- P46 is policy-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p46-card-context-default-policy.spec.md
+- docs/plans/2026-04-28-p46-card-context-default-policy.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not change CLI or MCP defaults.
+- Do not change `mempal_search`.
+- Do not add migrations or schema changes.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records the default-context decision
+  Test:
+    Filter: rg -n "P46 keeps card-aware context opt-in|default context remains drawer-only" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the Phase-2 card retrieval/runtime section
+  Then it states that P46 keeps card-aware context opt-in
+  And it states that default context remains drawer-only
+
+Scenario: MIND-MODEL defines future default evidence requirements
+  Test:
+    Filter: rg -n "Evidence required before default enablement|rollback criteria|context bloat" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the future default policy
+  Then it lists evidence required before default enablement
+  And it mentions rollback criteria
+
+Scenario: Inventories include P46
+  Test:
+    Filter: rg -n "p46-card-context-default-policy|P46 card context default policy" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P46
+  Then both AGENTS.md and CLAUDE.md include the P46 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+  Given the P46 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+Scenario: Explicit opt-in language remains present
+  Test:
+    Filter: rg -n "include_cards=true|--include-cards|opt-in" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the card-aware context section
+  Then explicit opt-in language remains present
+
+## Out of Scope
+
+- Changing `mempal context` or `mempal_context` defaults.
+- Adding telemetry or evaluator scoring.
+- Adding card embeddings.
+- Returning cards from `mempal_search`.


### PR DESCRIPTION
## Summary

- Add P46 policy spec and plan for card-aware context defaults.
- Keep `mempal context` and `mempal_context` drawer-only by default.
- Define evidence required before any future default-on card context change.
- Require rollback criteria for a future default enablement spec.
- Update MIND-MODEL and agent inventories.

## Verification

- `agent-spec parse specs/p46-card-context-default-policy.spec.md`
- `agent-spec lint specs/p46-card-context-default-policy.spec.md --min-score 0.7`
- `rg -n "P46 keeps card-aware context opt-in|default context remains drawer-only" docs/MIND-MODEL-DESIGN.md`
- `rg -n "Evidence required before default enablement|rollback criteria|context bloat" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p46-card-context-default-policy|P46 card context default policy" AGENTS.md CLAUDE.md`
- `git diff --name-only main...HEAD`
- `git diff --check`
