### PR TITLE
feat: expose phase 3 runtime evidence over MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p57-card-embedding-evidence-gate.spec.md` | 完成 | P57 card embedding evidence gate：card embeddings 需 measured miss evidence，未新增 vector schema |
 | `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
+| `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -170,6 +171,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p57-card-embedding-evidence-gate.md` — P57 card embedding evidence gate（已完成）
 - `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
+- `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 
 ### Spec 使用方式
 
@@ -188,9 +190,9 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，17 条规则
 
-## MCP 工具（18 个）
+## MCP 工具（19 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -205,6 +207,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：record/list/stats/gate/research_validate_plan（P60） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p57-card-embedding-evidence-gate.spec.md` | 完成 | P57 card embedding evidence gate：card embeddings 需 measured miss evidence，未新增 vector schema |
 | `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
+| `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -168,6 +169,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p57-card-embedding-evidence-gate.md` — P57 card embedding evidence gate（已完成）
 - `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
+- `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 
 ### Spec 使用方式
 
@@ -186,9 +188,9 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，17 条规则
 
-## MCP 工具（18 个）
+## MCP 工具（19 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -203,6 +205,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：record/list/stats/gate/research_validate_plan（P60） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1298,6 +1298,14 @@ external JSON report/input contract with `report_id`, `title`, `sources`,
 research adapter ingestion still preserves the P49 evidence-first boundary and
 does not create promoted/canonical knowledge.
 
+P60 exposes the Phase-3 runtime evidence baseline to MCP-connected agents
+through `mempal_phase3`. The MCP tool uses `action` values
+`record/list/stats/gate/research_validate_plan`, mirroring the P54-P59 CLI
+surfaces without adding new authority. `record` appends
+`runtime_adoption_events`; `list`, `stats`, `gate`, and
+`research_validate_plan` remain read-only. MCP research validation accepts a
+JSON report object and still does not ingest or promote knowledge.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md
+++ b/docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md
@@ -1,0 +1,43 @@
+# P60 MCP Phase-3 Runtime Surface
+
+## Goal
+
+Expose the P54-P59 Phase-3 runtime evidence baseline to MCP-connected agents
+through one bounded `mempal_phase3` tool.
+
+## Scope
+
+- Add `specs/p60-mcp-phase3-runtime-surface.spec.md`.
+- Add MCP request/response DTOs for Phase-3 runtime evidence.
+- Add `mempal_phase3` MCP tool with actions:
+  - `record`
+  - `list`
+  - `stats`
+  - `gate`
+  - `research_validate_plan`
+- Update `MEMORY_PROTOCOL`, `docs/MIND-MODEL-DESIGN.md`, `AGENTS.md`, and
+  `CLAUDE.md`.
+- Do not change schema v9 or default runtime behavior.
+
+## Steps
+
+- [x] Write failing MCP tests for record/stats/gate, research validation, invalid
+  action, and tool registry/protocol visibility.
+- [x] Implement minimal `mempal_phase3` surface.
+- [x] Update memory protocol.
+- [x] Update design and repository inventories.
+- [x] Run spec checks and Rust verification.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p60-mcp-phase3-runtime-surface.spec.md
+agent-spec lint specs/p60-mcp-phase3-runtime-surface.spec.md --min-score 0.7
+cargo test mcp::server::tests::test_mcp_phase3 --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p60-mcp-phase3-runtime-surface.spec.md
+++ b/specs/p60-mcp-phase3-runtime-surface.spec.md
@@ -1,0 +1,98 @@
+spec: task
+name: "P60: MCP Phase-3 runtime surface"
+inherits: project
+tags: ["phase-3", "mcp", "runtime-adoption"]
+---
+
+## Intent
+
+P54-P59 exposed Phase-3 runtime adoption evidence through CLI, but agent runtime
+primarily uses MCP. P60 adds one minimal MCP surface, `mempal_phase3`, so agents
+can record runtime adoption events, inspect adoption evidence, evaluate Phase-3
+readiness gates, and validate external research report contracts without
+shelling out.
+
+## Decisions
+
+- Add one MCP tool named `mempal_phase3`.
+- Use an `action` field instead of multiple tools.
+- Supported actions are `record`, `list`, `stats`, `gate`, and `research_validate_plan`.
+- `record` appends a `runtime_adoption_events` row using the existing schema v9 table.
+- `list`, `stats`, `gate`, and `research_validate_plan` are read-only.
+- MCP `research_validate_plan` accepts a JSON `report` object rather than a filesystem path.
+- The tool must preserve P56-P59 boundaries: no default card context enablement, no card vector schema, no evaluator lifecycle mutation, and no promoted/canonical research ingestion.
+
+## Boundaries
+
+### Allowed Changes
+
+- `src/mcp/server.rs`
+- `src/mcp/tools.rs`
+- `src/core/protocol.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md`
+- `specs/p60-mcp-phase3-runtime-surface.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+
+- Do not add schema v10 or modify `runtime_adoption_events`.
+- Do not add card vector tables or card embeddings.
+- Do not change `mempal context` / `mempal_context` default `include_cards` behavior.
+- Do not let evaluator signals mutate knowledge drawer or knowledge card lifecycle state.
+- Do not ingest research reports or create promoted/canonical knowledge from this MCP tool.
+- Do not add REST API endpoints.
+
+## Acceptance Criteria
+
+Scenario: MCP records and summarizes Phase-3 adoption events
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_record_stats_and_gate_actions
+  Level: unit
+  Given an empty test database at schema v9
+  When `mempal_phase3` records three `card_context` accepted events for `include_cards`
+  Then the response returns the created event ids
+  And `action=stats` reports `accepted=3` and `rollbacks=0`
+  And `action=gate` for `card-context-default` reports `ready=true`
+
+Scenario: MCP research validation is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_research_validate_plan_is_read_only
+  Level: unit
+  Given a valid external research report JSON object
+  When `mempal_phase3` runs `action=research_validate_plan`
+  Then the response reports `valid=true`
+  And the drawer count is unchanged
+  And no runtime adoption event is inserted
+
+Scenario: invalid MCP action is rejected without mutation
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_rejects_invalid_action_without_mutation
+  Level: unit
+  Given a database with zero runtime adoption events
+  When `mempal_phase3` is called with unsupported `action=promote`
+  Then the request fails with an invalid action error
+  And the runtime adoption event count remains unchanged
+
+Scenario: MCP tool registry and protocol advertise Phase-3 surface
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface
+  Level: unit
+  Given the MCP server tool registry
+  When listing available tools
+  Then `mempal_phase3` exists
+  And its description lists `record/list/stats/gate/research_validate_plan`
+  And `MEMORY_PROTOCOL` mentions `mempal_phase3` and runtime adoption evidence
+
+## Out of Scope
+
+- Automatic runtime adoption recording protocol.
+- Card context default-on behavior.
+- Card-level embeddings.
+- Evaluator advisory API response contracts beyond the read-only gate.
+- Research adapter apply/ingest behavior.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -210,6 +210,14 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    counterexample evidence. It does not create cards, replace mempal_search,
    assemble default context, or backfill drawers.
 
