### PR TITLE
docs: define card embedding policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p44-card-context-assembler.spec.md` | 完成 | `mempal context` / `mempal_context` 显式 `include_cards`：按 P43 contract 注入 active cards + evidence citations |
 | `specs/p45-card-linked-evidence-retrieval.spec.md` | 完成 | `mempal knowledge-card retrieve` / `mempal_knowledge_cards action=retrieve`：通过 linked evidence 检索 active cards，不改默认 search |
 | `specs/p46-card-context-default-policy.spec.md` | 完成 | P46 card context default policy：card-aware context 继续 opt-in；未来默认启用必须有 runtime evidence 和 rollback criteria |
+| `specs/p47-card-embedding-policy.spec.md` | 完成 | P47 card embedding policy：暂不加 card-level embeddings；未来实现必须证明 statement-match misses、处理 stale vectors 和 rollback |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -144,6 +145,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p44-card-context-assembler.md` — P44 card-aware context assembler（已完成）
 - `docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md` — P45 card linked-evidence retrieval（已完成）
 - `docs/plans/2026-04-28-p46-card-context-default-policy.md` — P46 card context default policy（已完成）
+- `docs/plans/2026-04-28-p47-card-embedding-policy.md` — P47 card embedding policy（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p44-card-context-assembler.spec.md` | 完成 | `mempal context` / `mempal_context` 显式 `include_cards`：按 P43 contract 注入 active cards + evidence citations |
 | `specs/p45-card-linked-evidence-retrieval.spec.md` | 完成 | `mempal knowledge-card retrieve` / `mempal_knowledge_cards action=retrieve`：通过 linked evidence 检索 active cards，不改默认 search |
 | `specs/p46-card-context-default-policy.spec.md` | 完成 | P46 card context default policy：card-aware context 继续 opt-in；未来默认启用必须有 runtime evidence 和 rollback criteria |
+| `specs/p47-card-embedding-policy.spec.md` | 完成 | P47 card embedding policy：暂不加 card-level embeddings；未来实现必须证明 statement-match misses、处理 stale vectors 和 rollback |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -142,6 +143,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p44-card-context-assembler.md` — P44 card-aware context assembler（已完成）
 - `docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md` — P45 card linked-evidence retrieval（已完成）
 - `docs/plans/2026-04-28-p46-card-context-default-policy.md` — P46 card context default policy（已完成）
+- `docs/plans/2026-04-28-p47-card-embedding-policy.md` — P47 card embedding policy（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1062,6 +1062,30 @@ Evidence required before default enablement:
 - explicit rollback criteria: a future default-on spec must define how to return
   to drawer-only defaults if card injection degrades runtime behavior
 
+P47 keeps card-level embeddings deferred. P45 linked-evidence retrieval remains
+the only implemented card retrieval strategy: cards are found through matched
+evidence drawers, not through a separate card vector index.
+
+This keeps the citation model simple. Card statements are distilled beliefs;
+evidence drawers remain the source-backed material. A card embedding index would
+make card statements directly retrievable, which may improve recall, but it also
+adds a new stale-vector surface and can make unsupported belief text feel like a
+primary source unless every result still carries linked evidence citations.
+
+Evidence required before card embeddings:
+
+- statement-match misses: repeated retrieval traces where linked-evidence search
+  misses useful active cards because evidence wording does not match the query
+  but the card statement does
+- citation preservation: card-embedding results must still return linked
+  evidence citations as the citation root
+- measurable recall improvement over P45 linked-evidence retrieval without
+  unacceptable precision loss
+- schema and maintenance plan for card vector storage, reindexing, and
+  stale-vector handling
+- rollback behavior that can disable card-vector retrieval and fall back to P45
+  linked-evidence retrieval without data loss
+
 ## Decision on Bootstrap vs Final Architecture
 
 Current recommendation:
@@ -1124,8 +1148,6 @@ Proceed with the following assumptions unless future evidence rejects them:
 
 The remaining work is intentionally explicit:
 
-- decide whether a later retrieval phase needs card-level embeddings in addition
-  to P45 linked-evidence retrieval
 - decide whether Phase-2 card lifecycle should write JSONL audit entries in
   addition to append-only `knowledge_events`
 - integrate external `research-rs` outputs as evidence/candidate insights

