### PR TITLE
docs: define evaluator promotion policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p47-card-embedding-policy.spec.md` | 完成 | P47 card embedding policy：暂不加 card-level embeddings；未来实现必须证明 statement-match misses、处理 stale vectors 和 rollback |
 | `specs/p48-card-audit-policy.spec.md` | 完成 | P48 card audit policy：`knowledge_events` 是 Phase-2 card lifecycle 权威审计；不默认双写 JSONL |
 | `specs/p49-research-ingestion-policy.spec.md` | 完成 | P49 research ingestion policy：research-rs 输出只进 evidence / evidence-backed candidate insights，不可直接定义 dao |
+| `specs/p50-evaluator-promotion-policy.spec.md` | 完成 | P50 evaluator promotion policy：evaluator 只能 advisory，不可绕过 deterministic gates / human review |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -150,6 +151,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p47-card-embedding-policy.md` — P47 card embedding policy（已完成）
 - `docs/plans/2026-04-29-p48-card-audit-policy.md` — P48 card audit policy（已完成）
 - `docs/plans/2026-04-29-p49-research-ingestion-policy.md` — P49 research ingestion policy（已完成）
+- `docs/plans/2026-04-29-p50-evaluator-promotion-policy.md` — P50 evaluator promotion policy（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p47-card-embedding-policy.spec.md` | 完成 | P47 card embedding policy：暂不加 card-level embeddings；未来实现必须证明 statement-match misses、处理 stale vectors 和 rollback |
 | `specs/p48-card-audit-policy.spec.md` | 完成 | P48 card audit policy：`knowledge_events` 是 Phase-2 card lifecycle 权威审计；不默认双写 JSONL |
 | `specs/p49-research-ingestion-policy.spec.md` | 完成 | P49 research ingestion policy：research-rs 输出只进 evidence / evidence-backed candidate insights，不可直接定义 dao |
+| `specs/p50-evaluator-promotion-policy.spec.md` | 完成 | P50 evaluator promotion policy：evaluator 只能 advisory，不可绕过 deterministic gates / human review |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -148,6 +149,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-28-p47-card-embedding-policy.md` — P47 card embedding policy（已完成）
 - `docs/plans/2026-04-29-p48-card-audit-policy.md` — P48 card audit policy（已完成）
 - `docs/plans/2026-04-29-p49-research-ingestion-policy.md` — P49 research ingestion policy（已完成）
+- `docs/plans/2026-04-29-p50-evaluator-promotion-policy.md` — P50 evaluator promotion policy（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1174,10 +1174,35 @@ Proceed with the following assumptions unless future evidence rejects them:
 
 ## Future Work After P42
 
-The remaining work is intentionally explicit:
+P42 originally left one explicit follow-up:
 
 - add evaluator-assisted promotion only behind deterministic gates and human
   review rules for high-level knowledge
+
+P50 closes that item as policy. P50 defines evaluator-assisted promotion as advisory-only.
+Evaluators are not lifecycle actors.
+
+Evaluators may:
+
+- recommend promotion or demotion candidates
+- propose supporting, verification, teaching, and counterexample evidence refs
+- produce contradiction candidates and risk notes
+- explain why a knowledge item appears ready or unsafe
+
+Evaluators must not directly mutate status or otherwise act as lifecycle writers:
+
+- append lifecycle refs as authoritative gate input
+- bypass deterministic promotion or demotion gates
+- satisfy reviewer requirements by evaluator-only review
+- create automatic promotion or demotion paths
+
+The deterministic gates remain authoritative. Promotion and demotion still go
+through the existing gate-enforced CLI/MCP lifecycle surfaces. `dao_tian`
+canonicalization still requires a human reviewer; evaluator-only canonization is forbidden.
+If a future implementation adds evaluator APIs, that work must be a separate
+spec and preserve deterministic replay, evidence citation, and audit semantics.
+
+No open Future Work remains in the P42 list.
 
 ## Closing Summary
 

