### PR TITLE
feat: add phase 3 runtime evidence gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,12 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p51-mind-model-closure-audit.spec.md` | 完成 | P51 mind model closure audit：确认 P12-P50 baseline 已完成，未来扩展必须开新阶段 spec |
 | `specs/p52-phase-3-intake-roadmap.spec.md` | 完成 | P52 phase 3 intake roadmap：定义 baseline 后新阶段候选轨道与 evidence/rollback/acceptance 入口规则 |
 | `specs/p53-phase-3-candidate-evidence-audit.spec.md` | 完成 | P53 phase 3 candidate evidence audit：评估 Phase-3 候选证据，推荐先做 runtime adoption evidence |
+| `specs/p54-runtime-adoption-evidence.spec.md` | 完成 | P54 runtime adoption evidence：schema v9 `runtime_adoption_events` + DB API |
+| `specs/p55-runtime-adoption-cli.spec.md` | 完成 | P55 runtime adoption CLI：`mempal phase3 adoption record/list/stats` |
+| `specs/p56-card-context-default-gate.spec.md` | 完成 | P56 card context default gate：read-only Phase-3 gate，不改 `include_cards` 默认值 |
+| `specs/p57-card-embedding-evidence-gate.spec.md` | 完成 | P57 card embedding evidence gate：card embeddings 需 measured miss evidence，未新增 vector schema |
+| `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
+| `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -158,6 +164,12 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-29-p51-mind-model-closure-audit.md` — P51 mind model closure audit（已完成）
 - `docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md` — P52 phase 3 intake roadmap（已完成）
 - `docs/plans/2026-05-02-p53-phase-3-candidate-evidence-audit.md` — P53 phase 3 candidate evidence audit（已完成）
+- `docs/plans/2026-05-02-p54-runtime-adoption-evidence.md` — P54 runtime adoption evidence（已完成）
+- `docs/plans/2026-05-02-p55-runtime-adoption-cli.md` — P55 runtime adoption CLI（已完成）
+- `docs/plans/2026-05-02-p56-card-context-default-gate.md` — P56 card context default gate（已完成）
+- `docs/plans/2026-05-02-p57-card-embedding-evidence-gate.md` — P57 card embedding evidence gate（已完成）
+- `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
+- `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 
 ### Spec 使用方式
 
@@ -168,7 +180,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 
 ## 关键架构约束
 
-- **存储**：SQLite + sqlite-vec，单文件 `~/.mempal/palace.db`，schema v8
+- **存储**：SQLite + sqlite-vec，单文件 `~/.mempal/palace.db`，schema v9
 - **嵌入**：model2vec-rs 默认（potion-multilingual-128M, 256d），可选 ort (ONNX) 通过 `onnx` feature flag
 - **搜索**：BM25 (FTS5) + 向量 + RRF 融合混合检索
 - **AAAK 是输出格式化器**：不被 ingest 或 search 依赖
@@ -224,7 +236,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 
 ```
 crates/
-├── mempal-core/      # 数据模型 + SQLite schema v8 + taxonomy + triples
+├── mempal-core/      # 数据模型 + SQLite schema v9 + taxonomy + triples
 ├── mempal-ingest/    # 导入管道
 ├── mempal-search/    # 混合搜索（BM25+向量+RRF）+ 路由 + tunnel hints
 ├── mempal-embed/     # 嵌入层（model2vec 默认, ort 可选）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,12 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p51-mind-model-closure-audit.spec.md` | 完成 | P51 mind model closure audit：确认 P12-P50 baseline 已完成，未来扩展必须开新阶段 spec |
 | `specs/p52-phase-3-intake-roadmap.spec.md` | 完成 | P52 phase 3 intake roadmap：定义 baseline 后新阶段候选轨道与 evidence/rollback/acceptance 入口规则 |
 | `specs/p53-phase-3-candidate-evidence-audit.spec.md` | 完成 | P53 phase 3 candidate evidence audit：评估 Phase-3 候选证据，推荐先做 runtime adoption evidence |
+| `specs/p54-runtime-adoption-evidence.spec.md` | 完成 | P54 runtime adoption evidence：schema v9 `runtime_adoption_events` + DB API |
+| `specs/p55-runtime-adoption-cli.spec.md` | 完成 | P55 runtime adoption CLI：`mempal phase3 adoption record/list/stats` |
+| `specs/p56-card-context-default-gate.spec.md` | 完成 | P56 card context default gate：read-only Phase-3 gate，不改 `include_cards` 默认值 |
+| `specs/p57-card-embedding-evidence-gate.spec.md` | 完成 | P57 card embedding evidence gate：card embeddings 需 measured miss evidence，未新增 vector schema |
+| `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
+| `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -156,6 +162,12 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-04-29-p51-mind-model-closure-audit.md` — P51 mind model closure audit（已完成）
 - `docs/plans/2026-05-01-p52-phase-3-intake-roadmap.md` — P52 phase 3 intake roadmap（已完成）
 - `docs/plans/2026-05-02-p53-phase-3-candidate-evidence-audit.md` — P53 phase 3 candidate evidence audit（已完成）
+- `docs/plans/2026-05-02-p54-runtime-adoption-evidence.md` — P54 runtime adoption evidence（已完成）
+- `docs/plans/2026-05-02-p55-runtime-adoption-cli.md` — P55 runtime adoption CLI（已完成）
+- `docs/plans/2026-05-02-p56-card-context-default-gate.md` — P56 card context default gate（已完成）
+- `docs/plans/2026-05-02-p57-card-embedding-evidence-gate.md` — P57 card embedding evidence gate（已完成）
+- `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
+- `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 
 ### Spec 使用方式
 
@@ -166,7 +178,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 
 ## 关键架构约束
 
-- **存储**：SQLite + sqlite-vec，单文件 `~/.mempal/palace.db`，schema v8
+- **存储**：SQLite + sqlite-vec，单文件 `~/.mempal/palace.db`，schema v9
 - **嵌入**：model2vec-rs 默认（potion-multilingual-128M, 256d），可选 ort (ONNX) 通过 `onnx` feature flag
 - **搜索**：BM25 (FTS5) + 向量 + RRF 融合混合检索
 - **AAAK 是输出格式化器**：不被 ingest 或 search 依赖
@@ -222,7 +234,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 
 ```
 crates/
-├── mempal-core/      # 数据模型 + SQLite schema v8 + taxonomy + triples
+├── mempal-core/      # 数据模型 + SQLite schema v9 + taxonomy + triples
 ├── mempal-ingest/    # 导入管道
 ├── mempal-search/    # 混合搜索（BM25+向量+RRF）+ 路由 + tunnel hints
 ├── mempal-embed/     # 嵌入层（model2vec 默认, ort 可选）

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1267,6 +1267,37 @@ Recommended first Phase-3 track: runtime adoption evidence. Runtime adoption evi
 This keeps Phase 3 evidence-first: implement measurement before implementing
 new authority, new retrieval defaults, or new external ingestion adapters.
 