--- a/docs/plans/2026-04-28-p47-card-embedding-policy.md
+++ b/docs/plans/2026-04-28-p47-card-embedding-policy.md
@@ -1,0 +1,25 @@
+# P47 Card Embedding Policy Plan
+
+**Goal:** Resolve the card embedding future-work item by keeping card-level
+embeddings deferred and defining the evidence/schema requirements for any later
+implementation.
+
+## Checklist
+
+- [x] Add P47 task contract.
+- [x] Update MIND-MODEL with the card embedding deferral policy.
+- [x] Update AGENTS/CLAUDE inventories.
+- [x] Run spec lint and docs-only verification.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p47-card-embedding-policy.spec.md
+agent-spec lint specs/p47-card-embedding-policy.spec.md --min-score 0.7
+rg -n "P47 keeps card-level embeddings deferred|linked-evidence retrieval remains the only implemented card retrieval strategy" docs/MIND-MODEL-DESIGN.md
+rg -n "Evidence required before card embeddings|statement-match misses|stale-vector handling|rollback behavior" docs/MIND-MODEL-DESIGN.md
+rg -n "p47-card-embedding-policy|P47 card embedding policy" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+! rg -n "knowledge_card_vectors|card vector|card_vectors" src
+git diff --check
+```

--- a/specs/p47-card-embedding-policy.spec.md
+++ b/specs/p47-card-embedding-policy.spec.md
@@ -1,0 +1,81 @@
+spec: task
+name: "P47: card embedding policy"
+inherits: project
+tags: [mind-model, knowledge-card, retrieval-policy]
+---
+
+## Intent
+
+P45 implemented linked-evidence-first card retrieval. P47 resolves the remaining
+card embedding question: do not add card-level embeddings yet; define the evidence
+and schema constraints required before a later implementation may introduce them.
+
+## Decisions
+
+- Keep P45 linked-evidence retrieval as the only implemented card retrieval strategy for now.
+- Do not add `knowledge_card_vectors`, card vector writes, card reindexing, or card embedding ranking in P47.
+- Card embeddings are only justified if linked-evidence retrieval misses useful cards because the evidence wording does not match the user query but the card statement does.
+- Any future card embedding implementation must preserve linked evidence citations as the citation root.
+- Any future card embedding implementation must define schema migration, reindex behavior, stale-vector handling, and rollback behavior.
+- P47 is policy-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p47-card-embedding-policy.spec.md
+- docs/plans/2026-04-28-p47-card-embedding-policy.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not add migrations or schema changes.
+- Do not add card vector tables.
+- Do not change `mempal_search`, `mempal_context`, or `mempal_knowledge_cards` behavior.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records no-card-embedding decision
+  Test:
+    Filter: rg -n "P47 keeps card-level embeddings deferred|linked-evidence retrieval remains the only implemented card retrieval strategy" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the Phase-2 card retrieval policy
+  Then it states that P47 defers card-level embeddings
+  And it states that linked-evidence retrieval remains the implemented strategy
+
+Scenario: MIND-MODEL defines evidence required for future card embeddings
+  Test:
+    Filter: rg -n "Evidence required before card embeddings|statement-match misses|stale-vector handling|rollback behavior" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the card embedding policy
+  Then it lists evidence required before card embeddings
+  And it mentions stale-vector handling and rollback behavior
+
+Scenario: Inventories include P47
+  Test:
+    Filter: rg -n "p47-card-embedding-policy|P47 card embedding policy" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P47
+  Then both AGENTS.md and CLAUDE.md include the P47 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+  Given the P47 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+Scenario: Vector schema remains absent
+  Test:
+    Filter: "! rg -n \"knowledge_card_vectors|card vector|card_vectors\" src"
+  Given the P47 branch
+  When searching runtime source
+  Then no card vector schema or runtime implementation exists
+
+## Out of Scope
+
+- Card embedding implementation.
+- Card vector table migration.
+- Card reindex command.
+- Hybrid card embedding plus linked-evidence ranking.


### PR DESCRIPTION
## Summary

- Add P47 policy spec and plan for card embeddings.
- Keep P45 linked-evidence retrieval as the only implemented card retrieval strategy.
- Defer card-level embeddings until statement-match misses justify the added schema/vector surface.
- Define future requirements: citation preservation, recall improvement, stale-vector handling, reindexing, and rollback behavior.
- Update MIND-MODEL and agent inventories.

## Verification

- `agent-spec parse specs/p47-card-embedding-policy.spec.md`
- `agent-spec lint specs/p47-card-embedding-policy.spec.md --min-score 0.7`
- `rg -n "P47 keeps card-level embeddings deferred|linked-evidence retrieval remains the only implemented card retrieval strategy" docs/MIND-MODEL-DESIGN.md`
- `rg -n "Evidence required before card embeddings|statement-match misses|stale-vector handling|rollback behavior" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p47-card-embedding-policy|P47 card embedding policy" AGENTS.md CLAUDE.md`
- `git diff --name-only main...HEAD`
- `! rg -n "knowledge_card_vectors|card vector|card_vectors" src`
- `git diff --check`
