### PR TITLE
docs: define phase 3 intake roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p49-research-ingestion-policy.spec.md` | 完成 | P49 research ingestion policy：research-rs 输出只进 evidence / evidence-backed candidate insights，不可直接定义 dao |
 | `specs/p50-evaluator-promotion-policy.spec.md` | 完成 | P50 evaluator promotion policy：evaluator 只能 advisory，不可绕过 deterministic gates / human review |
 | `specs/p51-mind-model-closure-audit.spec.md` | 完成 | P51 mind model closure audit：确认 P12-P50 baseline 已完成，未来扩展必须开新阶段 spec |
+| `specs/p52-phase-3-intake-roadmap.spec.md` | 完成 | P52 phase 3 intake roadmap：定义 baseline 后新阶段候选轨道与 evidence/rollback/acceptance 入口规则 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -154,6 +155,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-29-p49-research-ingestion-policy.md` — P49 research ingestion policy（已完成）
 - `docs/plans/2026-04-29-p50-evaluator-promotion-policy.md` — P50 evaluator promotion policy（已完成）
 - `docs/plans/2026-04-29-p51-mind-model-closure-audit.md` — P51 mind model closure audit（已完成）
+- `docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md` — P52 phase 3 intake roadmap（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p49-research-ingestion-policy.spec.md` | 完成 | P49 research ingestion policy：research-rs 输出只进 evidence / evidence-backed candidate insights，不可直接定义 dao |
 | `specs/p50-evaluator-promotion-policy.spec.md` | 完成 | P50 evaluator promotion policy：evaluator 只能 advisory，不可绕过 deterministic gates / human review |
 | `specs/p51-mind-model-closure-audit.spec.md` | 完成 | P51 mind model closure audit：确认 P12-P50 baseline 已完成，未来扩展必须开新阶段 spec |
+| `specs/p52-phase-3-intake-roadmap.spec.md` | 完成 | P52 phase 3 intake roadmap：定义 baseline 后新阶段候选轨道与 evidence/rollback/acceptance 入口规则 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -152,6 +153,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-29-p49-research-ingestion-policy.md` — P49 research ingestion policy（已完成）
 - `docs/plans/2026-04-29-p50-evaluator-promotion-policy.md` — P50 evaluator promotion policy（已完成）
 - `docs/plans/2026-04-29-p51-mind-model-closure-audit.md` — P51 mind model closure audit（已完成）
+- `docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md` — P52 phase 3 intake roadmap（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1226,6 +1226,31 @@ evaluator APIs, card-level embeddings, default card context, research adapters,
 or other expansions must start as new-stage specs with their own evidence,
 rollback criteria, and acceptance checks.
 
