### PR TITLE
docs: record mind model closure audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p48-card-audit-policy.spec.md` | 完成 | P48 card audit policy：`knowledge_events` 是 Phase-2 card lifecycle 权威审计；不默认双写 JSONL |
 | `specs/p49-research-ingestion-policy.spec.md` | 完成 | P49 research ingestion policy：research-rs 输出只进 evidence / evidence-backed candidate insights，不可直接定义 dao |
 | `specs/p50-evaluator-promotion-policy.spec.md` | 完成 | P50 evaluator promotion policy：evaluator 只能 advisory，不可绕过 deterministic gates / human review |
+| `specs/p51-mind-model-closure-audit.spec.md` | 完成 | P51 mind model closure audit：确认 P12-P50 baseline 已完成，未来扩展必须开新阶段 spec |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -152,6 +153,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-29-p48-card-audit-policy.md` — P48 card audit policy（已完成）
 - `docs/plans/2026-04-29-p49-research-ingestion-policy.md` — P49 research ingestion policy（已完成）
 - `docs/plans/2026-04-29-p50-evaluator-promotion-policy.md` — P50 evaluator promotion policy（已完成）
+- `docs/plans/2026-04-29-p51-mind-model-closure-audit.md` — P51 mind model closure audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p48-card-audit-policy.spec.md` | 完成 | P48 card audit policy：`knowledge_events` 是 Phase-2 card lifecycle 权威审计；不默认双写 JSONL |
 | `specs/p49-research-ingestion-policy.spec.md` | 完成 | P49 research ingestion policy：research-rs 输出只进 evidence / evidence-backed candidate insights，不可直接定义 dao |
 | `specs/p50-evaluator-promotion-policy.spec.md` | 完成 | P50 evaluator promotion policy：evaluator 只能 advisory，不可绕过 deterministic gates / human review |
+| `specs/p51-mind-model-closure-audit.spec.md` | 完成 | P51 mind model closure audit：确认 P12-P50 baseline 已完成，未来扩展必须开新阶段 spec |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -150,6 +151,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-29-p48-card-audit-policy.md` — P48 card audit policy（已完成）
 - `docs/plans/2026-04-29-p49-research-ingestion-policy.md` — P49 research ingestion policy（已完成）
 - `docs/plans/2026-04-29-p50-evaluator-promotion-policy.md` — P50 evaluator promotion policy（已完成）
+- `docs/plans/2026-04-29-p51-mind-model-closure-audit.md` — P51 mind model closure audit（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1204,6 +1204,28 @@ spec and preserve deterministic replay, evidence citation, and audit semantics.
 
 No open Future Work remains in the P42 list.
 