+## Phase 3 Runtime Surfaces
+
+P54 runtime adoption evidence adds schema v9 table `runtime_adoption_events`.
+Events capture explicit agent/runtime signals with `track`, `signal`, `feature`,
+optional query/context/card/evaluator/research references, note, metadata, and
+timestamp.
+
+P55 runtime adoption CLI exposes this evidence substrate:
+
+- `mempal phase3 adoption record`
+- `mempal phase3 adoption list`
+- `mempal phase3 adoption stats`
+
+P56 implements `mempal phase3 gate card-context-default`. Card context default gate remains read-only; `include_cards` remains opt-in. The gate requires
+accepted `card_context` adoption evidence and zero rollback signals before a
+future default-on spec can even be considered.
+
+P57 implements `mempal phase3 gate card-embeddings`. The gate remains read-only
+and adds no card vector schema. Card embeddings require repeated measured
+`card_embedding` miss signals, and linked evidence remains the citation root.
+
+P58 implements `mempal phase3 gate evaluator-api`. Evaluator API gate remains advisory-only and preserves the P50 advisory-only lifecycle boundary: evaluator
+signals cannot mutate status, satisfy reviewer requirements, or bypass
+deterministic gates.
+
+P59 implements `mempal phase3 research-validate-plan`. The command validates an
+external JSON report/input contract with `report_id`, `title`, `sources`,
+`findings`, and optional `candidate_insights`. It only validates and plans;
+research adapter ingestion still preserves the P49 evidence-first boundary and
+does not create promoted/canonical knowledge.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-02-p54-runtime-adoption-evidence.md
+++ b/docs/plans/2026-05-02-p54-runtime-adoption-evidence.md
@@ -1,0 +1,14 @@
+# P54 Runtime Adoption Evidence
+
+## Goal
+
+Add schema v9 `runtime_adoption_events` and DB APIs for Phase-3 runtime
+adoption evidence.
+
+## Verification
+
+```bash
+agent-spec parse specs/p54-runtime-adoption-evidence.spec.md
+agent-spec lint specs/p54-runtime-adoption-evidence.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_runtime_adoption_event_roundtrip_db
+```

--- a/docs/plans/2026-05-02-p55-runtime-adoption-cli.md
+++ b/docs/plans/2026-05-02-p55-runtime-adoption-cli.md
@@ -1,0 +1,13 @@
+# P55 Runtime Adoption CLI
+
+## Goal
+
+Expose runtime adoption events through `mempal phase3 adoption record/list/stats`.
+
+## Verification
+
+```bash
+agent-spec parse specs/p55-runtime-adoption-cli.spec.md
+agent-spec lint specs/p55-runtime-adoption-cli.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_stats_and_gate
+```

--- a/docs/plans/2026-05-02-p56-card-context-default-gate.md
+++ b/docs/plans/2026-05-02-p56-card-context-default-gate.md
@@ -1,0 +1,14 @@
+# P56 Card Context Default Gate
+
+## Goal
+
+Add a read-only `mempal phase3 gate card-context-default` readiness check based
+on runtime adoption evidence.
+
+## Verification
+
+```bash
+agent-spec parse specs/p56-card-context-default-gate.spec.md
+agent-spec lint specs/p56-card-context-default-gate.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_stats_and_gate
+```

--- a/docs/plans/2026-05-02-p57-card-embedding-evidence-gate.md
+++ b/docs/plans/2026-05-02-p57-card-embedding-evidence-gate.md
@@ -1,0 +1,14 @@
+# P57 Card Embedding Evidence Gate
+
+## Goal
+
+Add a read-only `mempal phase3 gate card-embeddings` readiness check that
+requires measured miss evidence before card embeddings can be implemented.
+
+## Verification
+
+```bash
+agent-spec parse specs/p57-card-embedding-evidence-gate.spec.md
+agent-spec lint specs/p57-card-embedding-evidence-gate.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence
+```

--- a/docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md
+++ b/docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md
@@ -1,0 +1,14 @@
+# P58 Evaluator API Evidence Gate
+
+## Goal
+
+Add a read-only `mempal phase3 gate evaluator-api` readiness check that
+preserves evaluator advisory-only boundaries.
+
+## Verification
+
+```bash
+agent-spec parse specs/p58-evaluator-api-evidence-gate.spec.md
+agent-spec lint specs/p58-evaluator-api-evidence-gate.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_evaluator_gate_exists_and_is_read_only
+```

--- a/docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md
+++ b/docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md
@@ -1,0 +1,15 @@
+# P59 Research Adapter Ingestion Contract
+
+## Goal
+
+Add `mempal phase3 research-validate-plan` to validate external research report
+JSON before any future evidence-first ingestion implementation.
+
+## Verification
+
+```bash
+agent-spec parse specs/p59-research-adapter-ingestion-contract.spec.md
+agent-spec lint specs/p59-research-adapter-ingestion-contract.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_research_validate_plan
+cargo test --test phase3_runtime test_cli_phase3_research_validate_plan_reports_missing_fields
+```

--- a/specs/p54-runtime-adoption-evidence.spec.md
+++ b/specs/p54-runtime-adoption-evidence.spec.md
@@ -1,0 +1,55 @@
+spec: task
+name: "P54: runtime adoption evidence"
+inherits: project
+tags: [phase-3, runtime-adoption, schema]
+---
+
+## Intent
+
+P54 creates the evidence substrate recommended by P53. Runtime adoption signals
+are stored as first-class events so later Phase-3 decisions can depend on
+measured agent behavior instead of speculation.
+
+## Decisions
+
+- Add schema v9 table `runtime_adoption_events`.
+- Store `track`, `signal`, `feature`, optional query/context/card/evaluator/research refs, note, metadata, and timestamp.
+- Add DB APIs to insert and list runtime adoption events.
+- Keep events append-only by convention for Phase 3 evidence.
+
+## Boundaries
+
+### Allowed Changes
+- src/core/db.rs
+- src/core/types.rs
+- tests/phase3_runtime.rs
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not change knowledge lifecycle promotion gates.
+- Do not make card context default.
+- Do not add evaluator authority.
+
+## Acceptance Criteria
+
+Scenario: schema v9 stores runtime adoption events
+  Test:
+    Filter: cargo test --test phase3_runtime test_runtime_adoption_event_roundtrip_db
+  Given a new database
+  When opening it through `Database::open`
+  Then schema version is 9
+  And a runtime adoption event can be inserted and listed
+
+Scenario: runtime event table is documented
+  Test:
+    Filter: rg -n "P54 runtime adoption evidence|runtime_adoption_events|schema v9" docs/MIND-MODEL-DESIGN.md AGENTS.md CLAUDE.md
+  Given project documentation
+  When searching for P54
+  Then schema v9 and runtime adoption events are documented
+
+## Out of Scope
+
+- Automatic event capture.
+- Changing runtime behavior based on events.