--- a/docs/plans/2026-04-29-p50-evaluator-promotion-policy.md
+++ b/docs/plans/2026-04-29-p50-evaluator-promotion-policy.md
@@ -1,0 +1,36 @@
+# P50 Evaluator Promotion Policy
+
+## Goal
+
+Close the final `docs/MIND-MODEL-DESIGN.md` future-work item by defining
+evaluator-assisted promotion as advisory-only. Evaluators may help identify
+evidence and risks, but deterministic gates and human review remain the
+authority for lifecycle changes.
+
+## Scope
+
+- Add `specs/p50-evaluator-promotion-policy.spec.md`.
+- Update `docs/MIND-MODEL-DESIGN.md` with the evaluator promotion policy.
+- Update `AGENTS.md` and `CLAUDE.md` spec/plan inventories.
+- Do not change Rust runtime code.
+
+## Steps
+
+- [x] Capture P50 task contract.
+- [x] Document evaluator advisory boundary in MIND-MODEL design.
+- [x] Update agent inventories.
+- [x] Run spec and grep acceptance checks.
+- [ ] Commit, ingest decision memory, push, and open PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p50-evaluator-promotion-policy.spec.md
+agent-spec lint specs/p50-evaluator-promotion-policy.spec.md --min-score 0.7
+rg -n "P50 defines evaluator-assisted promotion as advisory-only|Evaluators are not lifecycle actors|must not directly mutate status" docs/MIND-MODEL-DESIGN.md
+rg -n "deterministic gates remain authoritative|dao_tian.*human reviewer|evaluator-only canonization.*forbidden" docs/MIND-MODEL-DESIGN.md
+rg -n "p50-evaluator-promotion-policy|P50 evaluator promotion policy" AGENTS.md CLAUDE.md
+rg -n "evaluator-only.*canonization|reviewer_required=true|test_cli_knowledge_gate_requires_reviewer_for_dao_tian" specs docs tests
+git diff --name-only
+git diff --check
+```

--- a/specs/p50-evaluator-promotion-policy.spec.md
+++ b/specs/p50-evaluator-promotion-policy.spec.md
@@ -1,0 +1,84 @@
+spec: task
+name: "P50: evaluator promotion policy"
+inherits: project
+tags: [mind-model, evaluator, promotion-policy]
+---
+
+## Intent
+
+P20/P27/P38 already provide deterministic promotion gates, and P49 closed the
+research ingestion boundary. P50 closes the final MIND-MODEL future-work item
+by defining evaluator-assisted promotion as advisory-only: evaluators may
+recommend and gather evidence, but promotion remains gate-enforced and
+human-reviewed for high-level knowledge.
+
+## Decisions
+
+- Evaluators are advisory inputs, not lifecycle actors.
+- Evaluators may propose supporting, verification, teaching, and counterexample refs.
+- Evaluators may produce risk notes, contradiction candidates, and promotion recommendations.
+- Evaluators must not directly mutate lifecycle status, append lifecycle refs, or bypass deterministic gates.
+- `dao_tian -> canonical` and any high-level knowledge requiring reviewer cannot be satisfied by evaluator-only review.
+- Promotion and demotion remain through existing gate-enforced CLI/MCP lifecycle surfaces.
+- P50 is policy-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p50-evaluator-promotion-policy.spec.md
+- docs/plans/2026-04-29-p50-evaluator-promotion-policy.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not add evaluator scoring, telemetry, or runtime APIs.
+- Do not change promotion thresholds or reviewer requirements.
+- Do not add automatic promotion or demotion.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records evaluator advisory boundary
+  Test:
+    Filter: rg -n "P50 defines evaluator-assisted promotion as advisory-only|Evaluators are not lifecycle actors|must not directly mutate status" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading evaluator promotion policy
+  Then it states evaluator assistance is advisory-only
+  And it states evaluators cannot directly mutate lifecycle state
+
+Scenario: MIND-MODEL preserves deterministic gates and human review
+  Test:
+    Filter: rg -n "deterministic gates remain authoritative|dao_tian.*human reviewer|evaluator-only canonization.*forbidden" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading evaluator promotion policy
+  Then deterministic gates remain authoritative
+  And dao_tian canonicalization still requires human review
+
+Scenario: Inventories include P50
+  Test:
+    Filter: rg -n "p50-evaluator-promotion-policy|P50 evaluator promotion policy" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P50
+  Then both AGENTS.md and CLAUDE.md include the P50 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+  Given the P50 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+Scenario: Existing no evaluator-only canonization rule remains visible
+  Test:
+    Filter: rg -n "evaluator-only.*canonization|reviewer_required=true|test_cli_knowledge_gate_requires_reviewer_for_dao_tian" specs docs tests
+  Given existing gate policy and tests
+  When searching evaluator/reviewer rules
+  Then existing reviewer constraints remain visible
+
+## Out of Scope
+
+- Implementing evaluator APIs.
+- Adding evaluator scoring.
+- Automatic promotion or demotion.
+- Changing promotion gates.


### PR DESCRIPTION
## Summary

- define P50 evaluator-assisted promotion as advisory-only
- close the final `docs/MIND-MODEL-DESIGN.md` P42 future-work item
- update agent inventories with P50 spec and plan

## Verification

- `agent-spec parse specs/p50-evaluator-promotion-policy.spec.md`
- `agent-spec lint specs/p50-evaluator-promotion-policy.spec.md --min-score 0.7`
- `rg -n "P50 defines evaluator-assisted promotion as advisory-only|Evaluators are not lifecycle actors|must not directly mutate status" docs/MIND-MODEL-DESIGN.md`
- `rg -n "deterministic gates remain authoritative|dao_tian.*human reviewer|evaluator-only canonization.*forbidden" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p50-evaluator-promotion-policy|P50 evaluator promotion policy" AGENTS.md CLAUDE.md`
- `rg -n "evaluator-only.*canonization|reviewer_required=true|test_cli_knowledge_gate_requires_reviewer_for_dao_tian" specs docs tests`
- `git diff --check`
