### PR TITLE
feat: add runtime adoption recording guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
+| `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -172,6 +173,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
+- `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 
 ### Spec 使用方式
 
@@ -207,7 +209,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：record/list/stats/gate/research_validate_plan（P60） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/record/list/stats/gate/research_validate_plan（P60/P61） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
+| `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -170,6 +171,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
+- `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 
 ### Spec 使用方式
 
@@ -205,7 +207,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：record/list/stats/gate/research_validate_plan（P60） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/record/list/stats/gate/research_validate_plan（P60/P61） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1306,6 +1306,14 @@ surfaces without adding new authority. `record` appends
 `research_validate_plan` remain read-only. MCP research validation accepts a
 JSON report object and still does not ingest or promote knowledge.
 
+P61 adds a read-only runtime adoption recording protocol through
+`mempal_phase3 action=guidance`. The guidance tells agents when to record
+`used`, `accepted`, `rejected`, `miss`, `rollback`, `contradiction`, or
+`neutral`, and exposes the required `track`, `signal`, and `feature` fields
+plus optional context fields. This is a recording discipline, not automatic
+instrumentation: it adds no hooks, no background writes, no schema migration,
+and no default runtime behavior change.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md
+++ b/docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md
@@ -1,0 +1,39 @@
+# P61 Runtime Adoption Recording Protocol
+
+## Goal
+
+Define deterministic guidance for when agents should record Phase-3 runtime
+adoption events through `mempal_phase3`.
+
+## Scope
+
+- Add `specs/p61-runtime-adoption-recording-protocol.spec.md`.
+- Extend `mempal_phase3` with read-only `action=guidance`.
+- Add guidance DTOs for required fields, optional fields, signal semantics, and
+  track semantics.
+- Update `MEMORY_PROTOCOL`, `docs/MIND-MODEL-DESIGN.md`, `AGENTS.md`, and
+  `CLAUDE.md`.
+- Do not add automatic event recording or runtime hooks.
+
+## Steps
+
+- [x] Write failing MCP tests for guidance response and protocol visibility.
+- [x] Implement read-only guidance action.
+- [x] Update memory protocol with recording semantics.
+- [x] Update design and repository inventories.
+- [x] Run spec checks and Rust verification.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p61-runtime-adoption-recording-protocol.spec.md
+agent-spec lint specs/p61-runtime-adoption-recording-protocol.spec.md --min-score 0.7
+cargo test mcp::server::tests::test_mcp_phase3_guidance_action_is_read_only --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/specs/p61-runtime-adoption-recording-protocol.spec.md
+++ b/specs/p61-runtime-adoption-recording-protocol.spec.md
@@ -1,0 +1,85 @@
+spec: task
+name: "P61: runtime adoption recording protocol"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "mcp", "protocol"]
+---
+
+## Intent
+
+P60 made Phase-3 runtime evidence writable through MCP, but agents still need a
+deterministic protocol for when to record `used`, `accepted`, `rejected`,
+`miss`, `rollback`, `contradiction`, or `neutral`. P61 adds a read-only guidance
+surface and protocol text so agents can record concrete runtime outcomes without
+turning speculative reasoning into evidence.
+
+## Decisions
+
+- Extend `mempal_phase3` with `action=guidance`.
+- `guidance` is read-only and must not write `runtime_adoption_events`, drawers,
+  knowledge cards, or lifecycle events.
+- Guidance version starts at `1`.
+- Required record fields are `track`, `signal`, and `feature`.
+- Guidance defines signal semantics for `used`, `accepted`, `rejected`, `miss`,
+  `rollback`, `contradiction`, and `neutral`.
+- Guidance defines track semantics and feature examples for `runtime_adoption`,
+  `card_context`, `card_embedding`, `evaluator`, and `research_adapter`.
+- `MEMORY_PROTOCOL` must tell agents to call `action=guidance` when unsure and
+  to record only concrete runtime outcomes, not speculation.
+
+## Boundaries
+
+### Allowed Changes
+
+- `src/mcp/server.rs`
+- `src/mcp/tools.rs`
+- `src/core/protocol.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md`
+- `specs/p61-runtime-adoption-recording-protocol.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change P56-P60 gates.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not let evaluator or research guidance mutate lifecycle state.
+
+## Acceptance Criteria
+
+Scenario: guidance action returns recording protocol without side effects
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_guidance_action_is_read_only
+  Level: unit
+  Given an empty test database
+  When `mempal_phase3` is called with `action=guidance`
+  Then the response includes `version=1`
+  And the response states that only concrete runtime outcomes should be recorded
+  And the response includes required fields `track`, `signal`, and `feature`
+  And the response defines `used` and `rollback` signal semantics
+  And the response includes `card_context` with `include_cards` as a feature example
+  And drawer and runtime adoption event counts remain unchanged
+
+Scenario: protocol advertises guidance action and signal semantics
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface
+  Level: unit
+  Given the MCP tool registry and memory protocol
+  When inspecting `mempal_phase3`
+  Then the description lists `guidance/record/list/stats/gate/research_validate_plan`
+  And `MEMORY_PROTOCOL` mentions `action=guidance`
+  And `MEMORY_PROTOCOL` explains `used` and `rollback` recording semantics
+
+## Out of Scope
+
+- Automatic adoption recording after tool calls.
+- Runtime hooks for Claude, Codex, or other agents.
+- Adoption-event deduplication.
+- Aggregated analytics beyond existing `stats`.
+- Any default-on policy changes.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,10 +213,17 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   record/list/stats/gate/research_validate_plan actions over Phase-3
-   runtime_adoption_events. Gate and research_validate_plan are advisory and
-   read-only: they do not enable card context by default, add card embeddings,
-   mutate evaluator lifecycle state, or promote research output into knowledge.
+   guidance/record/list/stats/gate/research_validate_plan actions over
+   Phase-3 runtime_adoption_events. Start with action=guidance when unsure
+   whether a runtime outcome should be recorded. Record used when guidance was actually consumed,
+   accepted when it materially helped, rejected when it was
+   considered and intentionally not followed, miss when useful guidance should
+   have appeared but did not, rollback when behavior was reverted because
+   guidance degraded the outcome, contradiction when guidance conflicted with
+   stronger evidence or instructions, and neutral when no clear outcome impact
+   is known. Gate and research_validate_plan are advisory and read-only: they
+   do not enable card context by default, add card embeddings, mutate evaluator
+   lifecycle state, or promote research output into knowledge.
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
@@ -227,7 +234,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -63,8 +63,9 @@ use super::tools::{
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
     Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto,
-    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount,
-    SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
+    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionGuidanceDto,
+    RuntimeAdoptionSignalGuidanceDto, RuntimeAdoptionStatsDto, RuntimeAdoptionTrackGuidanceDto,
+    ScopeCount, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
     TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
     TunnelsRequest, TunnelsResponse,
 };
@@ -733,6 +734,90 @@ fn runtime_adoption_stats(events: &[RuntimeAdoptionEvent]) -> RuntimeAdoptionSta
     stats
 }
 
+fn runtime_adoption_guidance() -> RuntimeAdoptionGuidanceDto {
+    RuntimeAdoptionGuidanceDto {
+        version: 1,
+        recording_rule: "record only concrete runtime outcomes, not speculation".to_string(),
+        required_fields: vec![
+            "track".to_string(),
+            "signal".to_string(),
+            "feature".to_string(),
+        ],
+        optional_fields: vec![
+            "query".to_string(),
+            "context_hash".to_string(),
+            "card_id".to_string(),
+            "evaluator_id".to_string(),
+            "research_report_id".to_string(),
+            "note".to_string(),
+            "metadata".to_string(),
+        ],
+        signals: vec![
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "used".to_string(),
+                when: "record when guidance was actually consumed during a task".to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "accepted".to_string(),
+                when: "record when the consumed guidance materially helped the outcome".to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "rejected".to_string(),
+                when: "record when guidance was considered and intentionally not followed"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "miss".to_string(),
+                when: "record when useful guidance should have appeared but did not".to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "rollback".to_string(),
+                when: "record when behavior was reverted because guidance degraded the outcome"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "contradiction".to_string(),
+                when: "record when guidance conflicted with stronger evidence or instructions"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "neutral".to_string(),
+                when: "record when guidance was consumed but had no clear outcome impact"
+                    .to_string(),
+            },
+        ],
+        tracks: vec![
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "runtime_adoption".to_string(),
+                when: "general agent-runtime behavior evidence".to_string(),
+                feature_examples: vec!["context_pack".to_string(), "skill_selection".to_string()],
+            },
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "card_context".to_string(),
+                when: "card-aware context affected or should have affected behavior".to_string(),
+                feature_examples: vec!["include_cards".to_string()],
+            },
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "card_embedding".to_string(),
+                when: "linked-evidence card retrieval missed statement-level matches".to_string(),
+                feature_examples: vec!["card_statement_recall".to_string()],
+            },
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "evaluator".to_string(),
+                when: "evaluator advice affected or should have affected a lifecycle decision"
+                    .to_string(),
+                feature_examples: vec!["advisory_gate".to_string()],
+            },
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "research_adapter".to_string(),
+                when: "external research report validation or ingestion planning affected behavior"
+                    .to_string(),
+                feature_examples: vec!["research_validate_plan".to_string()],
+            },
+        ],
+    }
+}
+
 fn phase3_gate_report(
     db: &Database,
     candidate: &str,
@@ -1329,7 +1414,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: record/list/stats/gate/research_validate_plan. Record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1339,6 +1424,14 @@ impl MempalMcpServer {
             .ok_or_else(|| ErrorData::invalid_params("action must not be empty", None))?;
 
         match action {
+            "guidance" => Ok(Json(Phase3Response {
+                guidance: Some(runtime_adoption_guidance()),
+                event: None,
+                events: Vec::new(),
+                stats: None,
+                gate: None,
+                research_plan: None,
+            })),
             "record" => {
                 let db = self.open_db()?;
                 let track = parse_runtime_adoption_track(required_string(
@@ -1373,6 +1466,7 @@ impl MempalMcpServer {
                     )
                 })?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1397,6 +1491,7 @@ impl MempalMcpServer {
                         )
                     })?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1424,6 +1519,7 @@ impl MempalMcpServer {
                         )
                     })?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1436,6 +1532,7 @@ impl MempalMcpServer {
                 let candidate = required_string(request.candidate.as_deref(), "candidate")?;
                 let gate = phase3_gate_report(&db, candidate)?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1448,6 +1545,7 @@ impl MempalMcpServer {
                     ErrorData::invalid_params("report is required for research_validate_plan", None)
                 })?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1457,7 +1555,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3680,9 +3778,9 @@ mod tests {
             .await
             .expect_err("invalid action should fail");
         assert!(
-            error
-                .to_string()
-                .contains("actions are record, list, stats, gate, research_validate_plan")
+            error.to_string().contains(
+                "actions are guidance, record, list, stats, gate, research_validate_plan"
+            )
         );
 
         let db = Database::open(&db_path).expect("open db");
@@ -3691,6 +3789,63 @@ mod tests {
                 .expect("events")
                 .len(),
             before
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_guidance_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "guidance"
+            }))
+            .await
+            .expect("guidance");
+        let guidance = response.guidance.expect("guidance");
+        assert_eq!(guidance.version, 1);
+        assert_eq!(
+            guidance.recording_rule,
+            "record only concrete runtime outcomes, not speculation"
+        );
+        assert!(guidance.required_fields.contains(&"track".to_string()));
+        assert!(guidance.required_fields.contains(&"signal".to_string()));
+        assert!(guidance.required_fields.contains(&"feature".to_string()));
+        assert!(
+            guidance
+                .signals
+                .iter()
+                .any(|signal| signal.signal == "used" && signal.when.contains("actually consumed"))
+        );
+        assert!(
+            guidance
+                .signals
+                .iter()
+                .any(|signal| signal.signal == "rollback" && signal.when.contains("reverted"))
+        );
+        assert!(guidance.tracks.iter().any(|track| {
+            track.track == "card_context"
+                && track
+                    .feature_examples
+                    .contains(&"include_cards".to_string())
+        }));
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
         );
     }
 
@@ -3704,8 +3859,18 @@ mod tests {
             .expect("mempal_phase3 tool exists");
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
-        assert!(description.contains("Actions: record/list/stats/gate/research_validate_plan"));
+        assert!(
+            description.contains("Actions: guidance/record/list/stats/gate/research_validate_plan")
+        );
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL
+                .contains("used when guidance was actually consumed")
+        );
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL.contains("rollback when behavior was reverted")
+        );
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL.contains("runtime adoption"),
             "protocol should explain the Phase-3 runtime evidence surface"

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -327,6 +327,8 @@ pub struct Phase3Request {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub guidance: Option<RuntimeAdoptionGuidanceDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -336,6 +338,29 @@ pub struct Phase3Response {
     pub gate: Option<Phase3GateDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub research_plan: Option<ResearchAdapterPlanDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionGuidanceDto {
+    pub version: u32,
+    pub recording_rule: String,
+    pub required_fields: Vec<String>,
+    pub optional_fields: Vec<String>,
+    pub signals: Vec<RuntimeAdoptionSignalGuidanceDto>,
+    pub tracks: Vec<RuntimeAdoptionTrackGuidanceDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionSignalGuidanceDto {
+    pub signal: String,
+    pub when: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionTrackGuidanceDto {
+    pub track: String,
+    pub when: String,
+    pub feature_examples: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]


### PR DESCRIPTION
## Summary

- Add P61 runtime adoption recording protocol spec and implementation.
- Extend `mempal_phase3` with read-only `action=guidance`.
- Return versioned guidance for required fields, signal semantics, and track feature examples.
- Update `MEMORY_PROTOCOL`, `MIND-MODEL-DESIGN`, `AGENTS.md`, and `CLAUDE.md` inventories.

## Boundaries

- No automatic event recording.
- No hooks or background instrumentation.
- No schema migration.
- No default runtime behavior change.

## Verification

- `agent-spec parse specs/p61-runtime-adoption-recording-protocol.spec.md`
- `agent-spec lint specs/p61-runtime-adoption-recording-protocol.spec.md --min-score 0.7`
- `cargo test mcp::server::tests::test_mcp_phase3_guidance_action_is_read_only --lib`
- `cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib`
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `git diff --check`
