### PR TITLE
docs: define card audit policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p45-card-linked-evidence-retrieval.spec.md` | 完成 | `mempal knowledge-card retrieve` / `mempal_knowledge_cards action=retrieve`：通过 linked evidence 检索 active cards，不改默认 search |
 | `specs/p46-card-context-default-policy.spec.md` | 完成 | P46 card context default policy：card-aware context 继续 opt-in；未来默认启用必须有 runtime evidence 和 rollback criteria |
 | `specs/p47-card-embedding-policy.spec.md` | 完成 | P47 card embedding policy：暂不加 card-level embeddings；未来实现必须证明 statement-match misses、处理 stale vectors 和 rollback |
+| `specs/p48-card-audit-policy.spec.md` | 完成 | P48 card audit policy：`knowledge_events` 是 Phase-2 card lifecycle 权威审计；不默认双写 JSONL |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -146,6 +147,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md` — P45 card linked-evidence retrieval（已完成）
 - `docs/plans/2026-04-28-p46-card-context-default-policy.md` — P46 card context default policy（已完成）
 - `docs/plans/2026-04-28-p47-card-embedding-policy.md` — P47 card embedding policy（已完成）
+- `docs/plans/2026-04-29-p48-card-audit-policy.md` — P48 card audit policy（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p45-card-linked-evidence-retrieval.spec.md` | 完成 | `mempal knowledge-card retrieve` / `mempal_knowledge_cards action=retrieve`：通过 linked evidence 检索 active cards，不改默认 search |
 | `specs/p46-card-context-default-policy.spec.md` | 完成 | P46 card context default policy：card-aware context 继续 opt-in；未来默认启用必须有 runtime evidence 和 rollback criteria |
 | `specs/p47-card-embedding-policy.spec.md` | 完成 | P47 card embedding policy：暂不加 card-level embeddings；未来实现必须证明 statement-match misses、处理 stale vectors 和 rollback |
+| `specs/p48-card-audit-policy.spec.md` | 完成 | P48 card audit policy：`knowledge_events` 是 Phase-2 card lifecycle 权威审计；不默认双写 JSONL |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -144,6 +145,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p45-card-linked-evidence-retrieval.md` — P45 card linked-evidence retrieval（已完成）
 - `docs/plans/2026-04-28-p46-card-context-default-policy.md` — P46 card context default policy（已完成）
 - `docs/plans/2026-04-28-p47-card-embedding-policy.md` — P47 card embedding policy（已完成）
+- `docs/plans/2026-04-29-p48-card-audit-policy.md` — P48 card audit policy（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1086,6 +1086,21 @@ Evidence required before card embeddings:
 - rollback behavior that can disable card-vector retrieval and fall back to P45
   linked-evidence retrieval without data loss
 
+P48 keeps `knowledge_events` as the authoritative Phase-2 card audit trail, with
+no default JSONL dual-write for card lifecycle mutations. This keeps card
+promote/demote/backfill behavior transactionally bound to the same SQLite
+database that owns `knowledge_cards` and `knowledge_evidence_links`.
+
+Stage-1 drawer lifecycle continues to use `audit.jsonl` where already defined.
+Phase-2 card lifecycle does not mirror those entries into `audit.jsonl` by
+default because that would create two audit surfaces with different durability
+and transaction semantics. The append-only `knowledge_events` table is the
+source of truth for card lifecycle history.
+
+If an external integration needs JSONL card history, it should be added as an
+explicit export surface. JSONL export must be derived from `knowledge_events`,
+must be reproducible, and must not become a second source of truth.
+
 ## Decision on Bootstrap vs Final Architecture
 
 Current recommendation:
@@ -1148,8 +1163,6 @@ Proceed with the following assumptions unless future evidence rejects them:
 
 The remaining work is intentionally explicit:
 
-- decide whether Phase-2 card lifecycle should write JSONL audit entries in
-  addition to append-only `knowledge_events`
 - integrate external `research-rs` outputs as evidence/candidate insights
   without letting research directly define `dao`
 - add evaluator-assisted promotion only behind deterministic gates and human