+## Phase 3 Intake Roadmap
+
+P52 Phase-3 intake roadmap defines how work starts after baseline closure.
+Phase 3 is new-stage work, not unfinished P12-P50 baseline work.
+
+Candidate tracks:
+
+- evaluator APIs
+- card retrieval maturity
+- research adapter ingestion
+- runtime adoption evidence
+
+Intake rules:
+
+- each candidate must state evidence, rollback criteria, and acceptance checks before implementation begins
+- default-enabling card context or card embeddings requires measured retrieval benefit
+- Evaluator APIs must preserve the P50 advisory-only lifecycle boundary
+- Research adapters must preserve the P49 evidence-first ingestion boundary
+- card retrieval changes must preserve citation and audit semantics
+- runtime adoption work must include rollback criteria for agent behavior changes
+
+The first Phase-3 implementation should be selected only after one candidate has
+enough evidence to justify implementation. Until then, Phase 3 remains an intake
+queue, not an implementation commitment.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md
+++ b/docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md
@@ -1,0 +1,36 @@
+# P52 Phase 3 Intake Roadmap
+
+## Goal
+
+Define the post-baseline intake rules for Phase 3. P12-P50 is closed; future
+work must start as new-stage specs with evidence, rollback criteria, and
+acceptance checks before implementation.
+
+## Scope
+
+- Add `specs/p52-phase-3-intake-roadmap.spec.md`.
+- Add Phase-3 intake roadmap text to `docs/MIND-MODEL-DESIGN.md`.
+- Update `AGENTS.md` and `CLAUDE.md` inventories.
+- Do not change runtime code.
+
+## Steps
+
+- [x] Capture P52 task contract.
+- [x] Document Phase-3 intake rules and candidate tracks.
+- [x] Update agent inventories.
+- [x] Run spec and grep acceptance checks.
+- [ ] Commit, ingest decision memory, push, and open PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p52-phase-3-intake-roadmap.spec.md
+agent-spec lint specs/p52-phase-3-intake-roadmap.spec.md --min-score 0.7
+rg -n "P52 Phase-3 intake roadmap|Phase 3 is new-stage work, not unfinished P12-P50 baseline work" docs/MIND-MODEL-DESIGN.md
+rg -n "evaluator APIs|card retrieval maturity|research adapter ingestion|runtime adoption evidence" docs/MIND-MODEL-DESIGN.md
+rg -n "must state evidence, rollback criteria, and acceptance checks before implementation begins|default-enabling card context or card embeddings requires measured retrieval benefit" docs/MIND-MODEL-DESIGN.md
+rg -n "Evaluator APIs must preserve the P50 advisory-only lifecycle boundary|Research adapters must preserve the P49 evidence-first ingestion boundary" docs/MIND-MODEL-DESIGN.md
+rg -n "p52-phase-3-intake-roadmap|P52 phase 3 intake roadmap" AGENTS.md CLAUDE.md
+git diff --name-only
+git diff --check
+```

--- a/specs/p52-phase-3-intake-roadmap.spec.md
+++ b/specs/p52-phase-3-intake-roadmap.spec.md
@@ -1,0 +1,94 @@
+spec: task
+name: "P52: phase 3 intake roadmap"
+inherits: project
+tags: [mind-model, phase-3, roadmap]
+---
+
+## Intent
+
+P51 closed the P12-P50 MIND-MODEL baseline. P52 defines the next-stage intake
+roadmap so future work starts from evidence-backed specs instead of reopening
+the completed baseline.
+
+## Decisions
+
+- Phase 3 is not a continuation of unfinished P12-P50 baseline work.
+- Phase 3 candidate tracks are evaluator APIs, card retrieval maturity, research
+  adapter ingestion, and runtime adoption evidence.
+- A Phase 3 candidate must state evidence, rollback criteria, and acceptance
+  checks before implementation begins.
+- Default-enabling card context or card embeddings requires measured retrieval
+  benefit and rollback criteria.
+- Evaluator APIs must preserve the P50 advisory-only lifecycle boundary.
+- Research adapters must preserve the P49 evidence-first ingestion boundary.
+- P52 is roadmap-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p52-phase-3-intake-roadmap.spec.md
+- docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not implement evaluator APIs.
+- Do not implement card embeddings.
+- Do not default-enable card context.
+- Do not implement a research adapter.
+- Do not reopen P12-P50 baseline tasks.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL defines Phase 3 as new-stage work
+  Test:
+    Filter: rg -n "P52 Phase-3 intake roadmap|Phase 3 is new-stage work, not unfinished P12-P50 baseline work" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the post-baseline roadmap
+  Then it states Phase 3 is new-stage work
+  And it does not reopen the completed P12-P50 baseline
+
+Scenario: MIND-MODEL lists candidate tracks
+  Test:
+    Filter: rg -n "evaluator APIs|card retrieval maturity|research adapter ingestion|runtime adoption evidence" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading Phase 3 candidate tracks
+  Then evaluator APIs, card retrieval maturity, research adapter ingestion, and runtime adoption evidence are listed
+
+Scenario: MIND-MODEL requires evidence before implementation
+  Test:
+    Filter: rg -n "must state evidence, rollback criteria, and acceptance checks before implementation begins|default-enabling card context or card embeddings requires measured retrieval benefit" docs/MIND-MODEL-DESIGN.md
+  Given the Phase 3 intake rules
+  When evaluating a candidate
+  Then it must define evidence, rollback, and acceptance checks before implementation
+  And card defaults or embeddings require measured retrieval benefit
+
+Scenario: Existing P49/P50 boundaries remain binding
+  Test:
+    Filter: rg -n "Evaluator APIs must preserve the P50 advisory-only lifecycle boundary|Research adapters must preserve the P49 evidence-first ingestion boundary" docs/MIND-MODEL-DESIGN.md
+  Given Phase 3 candidate tracks
+  When evaluator or research work is proposed
+  Then P50 and P49 boundaries remain binding
+
+Scenario: Inventories include P52
+  Test:
+    Filter: rg -n "p52-phase-3-intake-roadmap|P52 phase 3 intake roadmap" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P52
+  Then both AGENTS.md and CLAUDE.md include the P52 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+  Given the P52 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+## Out of Scope
+
+- Implementing Phase 3 features.
+- Choosing one Phase 3 candidate to implement.
+- Changing completed P12-P50 behavior.
+- Changing promotion, research, or card runtime policy.


### PR DESCRIPTION
## Summary

- define Phase 3 as new-stage work after the closed P12-P50 baseline
- list candidate tracks: evaluator APIs, card retrieval maturity, research adapter ingestion, runtime adoption evidence
- require evidence, rollback criteria, and acceptance checks before any Phase 3 implementation

## Verification

- `agent-spec parse specs/p52-phase-3-intake-roadmap.spec.md`
- `agent-spec lint specs/p52-phase-3-intake-roadmap.spec.md --min-score 0.7`
- `rg -n "P52 Phase-3 intake roadmap|Phase 3 is new-stage work, not unfinished P12-P50 baseline work" docs/MIND-MODEL-DESIGN.md`
- `rg -n "evaluator APIs|card retrieval maturity|research adapter ingestion|runtime adoption evidence" docs/MIND-MODEL-DESIGN.md`
- `rg -n "must state evidence, rollback criteria, and acceptance checks before implementation begins|default-enabling card context or card embeddings requires measured retrieval benefit" docs/MIND-MODEL-DESIGN.md`
- `rg -n "Evaluator APIs must preserve the P50 advisory-only lifecycle boundary|Research adapters must preserve the P49 evidence-first ingestion boundary" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p52-phase-3-intake-roadmap|P52 phase 3 intake roadmap" AGENTS.md CLAUDE.md`
- `git diff --check`
