### PR TITLE
docs: define research ingestion policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p46-card-context-default-policy.spec.md` | 完成 | P46 card context default policy：card-aware context 继续 opt-in；未来默认启用必须有 runtime evidence 和 rollback criteria |
 | `specs/p47-card-embedding-policy.spec.md` | 完成 | P47 card embedding policy：暂不加 card-level embeddings；未来实现必须证明 statement-match misses、处理 stale vectors 和 rollback |
 | `specs/p48-card-audit-policy.spec.md` | 完成 | P48 card audit policy：`knowledge_events` 是 Phase-2 card lifecycle 权威审计；不默认双写 JSONL |
+| `specs/p49-research-ingestion-policy.spec.md` | 完成 | P49 research ingestion policy：research-rs 输出只进 evidence / evidence-backed candidate insights，不可直接定义 dao |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -148,6 +149,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p46-card-context-default-policy.md` — P46 card context default policy（已完成）
 - `docs/plans/2026-04-28-p47-card-embedding-policy.md` — P47 card embedding policy（已完成）
 - `docs/plans/2026-04-29-p48-card-audit-policy.md` — P48 card audit policy（已完成）
+- `docs/plans/2026-04-29-p49-research-ingestion-policy.md` — P49 research ingestion policy（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p46-card-context-default-policy.spec.md` | 完成 | P46 card context default policy：card-aware context 继续 opt-in；未来默认启用必须有 runtime evidence 和 rollback criteria |
 | `specs/p47-card-embedding-policy.spec.md` | 完成 | P47 card embedding policy：暂不加 card-level embeddings；未来实现必须证明 statement-match misses、处理 stale vectors 和 rollback |
 | `specs/p48-card-audit-policy.spec.md` | 完成 | P48 card audit policy：`knowledge_events` 是 Phase-2 card lifecycle 权威审计；不默认双写 JSONL |
+| `specs/p49-research-ingestion-policy.spec.md` | 完成 | P49 research ingestion policy：research-rs 输出只进 evidence / evidence-backed candidate insights，不可直接定义 dao |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -146,6 +147,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p46-card-context-default-policy.md` — P46 card context default policy（已完成）
 - `docs/plans/2026-04-28-p47-card-embedding-policy.md` — P47 card embedding policy（已完成）
 - `docs/plans/2026-04-29-p48-card-audit-policy.md` — P48 card audit policy（已完成）
+- `docs/plans/2026-04-29-p49-research-ingestion-policy.md` — P49 research ingestion policy（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -491,6 +491,19 @@ Therefore:
 - `research-rs` organizes the external world
 - memory governs what is promoted from those results
 
+P49 defines the research-rs ingestion path:
+
+- raw/source research output enters as `memory_kind=evidence` with `provenance=research`
+- structured summaries from research remain evidence unless explicitly distilled
+- candidate knowledge only through distill from existing evidence refs
+- contradiction signals become evidence or counterexamples for later demotion or
+  gate evaluation
+
+research must not directly create dao_tian. Research must not directly create
+canonical or promoted knowledge. It must not bypass lifecycle gates. The highest
+trust level research can supply by itself is source-backed evidence; memory owns
+distillation, promotion, demotion, and canonicalization.
+
 ## Runtime Wake-Up Order
 
 The runtime order should be explicit, not left to ad hoc semantic retrieval.
@@ -1163,8 +1176,6 @@ Proceed with the following assumptions unless future evidence rejects them:
 
 The remaining work is intentionally explicit:
 
-- integrate external `research-rs` outputs as evidence/candidate insights
-  without letting research directly define `dao`
 - add evaluator-assisted promotion only behind deterministic gates and human
   review rules for high-level knowledge
 