+17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
+   Use mempal_phase3 to record and inspect runtime adoption evidence before
+   proposing stronger defaults or new authority. The tool supports
+   record/list/stats/gate/research_validate_plan actions over Phase-3
+   runtime_adoption_events. Gate and research_validate_plan are advisory and
+   read-only: they do not enable card context by default, add card embeddings,
+   mutate evaluator lifecycle state, or promote research output into knowledge.
+
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
@@ -219,6 +227,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
+  mempal_phase3       — Phase-3 runtime adoption evidence record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,7 +7,8 @@ use crate::core::{
     db::Database,
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
-        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, SourceType,
+        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
+        RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
         TriggerHints, Triple,
     },
     utils::{
@@ -61,9 +62,11 @@ use super::tools::{
     KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
-    RetrievedKnowledgeCardDto, ScopeCount, SearchRequest, SearchResponse, SearchResultDto,
-    StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto,
-    TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
+    Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto,
+    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount,
+    SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
+    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
+    TunnelsRequest, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -225,6 +228,17 @@ impl MempalMcpServer {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         self.mempal_knowledge_cards(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn phase3_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<Phase3Response, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_phase3(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -609,6 +623,224 @@ fn required_string<'a>(
 ) -> std::result::Result<&'a str, ErrorData> {
     trim_to_option(value)
         .ok_or_else(|| ErrorData::invalid_params(format!("{field} is required"), None))
+}
+
+fn parse_runtime_adoption_track_opt(
+    value: Option<&str>,
+) -> std::result::Result<Option<RuntimeAdoptionTrack>, ErrorData> {
+    parse_enum(value, "track", |normalized| match normalized {
+        "runtime_adoption" => Some(RuntimeAdoptionTrack::RuntimeAdoption),
+        "card_context" => Some(RuntimeAdoptionTrack::CardContext),
+        "card_embedding" => Some(RuntimeAdoptionTrack::CardEmbedding),
+        "evaluator" => Some(RuntimeAdoptionTrack::Evaluator),
+        "research_adapter" => Some(RuntimeAdoptionTrack::ResearchAdapter),
+        _ => None,
+    })
+}
+
+fn parse_runtime_adoption_track(
+    value: &str,
+) -> std::result::Result<RuntimeAdoptionTrack, ErrorData> {
+    parse_runtime_adoption_track_opt(Some(value))?
+        .ok_or_else(|| ErrorData::invalid_params("track is required", None))
+}
+
+fn parse_runtime_adoption_signal(
+    value: &str,
+) -> std::result::Result<RuntimeAdoptionSignal, ErrorData> {
+    parse_enum(Some(value), "signal", |normalized| match normalized {
+        "used" => Some(RuntimeAdoptionSignal::Used),
+        "accepted" => Some(RuntimeAdoptionSignal::Accepted),
+        "rejected" => Some(RuntimeAdoptionSignal::Rejected),
+        "miss" => Some(RuntimeAdoptionSignal::Miss),
+        "rollback" => Some(RuntimeAdoptionSignal::Rollback),
+        "contradiction" => Some(RuntimeAdoptionSignal::Contradiction),
+        "neutral" => Some(RuntimeAdoptionSignal::Neutral),
+        _ => None,
+    })?
+    .ok_or_else(|| ErrorData::invalid_params("signal is required", None))
+}
+
+fn runtime_adoption_track_slug(track: &RuntimeAdoptionTrack) -> &'static str {
+    match track {
+        RuntimeAdoptionTrack::RuntimeAdoption => "runtime_adoption",
+        RuntimeAdoptionTrack::CardContext => "card_context",
+        RuntimeAdoptionTrack::CardEmbedding => "card_embedding",
+        RuntimeAdoptionTrack::Evaluator => "evaluator",
+        RuntimeAdoptionTrack::ResearchAdapter => "research_adapter",
+    }
+}
+
+fn phase3_event_id(
+    track: &RuntimeAdoptionTrack,
+    signal: &RuntimeAdoptionSignal,
+    feature: &str,
+) -> String {
+    let signal = match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    };
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let sanitized_feature = feature
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!(
+        "adoption_{}_{}_{}_{}",
+        runtime_adoption_track_slug(track),
+        signal,
+        sanitized_feature,
+        nanos
+    )
+}
+
+fn runtime_adoption_stats(events: &[RuntimeAdoptionEvent]) -> RuntimeAdoptionStatsDto {
+    let mut stats = RuntimeAdoptionStatsDto {
+        total: events.len(),
+        used: 0,
+        accepted: 0,
+        rejected: 0,
+        misses: 0,
+        rollbacks: 0,
+        contradictions: 0,
+        neutral: 0,
+    };
+    for event in events {
+        match event.signal {
+            RuntimeAdoptionSignal::Used => stats.used += 1,
+            RuntimeAdoptionSignal::Accepted => stats.accepted += 1,
+            RuntimeAdoptionSignal::Rejected => stats.rejected += 1,
+            RuntimeAdoptionSignal::Miss => stats.misses += 1,
+            RuntimeAdoptionSignal::Rollback => stats.rollbacks += 1,
+            RuntimeAdoptionSignal::Contradiction => stats.contradictions += 1,
+            RuntimeAdoptionSignal::Neutral => stats.neutral += 1,
+        }
+    }
+    stats
+}
+
+fn phase3_gate_report(
+    db: &Database,
+    candidate: &str,
+) -> std::result::Result<Phase3GateDto, ErrorData> {
+    let (track, ready_fn): (RuntimeAdoptionTrack, fn(&RuntimeAdoptionStatsDto) -> bool) =
+        match candidate {
+            "card-context-default" => (RuntimeAdoptionTrack::CardContext, |stats| {
+                stats.accepted >= 3 && stats.rollbacks == 0 && stats.rejected <= stats.accepted
+            }),
+            "card-embeddings" => (RuntimeAdoptionTrack::CardEmbedding, |stats| {
+                stats.misses >= 3 && stats.rollbacks == 0
+            }),
+            "evaluator-api" => (RuntimeAdoptionTrack::Evaluator, |stats| {
+                stats.accepted >= 3 && stats.rollbacks == 0 && stats.contradictions == 0
+            }),
+            "research-adapter" => (RuntimeAdoptionTrack::ResearchAdapter, |stats| {
+                stats.accepted >= 1 && stats.contradictions == 0 && stats.rollbacks == 0
+            }),
+            other => {
+                return Err(ErrorData::invalid_params(
+                    format!("unsupported phase3 candidate: {other}"),
+                    None,
+                ));
+            }
+        };
+    let events = db
+        .list_runtime_adoption_events(
+            &RuntimeAdoptionFilter {
+                track: Some(track.clone()),
+                feature: None,
+            },
+            10_000,
+        )
+        .map_err(|error| {
+            ErrorData::internal_error(
+                format!("failed to list runtime adoption events: {error}"),
+                None,
+            )
+        })?;
+    let stats = runtime_adoption_stats(&events);
+    let ready = ready_fn(&stats);
+    let mut reasons = Vec::new();
+    if ready {
+        reasons.push("minimum evidence threshold satisfied".to_string());
+    } else {
+        reasons.push("minimum evidence threshold not satisfied".to_string());
+    }
+    if stats.rollbacks > 0 {
+        reasons.push("rollback signals block default or authority changes".to_string());
+    }
+    if stats.contradictions > 0 {
+        reasons.push("contradiction signals require review before implementation".to_string());
+    }
+    Ok(Phase3GateDto {
+        candidate: candidate.to_string(),
+        ready,
+        required_track: runtime_adoption_track_slug(&track).to_string(),
+        stats,
+        reasons,
+    })
+}
+
+fn validate_research_adapter_plan_value(value: &serde_json::Value) -> ResearchAdapterPlanDto {
+    let mut errors = Vec::new();
+    let report_id = required_json_string(value, "report_id", &mut errors);
+    let title = required_json_string(value, "title", &mut errors);
+    let source_count = value
+        .get("sources")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    if source_count == 0 {
+        errors.push("sources must contain at least one item".to_string());
+    }
+    let finding_count = value
+        .get("findings")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    if finding_count == 0 {
+        errors.push("findings must contain at least one item".to_string());
+    }
+    let candidate_insight_count = value
+        .get("candidate_insights")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+
+    ResearchAdapterPlanDto {
+        valid: errors.is_empty(),
+        report_id,
+        title,
+        source_count,
+        finding_count,
+        candidate_insight_count,
+        errors,
+    }
+}
+
+fn required_json_string(
+    value: &serde_json::Value,
+    field: &'static str,
+    errors: &mut Vec<String>,
+) -> String {
+    match value.get(field).and_then(serde_json::Value::as_str) {
+        Some(raw) if !raw.trim().is_empty() => raw.trim().to_string(),
+        _ => {
+            errors.push(format!("{field} is required"));
+            String::new()
+        }
+    }
 }
 
 fn anchor_error(error: anchor::AnchorError) -> ErrorData {
@@ -1089,6 +1321,143 @@ impl MempalMcpServer {
             other => Err(ErrorData::invalid_params(
                 format!(
                     "unsupported knowledge cards action: {other}; actions are list, get, retrieve, events, gate, promote, demote"
+                ),
+                None,
+            )),
+        }
+    }
+
+    #[tool(
+        name = "mempal_phase3",
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: record/list/stats/gate/research_validate_plan. Record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+    )]
+    async fn mempal_phase3(
+        &self,
+        Parameters(request): Parameters<Phase3Request>,
+    ) -> std::result::Result<Json<Phase3Response>, ErrorData> {
+        let action = trim_to_option(Some(request.action.as_str()))
+            .ok_or_else(|| ErrorData::invalid_params("action must not be empty", None))?;
+
+        match action {
+            "record" => {
+                let db = self.open_db()?;
+                let track = parse_runtime_adoption_track(required_string(
+                    request.track.as_deref(),
+                    "track",
+                )?)?;
+                let signal = parse_runtime_adoption_signal(required_string(
+                    request.signal.as_deref(),
+                    "signal",
+                )?)?;
+                let feature = required_string(request.feature.as_deref(), "feature")?.to_string();
+                let event = RuntimeAdoptionEvent {
+                    id: request
+                        .id
+                        .unwrap_or_else(|| phase3_event_id(&track, &signal, &feature)),
+                    track,
+                    signal,
+                    feature,
+                    query: trim_to_owned(request.query.as_deref()),
+                    context_hash: trim_to_owned(request.context_hash.as_deref()),
+                    card_id: trim_to_owned(request.card_id.as_deref()),
+                    evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                    research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                    note: trim_to_owned(request.note.as_deref()),
+                    metadata: request.metadata,
+                    created_at: current_timestamp(),
+                };
+                db.insert_runtime_adoption_event(&event).map_err(|error| {
+                    ErrorData::internal_error(
+                        format!("failed to insert runtime adoption event: {error}"),
+                        None,
+                    )
+                })?;
+                Ok(Json(Phase3Response {
+                    event: Some(RuntimeAdoptionEventDto::from(event)),
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "list" => {
+                let db = self.open_db()?;
+                let events = db
+                    .list_runtime_adoption_events(
+                        &RuntimeAdoptionFilter {
+                            track: parse_runtime_adoption_track_opt(request.track.as_deref())?,
+                            feature: trim_to_owned(request.feature.as_deref()),
+                        },
+                        request.limit.unwrap_or(50),
+                    )
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to list runtime adoption events: {error}"),
+                            None,
+                        )
+                    })?;
+                Ok(Json(Phase3Response {
+                    event: None,
+                    events: events
+                        .into_iter()
+                        .map(RuntimeAdoptionEventDto::from)
+                        .collect(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "stats" => {
+                let db = self.open_db()?;
+                let events = db
+                    .list_runtime_adoption_events(
+                        &RuntimeAdoptionFilter {
+                            track: parse_runtime_adoption_track_opt(request.track.as_deref())?,
+                            feature: trim_to_owned(request.feature.as_deref()),
+                        },
+                        10_000,
+                    )
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to list runtime adoption events: {error}"),
+                            None,
+                        )
+                    })?;
+                Ok(Json(Phase3Response {
+                    event: None,
+                    events: Vec::new(),
+                    stats: Some(runtime_adoption_stats(&events)),
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "gate" => {
+                let db = self.open_db()?;
+                let candidate = required_string(request.candidate.as_deref(), "candidate")?;
+                let gate = phase3_gate_report(&db, candidate)?;
+                Ok(Json(Phase3Response {
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: Some(gate),
+                    research_plan: None,
+                }))
+            }
+            "research_validate_plan" => {
+                let report = request.report.ok_or_else(|| {
+                    ErrorData::invalid_params("report is required for research_validate_plan", None)
+                })?;
+                Ok(Json(Phase3Response {
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: Some(validate_research_adapter_plan_value(&report)),
+                }))
+            }
+            other => Err(ErrorData::invalid_params(
+                format!(
+                    "unsupported phase3 action: {other}; actions are record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -2061,7 +2430,7 @@ mod tests {
     use super::*;
     use crate::core::types::{
         BootstrapEvidenceArgs, KnowledgeCard, KnowledgeCardEvent, KnowledgeEventType,
-        KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+        KnowledgeEvidenceLink, KnowledgeEvidenceRole, RuntimeAdoptionFilter, RuntimeAdoptionTrack,
     };
     use crate::embed::Embedder;
 
@@ -3189,6 +3558,157 @@ mod tests {
         assert_eq!(
             db.knowledge_events("card_lifecycle").expect("events").len(),
             2
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_record_stats_and_gate_actions() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        for i in 0..3 {
+            let response = server
+                .phase3_json_for_test(serde_json::json!({
+                    "action": "record",
+                    "id": format!("mcp_card_context_accept_{i}"),
+                    "track": "card_context",
+                    "signal": "accepted",
+                    "feature": "include_cards",
+                    "query": "skill trigger context",
+                    "metadata": { "source": "mcp-test" }
+                }))
+                .await
+                .expect("record phase3 event");
+            assert_eq!(
+                response.event.expect("event").id,
+                format!("mcp_card_context_accept_{i}")
+            );
+        }
+
+        let stats = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "stats",
+                "track": "card_context",
+                "feature": "include_cards"
+            }))
+            .await
+            .expect("stats");
+        let stats = stats.stats.expect("stats");
+        assert_eq!(stats.total, 3);
+        assert_eq!(stats.accepted, 3);
+        assert_eq!(stats.rollbacks, 0);
+
+        let gate = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "gate",
+                "candidate": "card-context-default"
+            }))
+            .await
+            .expect("gate");
+        let gate = gate.gate.expect("gate");
+        assert!(gate.ready);
+        assert_eq!(gate.required_track, "card_context");
+
+        let db = Database::open(&db_path).expect("open db");
+        let events = db
+            .list_runtime_adoption_events(
+                &RuntimeAdoptionFilter {
+                    track: Some(RuntimeAdoptionTrack::CardContext),
+                    feature: Some("include_cards".to_string()),
+                },
+                10,
+            )
+            .expect("events");
+        assert_eq!(events.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_research_validate_plan_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "research_validate_plan",
+                "report": {
+                    "report_id": "research_001",
+                    "title": "Agent memory retrieval notes",
+                    "sources": [{ "url": "https://example.invalid/report" }],
+                    "findings": [{ "summary": "Measure card context before defaults." }],
+                    "candidate_insights": [{ "statement": "Measure before defaulting cards." }]
+                }
+            }))
+            .await
+            .expect("validate research plan");
+        let plan = response.research_plan.expect("research plan");
+        assert!(plan.valid);
+        assert_eq!(plan.report_id, "research_001");
+        assert_eq!(plan.source_count, 1);
+        assert_eq!(plan.candidate_insight_count, 1);
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_rejects_invalid_action_without_mutation() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let error = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "promote"
+            }))
+            .await
+            .expect_err("invalid action should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("actions are record, list, stats, gate, research_validate_plan")
+        );
+
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_phase3")
+            .expect("mempal_phase3 tool exists");
+        let description = tool.description.as_deref().unwrap_or_default();
+        assert!(description.contains("Phase-3 runtime adoption evidence"));
+        assert!(description.contains("Actions: record/list/stats/gate/research_validate_plan"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL.contains("runtime adoption"),
+            "protocol should explain the Phase-3 runtime evidence surface"
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,8 +1,8 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
-    MemoryDomain, MemoryKind, NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry,
-    TunnelEndpoint,
+    MemoryDomain, MemoryKind, NeighborChunk, RouteDecision, RuntimeAdoptionEvent,
+    RuntimeAdoptionSignal, RuntimeAdoptionTrack, SearchResult, TaxonomyEntry, TunnelEndpoint,
 };
 use crate::field_taxonomy::FieldTaxonomyEntry;
 use crate::knowledge_anchor::PublishAnchorOutcome;
@@ -303,6 +303,128 @@ pub struct KnowledgeCardsResponse {
     pub promote: Option<KnowledgeCardPromoteDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub demote: Option<KnowledgeCardDemoteDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct Phase3Request {
+    pub action: String,
+    pub id: Option<String>,
+    pub track: Option<String>,
+    pub signal: Option<String>,
+    pub feature: Option<String>,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub limit: Option<usize>,
+    pub candidate: Option<String>,
+    pub report: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Phase3Response {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<RuntimeAdoptionEventDto>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub events: Vec<RuntimeAdoptionEventDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stats: Option<RuntimeAdoptionStatsDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gate: Option<Phase3GateDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub research_plan: Option<ResearchAdapterPlanDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionEventDto {
+    pub id: String,
+    pub track: String,
+    pub signal: String,
+    pub feature: String,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionStatsDto {
+    pub total: usize,
+    pub used: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub misses: usize,
+    pub rollbacks: usize,
+    pub contradictions: usize,
+    pub neutral: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Phase3GateDto {
+    pub candidate: String,
+    pub ready: bool,
+    pub required_track: String,
+    pub stats: RuntimeAdoptionStatsDto,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ResearchAdapterPlanDto {
+    pub valid: bool,
+    pub report_id: String,
+    pub title: String,
+    pub source_count: usize,
+    pub finding_count: usize,
+    pub candidate_insight_count: usize,
+    pub errors: Vec<String>,
+}
+
+impl From<RuntimeAdoptionEvent> for RuntimeAdoptionEventDto {
+    fn from(event: RuntimeAdoptionEvent) -> Self {
+        Self {
+            id: event.id,
+            track: runtime_adoption_track_slug(&event.track).to_string(),
+            signal: runtime_adoption_signal_slug(&event.signal).to_string(),
+            feature: event.feature,
+            query: event.query,
+            context_hash: event.context_hash,
+            card_id: event.card_id,
+            evaluator_id: event.evaluator_id,
+            research_report_id: event.research_report_id,
+            note: event.note,
+            metadata: event.metadata,
+            created_at: event.created_at,
+        }
+    }
+}
+
+fn runtime_adoption_track_slug(track: &RuntimeAdoptionTrack) -> &'static str {
+    match track {
+        RuntimeAdoptionTrack::RuntimeAdoption => "runtime_adoption",
+        RuntimeAdoptionTrack::CardContext => "card_context",
+        RuntimeAdoptionTrack::CardEmbedding => "card_embedding",
+        RuntimeAdoptionTrack::Evaluator => "evaluator",
+        RuntimeAdoptionTrack::ResearchAdapter => "research_adapter",
+    }
+}
+
+fn runtime_adoption_signal_slug(signal: &RuntimeAdoptionSignal) -> &'static str {
+    match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]


### PR DESCRIPTION
## Summary

Implements P60 MCP Phase-3 runtime surface:

- Adds `mempal_phase3` MCP tool with `record/list/stats/gate/research_validate_plan` actions.
- `record` appends schema v9 `runtime_adoption_events`.
- `list`, `stats`, `gate`, and `research_validate_plan` remain read-only.
- MCP research validation accepts a JSON report object and does not ingest or promote knowledge.
- Updates `MEMORY_PROTOCOL`, MIND-MODEL docs, specs/plans, and agent inventories.

## Boundaries

- No schema v10.
- No card vector schema or card embeddings.
- No card context default change.
- No evaluator lifecycle mutation.
- No promoted/canonical research ingestion.

## Verification

- `agent-spec parse specs/p60-mcp-phase3-runtime-surface.spec.md`
- `agent-spec lint specs/p60-mcp-phase3-runtime-surface.spec.md --min-score 0.7`
- `cargo test mcp::server::tests::test_mcp_phase3 --lib`
- `cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib`
- `cargo check`
- `cargo check --features rest`
- `cargo fmt -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