--- a/docs/plans/2026-04-29-p48-card-audit-policy.md
+++ b/docs/plans/2026-04-29-p48-card-audit-policy.md
@@ -1,0 +1,25 @@
+# P48 Card Audit Policy Plan
+
+**Goal:** Resolve the Phase-2 card lifecycle JSONL audit question by keeping
+`knowledge_events` authoritative and avoiding default transactional dual-write
+to `audit.jsonl`.
+
+## Checklist
+
+- [x] Add P48 task contract.
+- [x] Update MIND-MODEL with card audit policy.
+- [x] Update AGENTS/CLAUDE inventories.
+- [x] Run spec lint and docs-only verification.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p48-card-audit-policy.spec.md
+agent-spec lint specs/p48-card-audit-policy.spec.md --min-score 0.7
+rg -n "P48 keeps knowledge_events as the authoritative Phase-2 card audit trail|no default JSONL dual-write" docs/MIND-MODEL-DESIGN.md
+rg -n "JSONL export.*derived from knowledge_events|not become a second source of truth" docs/MIND-MODEL-DESIGN.md
+rg -n "p48-card-audit-policy|P48 card audit policy" AGENTS.md CLAUDE.md
+rg -n "Do not write JSONL audit logs for Phase-2 card lifecycle" specs/p39-knowledge-card-lifecycle-cli.spec.md
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/specs/p48-card-audit-policy.spec.md
+++ b/specs/p48-card-audit-policy.spec.md
@@ -1,0 +1,83 @@
+spec: task
+name: "P48: card audit policy"
+inherits: project
+tags: [mind-model, knowledge-card, audit-policy]
+---
+
+## Intent
+
+Phase-2 knowledge cards already have transactional append-only
+`knowledge_events`. P48 resolves whether card lifecycle should also write the
+global JSONL audit log: no default double-write; keep `knowledge_events` as the
+authoritative card lifecycle audit trail, and only add JSONL export later if an
+external integration needs it.
+
+## Decisions
+
+- `knowledge_events` remain the authoritative audit trail for Phase-2 card lifecycle.
+- Do not write `audit.jsonl` from card promote/demote/backfill lifecycle by default.
+- Keep Stage-1 drawer lifecycle JSONL audit behavior unchanged.
+- If an external tool needs JSONL card history, add an explicit export surface rather than transactional dual-write.
+- Any future JSONL export must be derived from `knowledge_events` and must not become a second source of truth.
+- P48 is policy-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p48-card-audit-policy.spec.md
+- docs/plans/2026-04-29-p48-card-audit-policy.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not change card promote/demote/backfill behavior.
+- Do not write new JSONL audit entries for card lifecycle.
+- Do not change `knowledge_events` schema.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records card audit decision
+  Test:
+    Filter: rg -n "P48 keeps knowledge_events as the authoritative Phase-2 card audit trail|no default JSONL dual-write" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the Phase-2 card audit policy
+  Then it states that `knowledge_events` are authoritative
+  And it states there is no default JSONL dual-write
+
+Scenario: MIND-MODEL defines future JSONL export boundary
+  Test:
+    Filter: rg -n "JSONL export.*derived from knowledge_events|not become a second source of truth" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the card audit policy
+  Then it states future JSONL support should be export-derived
+  And it states JSONL must not become a second source of truth
+
+Scenario: Inventories include P48
+  Test:
+    Filter: rg -n "p48-card-audit-policy|P48 card audit policy" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P48
+  Then both AGENTS.md and CLAUDE.md include the P48 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+  Given the P48 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+Scenario: Existing no-JSONL card lifecycle rule remains visible
+  Test:
+    Filter: rg -n "Do not write JSONL audit logs for Phase-2 card lifecycle" specs/p39-knowledge-card-lifecycle-cli.spec.md
+  Given existing card lifecycle specs
+  When reading P39
+  Then the original no-JSONL rule remains present
+
+## Out of Scope
+
+- JSONL export implementation.
+- Changing card lifecycle runtime behavior.
+- Changing Stage-1 drawer audit behavior.
+- Changing `knowledge_events` schema.


### PR DESCRIPTION
## Summary

- Add P48 policy spec and plan for Phase-2 card audit behavior.
- Keep `knowledge_events` as the authoritative card lifecycle audit trail.
- Avoid default transactional dual-write to `audit.jsonl`.
- Define future JSONL support as export-derived from `knowledge_events`, not a second source of truth.
- Update MIND-MODEL and agent inventories.

## Verification

- `agent-spec parse specs/p48-card-audit-policy.spec.md`
- `agent-spec lint specs/p48-card-audit-policy.spec.md --min-score 0.7`
- `rg -n "P48 keeps knowledge_events as the authoritative Phase-2 card audit trail|no default JSONL dual-write" docs/MIND-MODEL-DESIGN.md`
- `rg -n "JSONL export.*derived from knowledge_events|not become a second source of truth" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p48-card-audit-policy|P48 card audit policy" AGENTS.md CLAUDE.md`
- `rg -n "Do not write JSONL audit logs for Phase-2 card lifecycle" specs/p39-knowledge-card-lifecycle-cli.spec.md`
- `git diff --name-only main...HEAD`
- `git diff --check`
