### PR TITLE
docs: audit phase 3 candidate evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p50-evaluator-promotion-policy.spec.md` | 完成 | P50 evaluator promotion policy：evaluator 只能 advisory，不可绕过 deterministic gates / human review |
 | `specs/p51-mind-model-closure-audit.spec.md` | 完成 | P51 mind model closure audit：确认 P12-P50 baseline 已完成，未来扩展必须开新阶段 spec |
 | `specs/p52-phase-3-intake-roadmap.spec.md` | 完成 | P52 phase 3 intake roadmap：定义 baseline 后新阶段候选轨道与 evidence/rollback/acceptance 入口规则 |
+| `specs/p53-phase-3-candidate-evidence-audit.spec.md` | 完成 | P53 phase 3 candidate evidence audit：评估 Phase-3 候选证据，推荐先做 runtime adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -156,6 +157,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-29-p50-evaluator-promotion-policy.md` — P50 evaluator promotion policy（已完成）
 - `docs/plans/2026-04-29-p51-mind-model-closure-audit.md` — P51 mind model closure audit（已完成）
 - `docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md` — P52 phase 3 intake roadmap（已完成）
+- `docs/plans/2026-05-02-p53-phase-3-candidate-evidence-audit.md` — P53 phase 3 candidate evidence audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p50-evaluator-promotion-policy.spec.md` | 完成 | P50 evaluator promotion policy：evaluator 只能 advisory，不可绕过 deterministic gates / human review |
 | `specs/p51-mind-model-closure-audit.spec.md` | 完成 | P51 mind model closure audit：确认 P12-P50 baseline 已完成，未来扩展必须开新阶段 spec |
 | `specs/p52-phase-3-intake-roadmap.spec.md` | 完成 | P52 phase 3 intake roadmap：定义 baseline 后新阶段候选轨道与 evidence/rollback/acceptance 入口规则 |
+| `specs/p53-phase-3-candidate-evidence-audit.spec.md` | 完成 | P53 phase 3 candidate evidence audit：评估 Phase-3 候选证据，推荐先做 runtime adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -154,6 +155,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-29-p50-evaluator-promotion-policy.md` — P50 evaluator promotion policy（已完成）
 - `docs/plans/2026-04-29-p51-mind-model-closure-audit.md` — P51 mind model closure audit（已完成）
 - `docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md` — P52 phase 3 intake roadmap（已完成）
+- `docs/plans/2026-05-02-p53-phase-3-candidate-evidence-audit.md` — P53 phase 3 candidate evidence audit（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1251,6 +1251,22 @@ The first Phase-3 implementation should be selected only after one candidate has
 enough evidence to justify implementation. Until then, Phase 3 remains an intake
 queue, not an implementation commitment.
 