+## Completion Status After P50
+
+P51 closure audit: the MIND-MODEL baseline is complete.
+
+No open implementation tasks remain in the P12-P50 baseline. The completed
+baseline includes:
+
+- typed evidence and knowledge drawers
+- `dao_tian`, `dao_ren`, `shu`, and `qi` governance boundaries
+- worktree/repo/global anchor behavior
+- wake-up/context separation
+- context-guided skill/tool selection
+- distill, gate, promote, demote, and anchor publication lifecycle surfaces
+- Phase-2 knowledge card storage, lifecycle, retrieval, and opt-in context
+- research ingestion and evaluator promotion policies
+
+Completion does not mean every optional future enhancement is implemented. It
+means the current design baseline has no known open implementation task. Future
+evaluator APIs, card-level embeddings, default card context, research adapters,
+or other expansions must start as new-stage specs with their own evidence,
+rollback criteria, and acceptance checks.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-04-29-p51-mind-model-closure-audit.md
+++ b/docs/plans/2026-04-29-p51-mind-model-closure-audit.md
@@ -1,0 +1,35 @@
+# P51 Mind Model Closure Audit
+
+## Goal
+
+Record the post-P50 closure state for `docs/MIND-MODEL-DESIGN.md`: the P12-P50
+MIND-MODEL baseline is complete, and future work must be opened as a new-stage
+spec rather than treated as unfinished P42 baseline work.
+
+## Scope
+
+- Add `specs/p51-mind-model-closure-audit.spec.md`.
+- Add a post-P50 closure note to `docs/MIND-MODEL-DESIGN.md`.
+- Update `AGENTS.md` and `CLAUDE.md` inventories.
+- Do not change runtime code.
+
+## Steps
+
+- [x] Capture P51 task contract.
+- [x] Document the post-P50 closure state.
+- [x] Update agent inventories.
+- [x] Run spec and grep acceptance checks.
+- [ ] Commit, ingest decision memory, push, and open PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p51-mind-model-closure-audit.spec.md
+agent-spec lint specs/p51-mind-model-closure-audit.spec.md --min-score 0.7
+rg -n "P51 closure audit: the MIND-MODEL baseline is complete|No open implementation tasks remain in the P12-P50 baseline" docs/MIND-MODEL-DESIGN.md
+rg -n "Completion does not mean every optional future enhancement is implemented|must start as new-stage specs" docs/MIND-MODEL-DESIGN.md
+rg -n "p51-mind-model-closure-audit|P51 mind model closure audit" AGENTS.md CLAUDE.md
+rg -n "No open Future Work remains in the P42 list|P50 closes that item as policy" docs/MIND-MODEL-DESIGN.md
+git diff --name-only
+git diff --check
+```

--- a/specs/p51-mind-model-closure-audit.spec.md
+++ b/specs/p51-mind-model-closure-audit.spec.md
@@ -1,0 +1,82 @@
+spec: task
+name: "P51: mind model closure audit"
+inherits: project
+tags: [mind-model, closure, audit]
+---
+
+## Intent
+
+P50 closed the final explicit Future Work item left by P42. P51 records the
+post-P50 closure state so future agents do not keep treating
+`docs/MIND-MODEL-DESIGN.md` as an unfinished implementation plan.
+
+## Decisions
+
+- The MIND-MODEL baseline from P12 through P50 is complete.
+- Completion means the current design decisions, governance boundaries, and
+  Stage-1/Phase-2 runtime surfaces are specified and implemented where intended.
+- Completion does not mean every optional future enhancement is implemented.
+- Future evaluator APIs, card-level embeddings, default card context, or
+  research adapters must start as new-stage specs with their own evidence.
+- P51 is a closure audit only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p51-mind-model-closure-audit.spec.md
+- docs/plans/2026-04-29-p51-mind-model-closure-audit.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not reopen P42 Future Work.
+- Do not add runtime behavior, schema changes, or MCP tools.
+- Do not change existing lifecycle thresholds or policy.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL states post-P50 closure
+  Test:
+    Filter: rg -n "P51 closure audit: the MIND-MODEL baseline is complete|No open implementation tasks remain in the P12-P50 baseline" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the closure status
+  Then it states the baseline is complete
+  And it states no open P12-P50 implementation tasks remain
+
+Scenario: MIND-MODEL distinguishes closure from optional future stages
+  Test:
+    Filter: rg -n "Completion does not mean every optional future enhancement is implemented|must start as new-stage specs" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the closure status
+  Then it distinguishes baseline closure from optional future enhancements
+  And it requires new-stage specs for future enhancements
+
+Scenario: Inventories include P51
+  Test:
+    Filter: rg -n "p51-mind-model-closure-audit|P51 mind model closure audit" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P51
+  Then both AGENTS.md and CLAUDE.md include the P51 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+  Given the P51 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+Scenario: Future Work list remains closed
+  Test:
+    Filter: rg -n "No open Future Work remains in the P42 list|P50 closes that item as policy" docs/MIND-MODEL-DESIGN.md
+  Given the P51 closure audit
+  When reading the P42 future-work section
+  Then the final P42 future-work item remains closed
+
+## Out of Scope
+
+- Implementing new runtime features.
+- Designing evaluator APIs.
+- Enabling card-level embeddings by default.
+- Changing MIND-MODEL governance rules.


### PR DESCRIPTION
## Summary

- record the post-P50 MIND-MODEL closure state
- clarify that the P12-P50 baseline has no open implementation tasks
- require optional future expansions to start as new-stage specs

## Verification

- `agent-spec parse specs/p51-mind-model-closure-audit.spec.md`
- `agent-spec lint specs/p51-mind-model-closure-audit.spec.md --min-score 0.7`
- `rg -n "P51 closure audit: the MIND-MODEL baseline is complete|No open implementation tasks remain in the P12-P50 baseline" docs/MIND-MODEL-DESIGN.md`
- `rg -n "Completion does not mean every optional future enhancement is implemented|must start as new-stage specs" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p51-mind-model-closure-audit|P51 mind model closure audit" AGENTS.md CLAUDE.md`
- `rg -n "No open Future Work remains in the P42 list|P50 closes that item as policy" docs/MIND-MODEL-DESIGN.md`
- `git diff --check`