--- a/specs/p55-runtime-adoption-cli.spec.md
+++ b/specs/p55-runtime-adoption-cli.spec.md
@@ -1,0 +1,53 @@
+spec: task
+name: "P55: runtime adoption CLI"
+inherits: project
+tags: [phase-3, runtime-adoption, cli]
+---
+
+## Intent
+
+P55 exposes the P54 evidence substrate through a minimal CLI so agents and
+hooks can explicitly record, inspect, and summarize runtime adoption events.
+
+## Decisions
+
+- Add `mempal phase3 adoption record`.
+- Add `mempal phase3 adoption list`.
+- Add `mempal phase3 adoption stats`.
+- CLI supports `plain` and `json` output where relevant.
+- Invalid tracks or signals are rejected by parsing.
+
+## Boundaries
+
+### Allowed Changes
+- src/main.rs
+- tests/phase3_runtime.rs
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not auto-record events from context/search by default.
+- Do not write lifecycle status from adoption events.
+
+## Acceptance Criteria
+
+Scenario: CLI records and summarizes adoption events
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_stats_and_gate
+  Given an empty mempal home
+  When recording card context adoption events
+  Then stats report accepted events
+  And gate evaluation can consume those events
+
+Scenario: invalid track is rejected
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_rejects_invalid_track
+  Given the CLI
+  When an unsupported track is supplied
+  Then the command exits with an error
+
+## Out of Scope
+
+- Background telemetry.
+- Network reporting.

--- a/specs/p56-card-context-default-gate.spec.md
+++ b/specs/p56-card-context-default-gate.spec.md
@@ -1,0 +1,53 @@
+spec: task
+name: "P56: card context default gate"
+inherits: project
+tags: [phase-3, card-context, gate]
+---
+
+## Intent
+
+P56 implements the decision gate required before card-aware context can become
+default. The gate reads P54/P55 adoption evidence and reports readiness without
+changing defaults.
+
+## Decisions
+
+- Add `mempal phase3 gate card-context-default`.
+- The gate is read-only.
+- The gate requires at least three accepted `card_context` signals and zero rollback signals.
+- Passing the gate does not change `include_cards` defaults.
+
+## Boundaries
+
+### Allowed Changes
+- src/main.rs
+- tests/phase3_runtime.rs
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not default-enable card-aware context.
+- Do not change `mempal context` or `mempal_context` defaults.
+
+## Acceptance Criteria
+
+Scenario: card context gate reads adoption evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_stats_and_gate
+  Given three accepted card context adoption events
+  When evaluating `card-context-default`
+  Then the gate reports `ready=true`
+  And the required track is `card_context`
+
+Scenario: card context remains explicit
+  Test:
+    Filter: rg -n "Card context default gate remains read-only|include_cards remains opt-in" docs/MIND-MODEL-DESIGN.md
+  Given the P56 documentation
+  When reading the card context gate policy
+  Then the default behavior remains unchanged
+
+## Out of Scope
+
+- Enabling card context by default.
+- Runtime telemetry capture.

--- a/specs/p57-card-embedding-evidence-gate.spec.md
+++ b/specs/p57-card-embedding-evidence-gate.spec.md
@@ -1,0 +1,53 @@
+spec: task
+name: "P57: card embedding evidence gate"
+inherits: project
+tags: [phase-3, card-embedding, gate]
+---
+
+## Intent
+
+P57 implements a read-only evidence gate for card embeddings. Card embeddings
+remain blocked until adoption evidence shows repeated linked-evidence retrieval
+misses.
+
+## Decisions
+
+- Add `mempal phase3 gate card-embeddings`.
+- The gate is read-only and does not add vector tables.
+- The gate requires at least three `card_embedding` miss signals and zero rollback signals.
+- Linked evidence remains the citation root.
+
+## Boundaries
+
+### Allowed Changes
+- src/main.rs
+- tests/phase3_runtime.rs
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not add `knowledge_card_vectors`.
+- Do not change retrieval ranking.
+- Do not change `mempal_search`.
+
+## Acceptance Criteria
+
+Scenario: card embedding gate blocks without miss evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence
+  Given no card embedding miss evidence
+  When evaluating `card-embeddings`
+  Then the gate reports `ready=false`
+
+Scenario: no card vector schema exists
+  Test:
+    Filter: "! rg -n \"knowledge_card_vectors|card_vectors\" src"
+  Given P57 implementation
+  When searching source
+  Then no card vector table exists
+
+## Out of Scope
+
+- Card embedding implementation.
+- Card reindexing.

--- a/specs/p58-evaluator-api-evidence-gate.spec.md
+++ b/specs/p58-evaluator-api-evidence-gate.spec.md
@@ -1,0 +1,53 @@
+spec: task
+name: "P58: evaluator API evidence gate"
+inherits: project
+tags: [phase-3, evaluator, gate]
+---
+
+## Intent
+
+P58 implements the first evaluator-facing Phase-3 surface as a read-only
+evidence gate. Evaluator APIs remain advisory-only and cannot mutate lifecycle
+state.
+
+## Decisions
+
+- Add `mempal phase3 gate evaluator-api`.
+- The gate reads `evaluator` adoption events.
+- The gate requires accepted evaluator advice and no rollback or contradiction signals.
+- P50 advisory-only lifecycle boundaries remain binding.
+
+## Boundaries
+
+### Allowed Changes
+- src/main.rs
+- tests/phase3_runtime.rs
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not add evaluator lifecycle write APIs.
+- Do not satisfy reviewer requirements through evaluator output.
+- Do not bypass deterministic gates.
+
+## Acceptance Criteria
+
+Scenario: evaluator gate is documented as advisory-only
+  Test:
+    Filter: rg -n "Evaluator API gate remains advisory-only|P50 advisory-only lifecycle boundary" docs/MIND-MODEL-DESIGN.md
+  Given P58 documentation
+  When reading evaluator gate policy
+  Then evaluator APIs remain advisory-only
+
+Scenario: evaluator gate exists
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_gate_exists_and_is_read_only
+  Given the CLI
+  When evaluating the evaluator API candidate
+  Then the command returns a read-only readiness report
+
+## Out of Scope
+
+- Evaluator scoring.
+- Evaluator-driven promotion.