+## Phase 3 Candidate Evidence Audit
+
+P53 Phase-3 candidate evidence audit records current readiness. No Phase-3 candidate is ready for direct implementation yet.
+
+Candidate readiness:
+
+- Runtime adoption evidence: recommended first measurement track. It should collect concrete agent-behavior evidence before default policy changes.
+- Card retrieval maturity: partial evidence from P43-P45, but it still needs measured retrieval misses and context impact before default context changes or card embeddings.
+- Evaluator APIs: blocked on advisory output contracts and lifecycle replay requirements.
+- Research adapter ingestion: blocked on an explicit external report/input contract.
+
+Recommended first Phase-3 track: runtime adoption evidence. Runtime adoption evidence is the common measurement substrate for deciding whether card-aware context should become default, whether card embeddings are justified, and what evaluator advice is actually useful to agents.
+
+This keeps Phase 3 evidence-first: implement measurement before implementing
+new authority, new retrieval defaults, or new external ingestion adapters.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-02-p53-phase-3-candidate-evidence-audit.md
+++ b/docs/plans/2026-05-02-p53-phase-3-candidate-evidence-audit.md
@@ -1,0 +1,35 @@
+# P53 Phase 3 Candidate Evidence Audit
+
+## Goal
+
+Audit the Phase-3 candidate tracks from P52 and record which track should come
+first. This is a decision/audit step, not implementation.
+
+## Scope
+
+- Add `specs/p53-phase-3-candidate-evidence-audit.spec.md`.
+- Add a Phase-3 candidate evidence audit section to `docs/MIND-MODEL-DESIGN.md`.
+- Update `AGENTS.md` and `CLAUDE.md` inventories.
+- Do not change runtime code.
+
+## Steps
+
+- [x] Capture P53 task contract.
+- [x] Document candidate readiness and blockers.
+- [x] Update agent inventories.
+- [x] Run spec and grep acceptance checks.
+- [ ] Commit, ingest decision memory, push, and open PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p53-phase-3-candidate-evidence-audit.spec.md
+agent-spec lint specs/p53-phase-3-candidate-evidence-audit.spec.md --min-score 0.7
+rg -n "P53 Phase-3 candidate evidence audit|No Phase-3 candidate is ready for direct implementation yet" docs/MIND-MODEL-DESIGN.md
+rg -n "Recommended first Phase-3 track: runtime adoption evidence|runtime adoption evidence is the common measurement substrate" docs/MIND-MODEL-DESIGN.md
+rg -n "Card retrieval maturity: partial evidence from P43-P45|needs measured retrieval misses and context impact" docs/MIND-MODEL-DESIGN.md
+rg -n "Evaluator APIs: blocked on advisory output contracts and lifecycle replay requirements|Research adapter ingestion: blocked on an explicit external report/input contract" docs/MIND-MODEL-DESIGN.md
+rg -n "p53-phase-3-candidate-evidence-audit|P53 phase 3 candidate evidence audit" AGENTS.md CLAUDE.md
+git diff --name-only
+git diff --check
+```

--- a/specs/p53-phase-3-candidate-evidence-audit.spec.md
+++ b/specs/p53-phase-3-candidate-evidence-audit.spec.md
@@ -1,0 +1,91 @@
+spec: task
+name: "P53: phase 3 candidate evidence audit"
+inherits: project
+tags: [mind-model, phase-3, evidence-audit]
+---
+
+## Intent
+
+P52 defined Phase-3 intake rules but did not choose an implementation track.
+P53 audits the current evidence for each Phase-3 candidate and records the next
+recommended step without implementing new runtime behavior.
+
+## Decisions
+
+- No Phase-3 candidate is ready for direct implementation yet.
+- Runtime adoption evidence is the recommended first Phase-3 measurement track.
+- Card retrieval maturity has partial evidence from P43-P45, but still needs measured retrieval misses and context impact before default changes or embeddings.
+- Evaluator APIs remain blocked on concrete advisory output contracts and lifecycle replay requirements.
+- Research adapter ingestion remains blocked on an explicit external report/input contract.
+- P53 is audit-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p53-phase-3-candidate-evidence-audit.spec.md
+- docs/plans/2026-05-02-p53-phase-3-candidate-evidence-audit.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not implement Phase-3 runtime features.
+- Do not choose card context default enablement.
+- Do not implement card embeddings.
+- Do not implement evaluator APIs.
+- Do not implement research adapter ingestion.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records candidate readiness
+  Test:
+    Filter: rg -n "P53 Phase-3 candidate evidence audit|No Phase-3 candidate is ready for direct implementation yet" docs/MIND-MODEL-DESIGN.md
+  Given the MIND-MODEL design document
+  When reading the Phase-3 evidence audit
+  Then it states that no candidate is ready for direct implementation
+  And it identifies the section as P53
+
+Scenario: MIND-MODEL recommends the first measurement track
+  Test:
+    Filter: rg -n "Recommended first Phase-3 track: runtime adoption evidence|runtime adoption evidence is the common measurement substrate" docs/MIND-MODEL-DESIGN.md
+  Given the candidate evidence audit
+  When reading the recommendation
+  Then runtime adoption evidence is recommended first
+  And the reason is that it supports later candidate decisions
+
+Scenario: MIND-MODEL records card retrieval evidence gap
+  Test:
+    Filter: rg -n "Card retrieval maturity: partial evidence from P43-P45|needs measured retrieval misses and context impact" docs/MIND-MODEL-DESIGN.md
+  Given the card retrieval candidate
+  When reading the evidence audit
+  Then linked-evidence retrieval is recognized as partial evidence
+  And measured misses/context impact remain required
+
+Scenario: MIND-MODEL records evaluator and research blockers
+  Test:
+    Filter: rg -n "Evaluator APIs: blocked on advisory output contracts and lifecycle replay requirements|Research adapter ingestion: blocked on an explicit external report/input contract" docs/MIND-MODEL-DESIGN.md
+  Given evaluator and research candidates
+  When reading the evidence audit
+  Then both blockers are explicitly recorded
+
+Scenario: Inventories include P53
+  Test:
+    Filter: rg -n "p53-phase-3-candidate-evidence-audit|P53 phase 3 candidate evidence audit" AGENTS.md CLAUDE.md
+  Given repo agent inventories
+  When searching for P53
+  Then both AGENTS.md and CLAUDE.md include the P53 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+  Given the P53 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+## Out of Scope
+
+- Implementing runtime adoption measurement.
+- Implementing any Phase-3 feature.
+- Changing Phase-2 knowledge card behavior.
+- Changing research or evaluator policy.


### PR DESCRIPTION
## Summary

- audit the four P52 Phase-3 candidate tracks
- record that no candidate is ready for direct implementation yet
- recommend runtime adoption evidence as the first Phase-3 measurement track

## Verification

- `agent-spec parse specs/p53-phase-3-candidate-evidence-audit.spec.md`
- `agent-spec lint specs/p53-phase-3-candidate-evidence-audit.spec.md --min-score 0.7`
- `rg -n "P53 Phase-3 candidate evidence audit|No Phase-3 candidate is ready for direct implementation yet" docs/MIND-MODEL-DESIGN.md`
- `rg -n "Recommended first Phase-3 track: runtime adoption evidence|runtime adoption evidence is the common measurement substrate" docs/MIND-MODEL-DESIGN.md`
- `rg -n "Card retrieval maturity: partial evidence from P43-P45|needs measured retrieval misses and context impact" docs/MIND-MODEL-DESIGN.md`
- `rg -n "Evaluator APIs: blocked on advisory output contracts and lifecycle replay requirements|Research adapter ingestion: blocked on an explicit external report/input contract" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p53-phase-3-candidate-evidence-audit|P53 phase 3 candidate evidence audit" AGENTS.md CLAUDE.md`
- `git diff --check`