--- a/docs/plans/2026-04-29-p49-research-ingestion-policy.md
+++ b/docs/plans/2026-04-29-p49-research-ingestion-policy.md
@@ -1,0 +1,25 @@
+# P49 Research Ingestion Policy Plan
+
+**Goal:** Resolve the research-rs integration future-work item by defining how
+external research output enters mempal without allowing research to directly
+define `dao`.
+
+## Checklist
+
+- [x] Add P49 task contract.
+- [x] Update MIND-MODEL with the research ingestion path and forbidden bypasses.
+- [x] Update AGENTS/CLAUDE inventories.
+- [x] Run spec lint and docs-only verification.
+
+## Verification Commands
+
+```bash
+agent-spec parse specs/p49-research-ingestion-policy.spec.md
+agent-spec lint specs/p49-research-ingestion-policy.spec.md --min-score 0.7
+rg -n "P49 defines the research-rs ingestion path|memory_kind=evidence.*provenance=research|candidate knowledge only through distill" docs/MIND-MODEL-DESIGN.md
+rg -n "research must not directly create dao_tian|must not directly create canonical or promoted knowledge|lifecycle gates" docs/MIND-MODEL-DESIGN.md
+rg -n "p49-research-ingestion-policy|P49 research ingestion policy" AGENTS.md CLAUDE.md
+rg -n "Provenance::Research|distill only allows candidate dao_ren or qi|evidence drawer accepts explicit runtime or research provenance" src tests
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/specs/p49-research-ingestion-policy.spec.md
+++ b/specs/p49-research-ingestion-policy.spec.md
@@ -1,0 +1,84 @@
+spec: task
+name: "P49: research ingestion policy"
+inherits: project
+tags: [mind-model, research, ingestion-policy]
+---
+
+## Intent
+
+External `research-rs` output should feed the memory system, but it must not
+become a parallel authority for `dao`. P49 closes this design item by defining
+the allowed path: research outputs enter as evidence drawers or candidate
+insights backed by evidence refs; promotion into `dao` remains governed by the
+memory lifecycle gates.
+
+## Decisions
+
+- `research-rs` remains external `qi`, not a `dao` container.
+- Research raw/source output enters mempal as `memory_kind=evidence` with `provenance=research`.
+- Research summaries or insights may become candidate knowledge only through distill from existing evidence refs.
+- Research must not directly create `dao_tian`, `canonical`, or `promoted` knowledge.
+- Contradiction signals from research should be stored as evidence/counterexamples for later demotion or gate evaluation.
+- P49 is policy-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p49-research-ingestion-policy.spec.md
+- docs/plans/2026-04-29-p49-research-ingestion-policy.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not add a research-rs adapter or CLI command.
+- Do not change ingest, distill, promotion, or demotion behavior.
+- Do not allow research to bypass lifecycle gates.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records research ingestion path
+  Test:
+    Filter: rg -n "P49 defines the research-rs ingestion path|memory_kind=evidence.*provenance=research|candidate knowledge only through distill" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the research-rs boundary section
+  Then it states that research output enters as evidence with research provenance
+  And it states that candidate knowledge must be created through distill from evidence refs
+
+Scenario: MIND-MODEL forbids research-defined dao
+  Test:
+    Filter: rg -n "research must not directly create dao_tian|must not directly create canonical or promoted knowledge|lifecycle gates" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the research-rs boundary section
+  Then it states that research must not directly create dao_tian
+  And it states research cannot bypass lifecycle gates
+
+Scenario: Inventories include P49
+  Test:
+    Filter: rg -n "p49-research-ingestion-policy|P49 research ingestion policy" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P49
+  Then both AGENTS.md and CLAUDE.md include the P49 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+  Given the P49 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+Scenario: Existing runtime support remains sufficient for policy
+  Test:
+    Filter: rg -n "Provenance::Research|distill only allows candidate dao_ren or qi|evidence drawer accepts explicit runtime or research provenance" src tests
+  Given existing runtime behavior
+  When searching for research provenance and distill constraints
+  Then the existing code supports research evidence
+  And distill remains constrained to candidate dao_ren or qi
+
+## Out of Scope
+
+- Implementing a research-rs import adapter.
+- Adding new schema for research reports.
+- Changing promotion thresholds.
+- Allowing automatic dao creation from research output.


### PR DESCRIPTION
## Summary

- Add P49 policy spec and plan for research-rs ingestion.
- Define research-rs as external `qi`, not a `dao` authority.
- Route raw/source research output into evidence drawers with `provenance=research`.
- Require candidate knowledge to be distilled from existing evidence refs.
- Forbid research from directly creating `dao_tian`, canonical, or promoted knowledge.
- Update MIND-MODEL and agent inventories.

## Verification

- `agent-spec parse specs/p49-research-ingestion-policy.spec.md`
- `agent-spec lint specs/p49-research-ingestion-policy.spec.md --min-score 0.7`
- `rg -n "P49 defines the research-rs ingestion path|memory_kind=evidence.*provenance=research|candidate knowledge only through distill" docs/MIND-MODEL-DESIGN.md`
- `rg -n "research must not directly create dao_tian|must not directly create canonical or promoted knowledge|lifecycle gates" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p49-research-ingestion-policy|P49 research ingestion policy" AGENTS.md CLAUDE.md`
- `rg -n "Provenance::Research|distill only allows candidate dao_ren or qi|evidence drawer accepts explicit runtime or research provenance" src tests`
- `git diff --name-only main...HEAD`
- `git diff --check`