--- a/specs/p59-research-adapter-ingestion-contract.spec.md
+++ b/specs/p59-research-adapter-ingestion-contract.spec.md
@@ -1,0 +1,55 @@
+spec: task
+name: "P59: research adapter ingestion contract"
+inherits: project
+tags: [phase-3, research, adapter]
+---
+
+## Intent
+
+P59 implements the first research adapter contract surface. External reports
+can be validated and planned, but validation does not ingest or promote
+knowledge.
+
+## Decisions
+
+- Add `mempal phase3 research-validate-plan`.
+- The accepted input is JSON with `report_id`, `title`, `sources`, `findings`, and optional `candidate_insights`.
+- Validation returns counts and errors in plain or JSON output.
+- Research adapter work preserves P49 evidence-first boundaries.
+
+## Boundaries
+
+### Allowed Changes
+- src/main.rs
+- tests/phase3_runtime.rs
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not ingest research reports automatically.
+- Do not create `dao_tian`, canonical, or promoted knowledge.
+- Do not bypass distill or lifecycle gates.
+
+## Acceptance Criteria
+
+Scenario: valid research report is accepted for planning
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_validate_plan
+  Given a valid research report JSON file
+  When running `mempal phase3 research-validate-plan`
+  Then the report is marked valid
+  And source/finding/candidate counts are returned
+
+Scenario: invalid research report reports missing fields
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_validate_plan_reports_missing_fields
+  Given an invalid research report JSON file
+  When validating the plan
+  Then the command succeeds with `valid=false`
+  And missing fields are reported
+
+## Out of Scope
+
+- Research ingestion execution.
+- Research-driven promotion.

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -12,12 +12,13 @@ use super::types::{
     AnchorKind, ChunkNeighbors, Drawer, ExplicitTunnel, KnowledgeCard, KnowledgeCardEvent,
     KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
     KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, NeighborChunk, Provenance,
-    ReindexSource, SourceType, TaxonomyEntry, Triple, TripleStats, TunnelEndpoint,
+    ReindexSource, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
+    RuntimeAdoptionTrack, SourceType, TaxonomyEntry, Triple, TripleStats, TunnelEndpoint,
     TunnelFollowResult,
 };
 use super::utils::{build_tunnel_id, current_timestamp, format_tunnel_endpoint};
 
-const CURRENT_SCHEMA_VERSION: u32 = 8;
+const CURRENT_SCHEMA_VERSION: u32 = 9;
 const DRAWER_SELECT_COLUMNS: &str = r#"
     id,
     content,
@@ -862,6 +863,84 @@ impl Database {
         self.conn
             .query_row("SELECT COUNT(*) FROM knowledge_cards", [], |row| row.get(0))
             .map_err(Into::into)
+    }
+
+    pub fn insert_runtime_adoption_event(
+        &self,
+        event: &RuntimeAdoptionEvent,
+    ) -> Result<(), DbError> {
+        self.conn.execute(
+            r#"
+            INSERT INTO runtime_adoption_events (
+                id,
+                track,
+                signal,
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+                created_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+            "#,
+            params![
+                event.id.as_str(),
+                runtime_adoption_track_as_str(&event.track),
+                runtime_adoption_signal_as_str(&event.signal),
+                event.feature.as_str(),
+                event.query.as_deref(),
+                event.context_hash.as_deref(),
+                event.card_id.as_deref(),
+                event.evaluator_id.as_deref(),
+                event.research_report_id.as_deref(),
+                event.note.as_deref(),
+                encode_optional_json(event.metadata.as_ref())?,
+                event.created_at.as_str(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_runtime_adoption_events(
+        &self,
+        filter: &RuntimeAdoptionFilter,
+        limit: usize,
+    ) -> Result<Vec<RuntimeAdoptionEvent>, DbError> {
+        let track = filter.track.as_ref().map(runtime_adoption_track_as_str);
+        let limit =
+            i64::try_from(limit).map_err(|_| DbError::InvalidSourceType("limit".to_string()))?;
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT
+                id,
+                track,
+                signal,
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+                created_at
+            FROM runtime_adoption_events
+            WHERE (?1 IS NULL OR track = ?1)
+              AND (?2 IS NULL OR feature = ?2)
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?3
+            "#,
+        )?;
+        let rows = statement
+            .query_map(params![track, filter.feature.as_deref(), limit], |row| {
+                runtime_adoption_event_from_row(row).map_err(row_decode_error)
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     pub fn list_knowledge_drawers_for_card_backfill(
@@ -1894,6 +1973,33 @@ BEGIN
 END;
 "#;
 
+const V9_MIGRATION_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS runtime_adoption_events (
+    id TEXT PRIMARY KEY,
+    track TEXT NOT NULL CHECK(track IN ('runtime_adoption', 'card_context', 'card_embedding', 'evaluator', 'research_adapter')),
+    signal TEXT NOT NULL CHECK(signal IN ('used', 'accepted', 'rejected', 'miss', 'rollback', 'contradiction', 'neutral')),
+    feature TEXT NOT NULL,
+    query TEXT,
+    context_hash TEXT,
+    card_id TEXT,
+    evaluator_id TEXT,
+    research_report_id TEXT,
+    note TEXT,
+    metadata TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(card_id) REFERENCES knowledge_cards(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_adoption_events_track_created_at
+    ON runtime_adoption_events(track, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_adoption_events_feature
+    ON runtime_adoption_events(feature);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_adoption_events_signal
+    ON runtime_adoption_events(signal);
+"#;
+
 fn migrations() -> &'static [Migration] {
     static MIGRATIONS: &[Migration] = &[
         Migration {
@@ -1927,6 +2033,10 @@ fn migrations() -> &'static [Migration] {
         Migration {
             version: 8,
             sql: V8_MIGRATION_SQL,
+        },
+        Migration {
+            version: 9,
+            sql: V9_MIGRATION_SQL,
         },
     ];
     MIGRATIONS
@@ -2150,6 +2260,58 @@ fn knowledge_event_type_from_str(event_type: &str) -> Result<KnowledgeEventType,
     }
 }
 
+fn runtime_adoption_track_as_str(track: &RuntimeAdoptionTrack) -> &'static str {
+    match track {
+        RuntimeAdoptionTrack::RuntimeAdoption => "runtime_adoption",
+        RuntimeAdoptionTrack::CardContext => "card_context",
+        RuntimeAdoptionTrack::CardEmbedding => "card_embedding",
+        RuntimeAdoptionTrack::Evaluator => "evaluator",
+        RuntimeAdoptionTrack::ResearchAdapter => "research_adapter",
+    }
+}
+
+fn runtime_adoption_track_from_str(track: &str) -> Result<RuntimeAdoptionTrack, DbError> {
+    match track {
+        "runtime_adoption" => Ok(RuntimeAdoptionTrack::RuntimeAdoption),
+        "card_context" => Ok(RuntimeAdoptionTrack::CardContext),
+        "card_embedding" => Ok(RuntimeAdoptionTrack::CardEmbedding),
+        "evaluator" => Ok(RuntimeAdoptionTrack::Evaluator),
+        "research_adapter" => Ok(RuntimeAdoptionTrack::ResearchAdapter),
+        other => Err(DbError::InvalidEnumValue {
+            kind: "runtime_adoption_track",
+            value: other.to_string(),
+        }),
+    }
+}
+
+fn runtime_adoption_signal_as_str(signal: &RuntimeAdoptionSignal) -> &'static str {
+    match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    }
+}
+
+fn runtime_adoption_signal_from_str(signal: &str) -> Result<RuntimeAdoptionSignal, DbError> {
+    match signal {
+        "used" => Ok(RuntimeAdoptionSignal::Used),
+        "accepted" => Ok(RuntimeAdoptionSignal::Accepted),
+        "rejected" => Ok(RuntimeAdoptionSignal::Rejected),
+        "miss" => Ok(RuntimeAdoptionSignal::Miss),
+        "rollback" => Ok(RuntimeAdoptionSignal::Rollback),
+        "contradiction" => Ok(RuntimeAdoptionSignal::Contradiction),
+        "neutral" => Ok(RuntimeAdoptionSignal::Neutral),
+        other => Err(DbError::InvalidEnumValue {
+            kind: "runtime_adoption_signal",
+            value: other.to_string(),
+        }),
+    }
+}
+
 fn encode_json<T: serde::Serialize + ?Sized>(value: &T) -> Result<String, DbError> {
     Ok(serde_json::to_string(value)?)
 }
@@ -2240,6 +2402,24 @@ fn knowledge_event_from_row(row: &Row<'_>) -> Result<KnowledgeCardEvent, DbError
         actor: row.get(6)?,
         metadata,
         created_at: row.get(8)?,
+    })
+}
+
+fn runtime_adoption_event_from_row(row: &Row<'_>) -> Result<RuntimeAdoptionEvent, DbError> {
+    let metadata = parse_optional_json(row.get::<_, Option<String>>(10)?.as_deref())?;
+    Ok(RuntimeAdoptionEvent {
+        id: row.get(0)?,
+        track: runtime_adoption_track_from_str(&row.get::<_, String>(1)?)?,
+        signal: runtime_adoption_signal_from_str(&row.get::<_, String>(2)?)?,
+        feature: row.get(3)?,
+        query: row.get(4)?,
+        context_hash: row.get(5)?,
+        card_id: row.get(6)?,
+        evaluator_id: row.get(7)?,
+        research_report_id: row.get(8)?,
+        note: row.get(9)?,
+        metadata,
+        created_at: row.get(11)?,
     })
 }
 

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -493,10 +493,10 @@ mod tests {
     }
 
     #[test]
-    fn protocol_update_does_not_change_schema_version() {
+    fn protocol_schema_version_matches_phase3_runtime_events() {
         let tempdir = tempfile::tempdir().expect("create temp dir");
         let db_path = tempdir.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
-        assert_eq!(db.schema_version().expect("schema version"), 8);
+        assert_eq!(db.schema_version().expect("schema version"), 9);
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -90,6 +90,50 @@ pub enum KnowledgeEventType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeAdoptionTrack {
+    RuntimeAdoption,
+    CardContext,
+    CardEmbedding,
+    Evaluator,
+    ResearchAdapter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeAdoptionSignal {
+    Used,
+    Accepted,
+    Rejected,
+    Miss,
+    Rollback,
+    Contradiction,
+    Neutral,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeAdoptionEvent {
+    pub id: String,
+    pub track: RuntimeAdoptionTrack,
+    pub signal: RuntimeAdoptionSignal,
+    pub feature: String,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuntimeAdoptionFilter {
+    pub track: Option<RuntimeAdoptionTrack>,
+    pub feature: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KnowledgeCard {
     pub id: String,
     pub statement: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,8 @@ use mempal::core::{
     types::{
         AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
         KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain,
-        MemoryKind, TaxonomyEntry, TriggerHints, TunnelEndpoint,
+        MemoryKind, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
+        RuntimeAdoptionTrack, TaxonomyEntry, TriggerHints, TunnelEndpoint,
     },
     utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
 };
@@ -168,6 +169,10 @@ enum Commands {
     KnowledgeCard {
         #[command(subcommand)]
         command: KnowledgeCardCommands,
+    },
+    Phase3 {
+        #[command(subcommand)]
+        command: Phase3Commands,
     },
     Tunnels {
         #[command(subcommand)]
@@ -549,6 +554,74 @@ enum KnowledgeCardCommands {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)] // clap command enums favor direct argument fields over boxing.
+enum Phase3Commands {
+    Adoption {
+        #[command(subcommand)]
+        command: Phase3AdoptionCommands,
+    },
+    Gate {
+        candidate: String,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    ResearchValidatePlan {
+        path: PathBuf,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)] // `record` intentionally carries the full event payload.
+enum Phase3AdoptionCommands {
+    Record {
+        #[arg(long)]
+        track: String,
+        #[arg(long)]
+        signal: String,
+        #[arg(long)]
+        feature: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    List {
+        #[arg(long)]
+        track: Option<String>,
+        #[arg(long)]
+        feature: Option<String>,
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Stats {
+        #[arg(long)]
+        track: Option<String>,
+        #[arg(long)]
+        feature: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum TunnelCommands {
     Add {
         #[arg(long)]
@@ -737,6 +810,7 @@ async fn run() -> Result<()> {
         Commands::Kg { command } => kg_command(&db, command),
         Commands::Knowledge { command } => knowledge_command(&db, &config, command).await,
         Commands::KnowledgeCard { command } => knowledge_card_command(&db, &config, command).await,
+        Commands::Phase3 { command } => phase3_command(&db, command),
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::FieldTaxonomy { format } => field_taxonomy_command(&format),
@@ -1318,6 +1392,52 @@ fn parse_knowledge_event_type(value: &str) -> Result<KnowledgeEventType> {
         "updated" => Ok(KnowledgeEventType::Updated),
         "published_anchor" => Ok(KnowledgeEventType::PublishedAnchor),
         other => bail!("unsupported knowledge event type: {other}"),
+    }
+}
+
+fn runtime_adoption_track_slug(value: &RuntimeAdoptionTrack) -> &'static str {
+    match value {
+        RuntimeAdoptionTrack::RuntimeAdoption => "runtime_adoption",
+        RuntimeAdoptionTrack::CardContext => "card_context",
+        RuntimeAdoptionTrack::CardEmbedding => "card_embedding",
+        RuntimeAdoptionTrack::Evaluator => "evaluator",
+        RuntimeAdoptionTrack::ResearchAdapter => "research_adapter",
+    }
+}
+
+fn parse_runtime_adoption_track(value: &str) -> Result<RuntimeAdoptionTrack> {
+    match value {
+        "runtime_adoption" => Ok(RuntimeAdoptionTrack::RuntimeAdoption),
+        "card_context" => Ok(RuntimeAdoptionTrack::CardContext),
+        "card_embedding" => Ok(RuntimeAdoptionTrack::CardEmbedding),
+        "evaluator" => Ok(RuntimeAdoptionTrack::Evaluator),
+        "research_adapter" => Ok(RuntimeAdoptionTrack::ResearchAdapter),
+        other => bail!("unsupported runtime adoption track: {other}"),
+    }
+}
+
+fn runtime_adoption_signal_slug(value: &RuntimeAdoptionSignal) -> &'static str {
+    match value {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    }
+}
+
+fn parse_runtime_adoption_signal(value: &str) -> Result<RuntimeAdoptionSignal> {
+    match value {
+        "used" => Ok(RuntimeAdoptionSignal::Used),
+        "accepted" => Ok(RuntimeAdoptionSignal::Accepted),
+        "rejected" => Ok(RuntimeAdoptionSignal::Rejected),
+        "miss" => Ok(RuntimeAdoptionSignal::Miss),
+        "rollback" => Ok(RuntimeAdoptionSignal::Rollback),
+        "contradiction" => Ok(RuntimeAdoptionSignal::Contradiction),
+        "neutral" => Ok(RuntimeAdoptionSignal::Neutral),
+        other => bail!("unsupported runtime adoption signal: {other}"),
     }
 }
 
@@ -2041,6 +2161,405 @@ async fn knowledge_card_command(
     }
 
     Ok(())
+}
+
+fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
+    match command {
+        Phase3Commands::Adoption { command } => phase3_adoption_command(db, command),
+        Phase3Commands::Gate { candidate, format } => {
+            let report = phase3_gate_report(db, &candidate)?;
+            print_phase3_gate_report(&report, &format)
+        }
+        Phase3Commands::ResearchValidatePlan { path, format } => {
+            let report = validate_research_adapter_plan(&path)?;
+            print_research_adapter_plan(&report, &format)
+        }
+    }
+}
+
+fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Result<()> {
+    match command {
+        Phase3AdoptionCommands::Record {
+            track,
+            signal,
+            feature,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            format,
+        } => {
+            let track = parse_runtime_adoption_track(&track)?;
+            let signal = parse_runtime_adoption_signal(&signal)?;
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let created_at = current_timestamp();
+            let nonce = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|duration| duration.as_nanos().to_string())
+                .unwrap_or_else(|_| "0".to_string());
+            let id = id.unwrap_or_else(|| {
+                stable_cli_id(
+                    "adoption",
+                    &[
+                        runtime_adoption_track_slug(&track),
+                        runtime_adoption_signal_slug(&signal),
+                        feature.as_str(),
+                        query.as_deref().unwrap_or(""),
+                        context_hash.as_deref().unwrap_or(""),
+                        card_id.as_deref().unwrap_or(""),
+                        evaluator_id.as_deref().unwrap_or(""),
+                        research_report_id.as_deref().unwrap_or(""),
+                        created_at.as_str(),
+                        nonce.as_str(),
+                    ],
+                )
+            });
+            let event = RuntimeAdoptionEvent {
+                id: id.clone(),
+                track,
+                signal,
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+                created_at,
+            };
+            db.insert_runtime_adoption_event(&event)
+                .context("failed to insert runtime adoption event")?;
+            match format.as_str() {
+                "plain" => println!("event_id={id} created=true"),
+                "json" => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&event)
+                        .context("failed to serialize adoption event")?
+                ),
+                other => bail!("unsupported phase3 adoption format: {other}"),
+            }
+            Ok(())
+        }
+        Phase3AdoptionCommands::List {
+            track,
+            feature,
+            limit,
+            format,
+        } => {
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: track
+                            .as_deref()
+                            .map(parse_runtime_adoption_track)
+                            .transpose()?,
+                        feature,
+                    },
+                    limit,
+                )
+                .context("failed to list runtime adoption events")?;
+            print_runtime_adoption_events(&events, &format)
+        }
+        Phase3AdoptionCommands::Stats {
+            track,
+            feature,
+            format,
+        } => {
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: track
+                            .as_deref()
+                            .map(parse_runtime_adoption_track)
+                            .transpose()?,
+                        feature,
+                    },
+                    10_000,
+                )
+                .context("failed to list runtime adoption events")?;
+            let stats = RuntimeAdoptionStats::from_events(&events);
+            print_runtime_adoption_stats(&stats, &format)
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeAdoptionStats {
+    total: usize,
+    used: usize,
+    accepted: usize,
+    rejected: usize,
+    misses: usize,
+    rollbacks: usize,
+    contradictions: usize,
+    neutral: usize,
+}
+
+impl RuntimeAdoptionStats {
+    fn from_events(events: &[RuntimeAdoptionEvent]) -> Self {
+        let mut stats = Self {
+            total: events.len(),
+            used: 0,
+            accepted: 0,
+            rejected: 0,
+            misses: 0,
+            rollbacks: 0,
+            contradictions: 0,
+            neutral: 0,
+        };
+        for event in events {
+            match event.signal {
+                RuntimeAdoptionSignal::Used => stats.used += 1,
+                RuntimeAdoptionSignal::Accepted => stats.accepted += 1,
+                RuntimeAdoptionSignal::Rejected => stats.rejected += 1,
+                RuntimeAdoptionSignal::Miss => stats.misses += 1,
+                RuntimeAdoptionSignal::Rollback => stats.rollbacks += 1,
+                RuntimeAdoptionSignal::Contradiction => stats.contradictions += 1,
+                RuntimeAdoptionSignal::Neutral => stats.neutral += 1,
+            }
+        }
+        stats
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Phase3GateReport {
+    candidate: String,
+    ready: bool,
+    required_track: &'static str,
+    stats: RuntimeAdoptionStats,
+    reasons: Vec<String>,
+}
+
+fn phase3_gate_report(db: &Database, candidate: &str) -> Result<Phase3GateReport> {
+    let (track, ready_fn): (RuntimeAdoptionTrack, fn(&RuntimeAdoptionStats) -> bool) =
+        match candidate {
+            "card-context-default" => (RuntimeAdoptionTrack::CardContext, |stats| {
+                stats.accepted >= 3 && stats.rollbacks == 0 && stats.rejected <= stats.accepted
+            }),
+            "card-embeddings" => (RuntimeAdoptionTrack::CardEmbedding, |stats| {
+                stats.misses >= 3 && stats.rollbacks == 0
+            }),
+            "evaluator-api" => (RuntimeAdoptionTrack::Evaluator, |stats| {
+                stats.accepted >= 3 && stats.rollbacks == 0 && stats.contradictions == 0
+            }),
+            "research-adapter" => (RuntimeAdoptionTrack::ResearchAdapter, |stats| {
+                stats.accepted >= 1 && stats.contradictions == 0 && stats.rollbacks == 0
+            }),
+            other => bail!("unsupported phase3 candidate: {other}"),
+        };
+    let events = db
+        .list_runtime_adoption_events(
+            &RuntimeAdoptionFilter {
+                track: Some(track.clone()),
+                feature: None,
+            },
+            10_000,
+        )
+        .context("failed to list runtime adoption events")?;
+    let stats = RuntimeAdoptionStats::from_events(&events);
+    let ready = ready_fn(&stats);
+    let mut reasons = Vec::new();
+    if ready {
+        reasons.push("minimum evidence threshold satisfied".to_string());
+    } else {
+        reasons.push("minimum evidence threshold not satisfied".to_string());
+    }
+    if stats.rollbacks > 0 {
+        reasons.push("rollback signals block default or authority changes".to_string());
+    }
+    if stats.contradictions > 0 {
+        reasons.push("contradiction signals require review before implementation".to_string());
+    }
+    Ok(Phase3GateReport {
+        candidate: candidate.to_string(),
+        ready,
+        required_track: runtime_adoption_track_slug(&track),
+        stats,
+        reasons,
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct ResearchAdapterPlanReport {
+    valid: bool,
+    report_id: String,
+    title: String,
+    source_count: usize,
+    finding_count: usize,
+    candidate_insight_count: usize,
+    errors: Vec<String>,
+}
+
+fn validate_research_adapter_plan(path: &Path) -> Result<ResearchAdapterPlanReport> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read research report {}", path.display()))?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse research report {}", path.display()))?;
+    let mut errors = Vec::new();
+    let report_id = required_string(&value, "report_id", &mut errors);
+    let title = required_string(&value, "title", &mut errors);
+    let sources = value
+        .get("sources")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    if sources == 0 {
+        errors.push("sources must contain at least one item".to_string());
+    }
+    let findings = value
+        .get("findings")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    if findings == 0 {
+        errors.push("findings must contain at least one item".to_string());
+    }
+    let candidate_insights = value
+        .get("candidate_insights")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    Ok(ResearchAdapterPlanReport {
+        valid: errors.is_empty(),
+        report_id,
+        title,
+        source_count: sources,
+        finding_count: findings,
+        candidate_insight_count: candidate_insights,
+        errors,
+    })
+}
+
+fn required_string(
+    value: &serde_json::Value,
+    field: &'static str,
+    errors: &mut Vec<String>,
+) -> String {
+    match value.get(field).and_then(serde_json::Value::as_str) {
+        Some(raw) if !raw.trim().is_empty() => raw.trim().to_string(),
+        _ => {
+            errors.push(format!("{field} is required"));
+            String::new()
+        }
+    }
+}
+
+fn print_runtime_adoption_events(events: &[RuntimeAdoptionEvent], format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            if events.is_empty() {
+                println!("no runtime adoption events");
+                return Ok(());
+            }
+            for event in events {
+                println!(
+                    "{} track={} signal={} feature={} at={}",
+                    event.id,
+                    runtime_adoption_track_slug(&event.track),
+                    runtime_adoption_signal_slug(&event.signal),
+                    event.feature,
+                    event.created_at
+                );
+                if let Some(note) = event.note.as_deref() {
+                    println!("  note: {note}");
+                }
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(events)
+                    .context("failed to serialize runtime adoption events")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
+    }
+}
+
+fn print_runtime_adoption_stats(stats: &RuntimeAdoptionStats, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("total={}", stats.total);
+            println!("used={}", stats.used);
+            println!("accepted={}", stats.accepted);
+            println!("rejected={}", stats.rejected);
+            println!("misses={}", stats.misses);
+            println!("rollbacks={}", stats.rollbacks);
+            println!("contradictions={}", stats.contradictions);
+            println!("neutral={}", stats.neutral);
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(stats)
+                    .context("failed to serialize runtime adoption stats")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
+    }
+}
+
+fn print_phase3_gate_report(report: &Phase3GateReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("candidate={}", report.candidate);
+            println!("ready={}", report.ready);
+            println!("required_track={}", report.required_track);
+            println!("accepted={}", report.stats.accepted);
+            println!("misses={}", report.stats.misses);
+            println!("rollbacks={}", report.stats.rollbacks);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize phase3 gate report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 gate format: {other}"),
+    }
+}
+
+fn print_research_adapter_plan(report: &ResearchAdapterPlanReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("valid={}", report.valid);
+            println!("report_id={}", report.report_id);
+            println!("title={}", report.title);
+            println!("source_count={}", report.source_count);
+            println!("finding_count={}", report.finding_count);
+            println!("candidate_insight_count={}", report.candidate_insight_count);
+            for error in &report.errors {
+                println!("error={error}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize research adapter plan")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported research adapter plan format: {other}"),
+    }
 }
 
 fn normalized_nonempty_strings(values: &[String]) -> Vec<String> {

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -981,10 +981,10 @@ async fn test_context_assembler_returns_typed_pack() {
 #[test]
 fn test_context_assembler_does_not_bump_schema() {
     let (tmp, db) = setup_cli_home();
-    assert_eq!(db.schema_version().expect("schema"), 8);
+    assert_eq!(db.schema_version().expect("schema"), 9);
     let before_tables = table_names(&db);
     let _ = run_context_plain(tmp.path(), "debug", &[]);
-    assert_eq!(db.schema_version().expect("schema"), 8);
+    assert_eq!(db.schema_version().expect("schema"), 9);
     assert_eq!(table_names(&db), before_tables);
 }
 

--- a/tests/knowledge_card_schema.rs
+++ b/tests/knowledge_card_schema.rs
@@ -245,28 +245,29 @@ fn insert_event(
 }
 
 #[test]
-fn test_new_database_schema_version_is_8() {
+fn test_new_database_schema_version_is_9() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 8);
+    assert_eq!(db.schema_version().expect("schema version"), 9);
     for table in [
         "knowledge_cards",
         "knowledge_evidence_links",
         "knowledge_events",
+        "runtime_adoption_events",
     ] {
         assert!(table_exists(&db, table), "{table} should exist");
     }
 }
 
 #[test]
-fn test_migration_v7_to_v8_adds_knowledge_card_tables_without_data_loss() {
+fn test_migration_v7_to_v9_adds_phase2_and_phase3_tables_without_data_loss() {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
     create_v7_db(&db_path);
 
     let db = Database::open(&db_path).expect("migrate v7 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 8);
+    assert_eq!(db.schema_version().expect("schema version"), 9);
     assert_eq!(db.drawer_count().expect("drawer count"), 1);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let taxonomy_count: i64 = db
@@ -284,6 +285,7 @@ fn test_migration_v7_to_v8_adds_knowledge_card_tables_without_data_loss() {
         "knowledge_cards",
         "knowledge_evidence_links",
         "knowledge_events",
+        "runtime_adoption_events",
     ] {
         let count: i64 = db
             .conn()

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -545,7 +545,7 @@ fn test_migration_backfills_legacy_drawers_with_bootstrap_defaults() {
     }
 
     let db = Database::open(&db_path).expect("migrate db to latest");
-    assert_eq!(db.schema_version().expect("schema version"), 8);
+    assert_eq!(db.schema_version().expect("schema version"), 9);
 
     let drawer = db
         .get_drawer("drawer_legacy_001")

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -245,7 +245,7 @@ fn test_migration_v6_to_v7_stamps_normalize_version_1() {
 
     let db = Database::open(&db_path).expect("migrate v6 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 8);
+    assert_eq!(db.schema_version().expect("schema version"), 9);
     assert_eq!(db.drawer_count().expect("drawer count"), 20);
     assert_eq!(count_normalize_version(&db, 1), 20);
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -1,0 +1,247 @@
+use std::fs;
+use std::process::Command;
+
+use mempal::core::db::Database;
+use mempal::core::types::{
+    RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack,
+};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_cli_home() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join(".mempal")).expect("create .mempal");
+    tmp
+}
+
+fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal")
+}
+
+#[test]
+fn test_runtime_adoption_event_roundtrip_db() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    assert_eq!(db.schema_version().expect("schema version"), 9);
+
+    let event = RuntimeAdoptionEvent {
+        id: "adoption_test".to_string(),
+        track: RuntimeAdoptionTrack::RuntimeAdoption,
+        signal: RuntimeAdoptionSignal::Accepted,
+        feature: "context-pack".to_string(),
+        query: Some("how should the agent choose skills?".to_string()),
+        context_hash: Some("ctx123".to_string()),
+        card_id: None,
+        evaluator_id: None,
+        research_report_id: None,
+        note: Some("agent used the context pack".to_string()),
+        metadata: Some(json!({"source": "test"})),
+        created_at: "1777710000".to_string(),
+    };
+    db.insert_runtime_adoption_event(&event)
+        .expect("insert adoption event");
+
+    let events = db
+        .list_runtime_adoption_events(
+            &RuntimeAdoptionFilter {
+                track: Some(RuntimeAdoptionTrack::RuntimeAdoption),
+                feature: Some("context-pack".to_string()),
+            },
+            10,
+        )
+        .expect("list adoption events");
+    assert_eq!(events, vec![event]);
+}
+
+#[test]
+fn test_cli_phase3_adoption_record_stats_and_gate() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        let id = format!("card_context_accept_{i}");
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                &id,
+                "--track",
+                "card_context",
+                "--signal",
+                "accepted",
+                "--feature",
+                "include_cards",
+                "--query",
+                "skill trigger context",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let stats = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "stats",
+            "--track",
+            "card_context",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        stats.status.success(),
+        "stats failed: {}",
+        String::from_utf8_lossy(&stats.stderr)
+    );
+    let stats_json: Value = serde_json::from_slice(&stats.stdout).expect("stats json");
+    assert_eq!(stats_json["accepted"], 3);
+    assert_eq!(stats_json["rollbacks"], 0);
+
+    let gate = run_mempal(
+        &home,
+        &["phase3", "gate", "card-context-default", "--format", "json"],
+    );
+    assert!(
+        gate.status.success(),
+        "gate failed: {}",
+        String::from_utf8_lossy(&gate.stderr)
+    );
+    let gate_json: Value = serde_json::from_slice(&gate.stdout).expect("gate json");
+    assert_eq!(gate_json["ready"], true);
+    assert_eq!(gate_json["required_track"], "card_context");
+}
+
+#[test]
+fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
+    let home = setup_cli_home();
+    let gate = run_mempal(
+        &home,
+        &["phase3", "gate", "card-embeddings", "--format", "json"],
+    );
+    assert!(
+        gate.status.success(),
+        "gate failed: {}",
+        String::from_utf8_lossy(&gate.stderr)
+    );
+    let gate_json: Value = serde_json::from_slice(&gate.stdout).expect("gate json");
+    assert_eq!(gate_json["ready"], false);
+    assert_eq!(gate_json["stats"]["misses"], 0);
+}
+
+#[test]
+fn test_cli_phase3_evaluator_gate_exists_and_is_read_only() {
+    let home = setup_cli_home();
+    let gate = run_mempal(
+        &home,
+        &["phase3", "gate", "evaluator-api", "--format", "json"],
+    );
+    assert!(
+        gate.status.success(),
+        "gate failed: {}",
+        String::from_utf8_lossy(&gate.stderr)
+    );
+    let gate_json: Value = serde_json::from_slice(&gate.stdout).expect("gate json");
+    assert_eq!(gate_json["candidate"], "evaluator-api");
+    assert_eq!(gate_json["ready"], false);
+    assert_eq!(gate_json["required_track"], "evaluator");
+}
+
+#[test]
+fn test_cli_phase3_adoption_record_rejects_invalid_track() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record",
+            "--track",
+            "invalid",
+            "--signal",
+            "accepted",
+            "--feature",
+            "x",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported runtime adoption track"));
+}
+
+#[test]
+fn test_cli_phase3_research_validate_plan() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("research-report.json");
+    fs::write(
+        &report_path,
+        json!({
+            "report_id": "research_001",
+            "title": "Agent memory retrieval notes",
+            "sources": [{"url": "https://example.invalid/report"}],
+            "findings": [{"summary": "linked evidence retrieval needs adoption evidence"}],
+            "candidate_insights": [{"statement": "measure before defaulting cards"}]
+        })
+        .to_string(),
+    )
+    .expect("write report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-validate-plan",
+            report_path.to_str().expect("report path"),
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "validate-plan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("plan json");
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["source_count"], 1);
+    assert_eq!(report["candidate_insight_count"], 1);
+}
+
+#[test]
+fn test_cli_phase3_research_validate_plan_reports_missing_fields() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("bad-research-report.json");
+    fs::write(&report_path, "{}").expect("write bad report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-validate-plan",
+            report_path.to_str().expect("report path"),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "validate-plan should report invalid input without failing: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("valid=false"));
+    assert!(stdout.contains("error=report_id is required"));
+    assert!(stdout.contains("error=sources must contain at least one item"));
+}

--- a/tests/search_neighbors.rs
+++ b/tests/search_neighbors.rs
@@ -291,7 +291,7 @@ async fn test_neighbors_limited_to_same_wing() {
 fn test_current_schema_has_chunk_index() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 8);
+    assert_eq!(db.schema_version().expect("schema version"), 9);
     let exists: bool = db
         .conn()
         .query_row(

--- a/tests/tunnels_explicit.rs
+++ b/tests/tunnels_explicit.rs
@@ -203,7 +203,7 @@ fn test_schema_v5_to_v6_migration_preserves_data() {
 
     let db = Database::open(&db_path).expect("migrate v5 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 8);
+    assert_eq!(db.schema_version().expect("schema version"), 9);
     assert_eq!(db.drawer_count().expect("drawer count"), 2);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let tunnels_count: i64 = db


### PR DESCRIPTION
## Summary

Implements the P54-P59 Phase 3 runtime baseline:

- P54 schema v9 `runtime_adoption_events` evidence substrate + DB API.
- P55 `mempal phase3 adoption record/list/stats` CLI.
- P56 read-only `card-context-default` evidence gate; card context remains opt-in.
- P57 read-only `card-embeddings` evidence gate; no card vector schema added.
- P58 advisory-only `evaluator-api` gate preserving P50 lifecycle boundaries.
- P59 `research-validate-plan` contract for external research report ingestion planning.

## Verification

- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --test phase3_runtime`
- `cargo test`
- `agent-spec parse/lint specs/p54..p59`
- Boundary grep for schema v9 docs, opt-in card context, no card vectors, evaluator advisory-only, and P49 research evidence-first boundary.
