### PR TITLE
feat: add runtime adoption CLI guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
+| `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -174,6 +175,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
+- `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
+| `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -172,6 +173,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
+- `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1314,6 +1314,12 @@ plus optional context fields. This is a recording discipline, not automatic
 instrumentation: it adds no hooks, no background writes, no schema migration,
 and no default runtime behavior change.
 
+P62 exposes the same recording protocol through CLI parity with
+`mempal phase3 adoption guidance`. The CLI supports plain and JSON output and
+shares the guidance implementation with `mempal_phase3 action=guidance`, so MCP
+agents, humans, and non-MCP automation inspect the same semantics. This remains
+read-only and does not append adoption events or change Phase-3 gate policy.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md
+++ b/docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md
@@ -1,0 +1,40 @@
+# P62 Runtime Adoption CLI Guidance
+
+## Goal
+
+Expose the P61 runtime adoption recording protocol through CLI parity:
+`mempal phase3 adoption guidance`.
+
+## Scope
+
+- Add `specs/p62-runtime-adoption-cli-guidance.spec.md`.
+- Add `mempal phase3 adoption guidance --format plain|json`.
+- Move runtime adoption guidance into shared core code used by MCP and CLI.
+- Update `MIND-MODEL-DESIGN.md`, `AGENTS.md`, and `CLAUDE.md`.
+- Preserve read-only behavior and avoid schema/runtime default changes.
+
+## Steps
+
+- [x] Write failing CLI guidance tests.
+- [x] Implement shared guidance data and CLI command.
+- [x] Keep MCP guidance on the shared implementation.
+- [x] Update design and repository inventories.
+- [x] Run spec checks and Rust verification.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p62-runtime-adoption-cli-guidance.spec.md
+agent-spec lint specs/p62-runtime-adoption-cli-guidance.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_json_is_read_only
+cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_plain
+cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_rejects_invalid_format
+cargo test mcp::server::tests::test_mcp_phase3_guidance_action_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p62-runtime-adoption-cli-guidance.spec.md
+++ b/specs/p62-runtime-adoption-cli-guidance.spec.md
@@ -1,0 +1,91 @@
+spec: task
+name: "P62: runtime adoption CLI guidance"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "cli", "protocol"]
+---
+
+## Intent
+
+P61 exposed the runtime adoption recording protocol through MCP, but the CLI
+surface still lacks the same read-only guidance. P62 adds CLI parity through
+`mempal phase3 adoption guidance` so humans and non-MCP agents can inspect the
+same deterministic recording semantics before appending runtime evidence.
+
+## Decisions
+
+- Add `mempal phase3 adoption guidance`.
+- Support `--format plain` and `--format json`.
+- The CLI and MCP guidance must come from one shared implementation, not two
+  independent copies.
+- Guidance remains read-only and must not write drawers, runtime adoption
+  events, knowledge cards, or lifecycle events.
+- Guidance includes version, recording rule, required fields, optional fields,
+  signal semantics, and track semantics.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/**`
+- `src/main.rs`
+- `src/mcp/**`
+- `tests/phase3_runtime.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md`
+- `specs/p62-runtime-adoption-cli-guidance.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not let CLI guidance mutate lifecycle state.
+
+## Acceptance Criteria
+
+Scenario: CLI guidance returns JSON without side effects
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_json_is_read_only
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption guidance --format json`
+  Then stdout is valid JSON
+  And the response includes `version=1`
+  And the response states that only concrete runtime outcomes should be recorded
+  And required fields include `track`, `signal`, and `feature`
+  And signal guidance includes `used` and `rollback`
+  And track guidance includes `card_context` with `include_cards`
+  And runtime adoption event count remains zero
+
+Scenario: CLI guidance supports plain output
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_plain
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption guidance`
+  Then stdout mentions `version=1`
+  And stdout mentions `recording_rule=record only concrete runtime outcomes, not speculation`
+  And stdout mentions `signal=used`
+  And stdout mentions `track=card_context`
+
+Scenario: CLI guidance rejects unsupported format
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_rejects_invalid_format
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption guidance --format yaml`
+  Then the command fails
+  And stderr mentions `unsupported phase3 adoption format`
+
+## Out of Scope
+
+- MCP behavior changes beyond reusing the shared guidance implementation.
+- Adoption-event deduplication.
+- New analytics beyond existing `stats`.
+- Any default-on policy changes.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod anchor;
 pub mod config;
 pub mod db;
+pub mod phase3;
 pub mod protocol;
 pub mod types;
 pub mod utils;

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -1,0 +1,108 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionGuidance {
+    pub version: u32,
+    pub recording_rule: String,
+    pub required_fields: Vec<String>,
+    pub optional_fields: Vec<String>,
+    pub signals: Vec<RuntimeAdoptionSignalGuidance>,
+    pub tracks: Vec<RuntimeAdoptionTrackGuidance>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionSignalGuidance {
+    pub signal: String,
+    pub when: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionTrackGuidance {
+    pub track: String,
+    pub when: String,
+    pub feature_examples: Vec<String>,
+}
+
+pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
+    RuntimeAdoptionGuidance {
+        version: 1,
+        recording_rule: "record only concrete runtime outcomes, not speculation".to_string(),
+        required_fields: vec![
+            "track".to_string(),
+            "signal".to_string(),
+            "feature".to_string(),
+        ],
+        optional_fields: vec![
+            "query".to_string(),
+            "context_hash".to_string(),
+            "card_id".to_string(),
+            "evaluator_id".to_string(),
+            "research_report_id".to_string(),
+            "note".to_string(),
+            "metadata".to_string(),
+        ],
+        signals: vec![
+            RuntimeAdoptionSignalGuidance {
+                signal: "used".to_string(),
+                when: "record when guidance was actually consumed during a task".to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "accepted".to_string(),
+                when: "record when the consumed guidance materially helped the outcome".to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "rejected".to_string(),
+                when: "record when guidance was considered and intentionally not followed"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "miss".to_string(),
+                when: "record when useful guidance should have appeared but did not".to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "rollback".to_string(),
+                when: "record when behavior was reverted because guidance degraded the outcome"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "contradiction".to_string(),
+                when: "record when guidance conflicted with stronger evidence or instructions"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "neutral".to_string(),
+                when: "record when guidance was consumed but had no clear outcome impact"
+                    .to_string(),
+            },
+        ],
+        tracks: vec![
+            RuntimeAdoptionTrackGuidance {
+                track: "runtime_adoption".to_string(),
+                when: "general agent-runtime behavior evidence".to_string(),
+                feature_examples: vec!["context_pack".to_string(), "skill_selection".to_string()],
+            },
+            RuntimeAdoptionTrackGuidance {
+                track: "card_context".to_string(),
+                when: "card-aware context affected or should have affected behavior".to_string(),
+                feature_examples: vec!["include_cards".to_string()],
+            },
+            RuntimeAdoptionTrackGuidance {
+                track: "card_embedding".to_string(),
+                when: "linked-evidence card retrieval missed statement-level matches".to_string(),
+                feature_examples: vec!["card_statement_recall".to_string()],
+            },
+            RuntimeAdoptionTrackGuidance {
+                track: "evaluator".to_string(),
+                when: "evaluator advice affected or should have affected a lifecycle decision"
+                    .to_string(),
+                feature_examples: vec!["advisory_gate".to_string()],
+            },
+            RuntimeAdoptionTrackGuidance {
+                track: "research_adapter".to_string(),
+                when: "external research report validation or ingestion planning affected behavior"
+                    .to_string(),
+                feature_examples: vec!["research_validate_plan".to_string()],
+            },
+        ],
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
     config::Config,
     db::Database,
+    phase3::{RuntimeAdoptionGuidance, runtime_adoption_guidance},
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
         AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
@@ -575,6 +576,10 @@ enum Phase3Commands {
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)] // `record` intentionally carries the full event payload.
 enum Phase3AdoptionCommands {
+    Guidance {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     Record {
         #[arg(long)]
         track: String,
@@ -2179,6 +2184,9 @@ fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
 
 fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Result<()> {
     match command {
+        Phase3AdoptionCommands::Guidance { format } => {
+            print_runtime_adoption_guidance(&runtime_adoption_guidance(), &format)
+        }
         Phase3AdoptionCommands::Record {
             track,
             signal,
@@ -2289,6 +2297,38 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn print_runtime_adoption_guidance(guidance: &RuntimeAdoptionGuidance, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("version={}", guidance.version);
+            println!("recording_rule={}", guidance.recording_rule);
+            println!("required_fields={}", guidance.required_fields.join(","));
+            println!("optional_fields={}", guidance.optional_fields.join(","));
+            for signal in &guidance.signals {
+                println!("signal={} when={}", signal.signal, signal.when);
+            }
+            for track in &guidance.tracks {
+                println!(
+                    "track={} when={} feature_examples={}",
+                    track.track,
+                    track.when,
+                    track.feature_examples.join(",")
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(guidance)
+                    .context("failed to serialize runtime adoption guidance")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,6 +5,7 @@ use crate::context::assemble_context_with_vector;
 use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
+    phase3::runtime_adoption_guidance,
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
         KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
@@ -63,9 +64,8 @@ use super::tools::{
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
     Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto,
-    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionGuidanceDto,
-    RuntimeAdoptionSignalGuidanceDto, RuntimeAdoptionStatsDto, RuntimeAdoptionTrackGuidanceDto,
-    ScopeCount, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
+    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount,
+    SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
     TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
     TunnelsRequest, TunnelsResponse,
 };
@@ -734,90 +734,6 @@ fn runtime_adoption_stats(events: &[RuntimeAdoptionEvent]) -> RuntimeAdoptionSta
     stats
 }
 
-fn runtime_adoption_guidance() -> RuntimeAdoptionGuidanceDto {
-    RuntimeAdoptionGuidanceDto {
-        version: 1,
-        recording_rule: "record only concrete runtime outcomes, not speculation".to_string(),
-        required_fields: vec![
-            "track".to_string(),
-            "signal".to_string(),
-            "feature".to_string(),
-        ],
-        optional_fields: vec![
-            "query".to_string(),
-            "context_hash".to_string(),
-            "card_id".to_string(),
-            "evaluator_id".to_string(),
-            "research_report_id".to_string(),
-            "note".to_string(),
-            "metadata".to_string(),
-        ],
-        signals: vec![
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "used".to_string(),
-                when: "record when guidance was actually consumed during a task".to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "accepted".to_string(),
-                when: "record when the consumed guidance materially helped the outcome".to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "rejected".to_string(),
-                when: "record when guidance was considered and intentionally not followed"
-                    .to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "miss".to_string(),
-                when: "record when useful guidance should have appeared but did not".to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "rollback".to_string(),
-                when: "record when behavior was reverted because guidance degraded the outcome"
-                    .to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "contradiction".to_string(),
-                when: "record when guidance conflicted with stronger evidence or instructions"
-                    .to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "neutral".to_string(),
-                when: "record when guidance was consumed but had no clear outcome impact"
-                    .to_string(),
-            },
-        ],
-        tracks: vec![
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "runtime_adoption".to_string(),
-                when: "general agent-runtime behavior evidence".to_string(),
-                feature_examples: vec!["context_pack".to_string(), "skill_selection".to_string()],
-            },
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "card_context".to_string(),
-                when: "card-aware context affected or should have affected behavior".to_string(),
-                feature_examples: vec!["include_cards".to_string()],
-            },
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "card_embedding".to_string(),
-                when: "linked-evidence card retrieval missed statement-level matches".to_string(),
-                feature_examples: vec!["card_statement_recall".to_string()],
-            },
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "evaluator".to_string(),
-                when: "evaluator advice affected or should have affected a lifecycle decision"
-                    .to_string(),
-                feature_examples: vec!["advisory_gate".to_string()],
-            },
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "research_adapter".to_string(),
-                when: "external research report validation or ingestion planning affected behavior"
-                    .to_string(),
-                feature_examples: vec!["research_validate_plan".to_string()],
-            },
-        ],
-    }
-}
-
 fn phase3_gate_report(
     db: &Database,
     candidate: &str,
@@ -1425,7 +1341,7 @@ impl MempalMcpServer {
 
         match action {
             "guidance" => Ok(Json(Phase3Response {
-                guidance: Some(runtime_adoption_guidance()),
+                guidance: Some(runtime_adoption_guidance().into()),
                 event: None,
                 events: Vec::new(),
                 stats: None,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,4 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
+use crate::core::phase3::{
+    RuntimeAdoptionGuidance, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
+};
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
     MemoryDomain, MemoryKind, NeighborChunk, RouteDecision, RuntimeAdoptionEvent,
@@ -361,6 +364,38 @@ pub struct RuntimeAdoptionTrackGuidanceDto {
     pub track: String,
     pub when: String,
     pub feature_examples: Vec<String>,
+}
+
+impl From<RuntimeAdoptionGuidance> for RuntimeAdoptionGuidanceDto {
+    fn from(guidance: RuntimeAdoptionGuidance) -> Self {
+        Self {
+            version: guidance.version,
+            recording_rule: guidance.recording_rule,
+            required_fields: guidance.required_fields,
+            optional_fields: guidance.optional_fields,
+            signals: guidance.signals.into_iter().map(Into::into).collect(),
+            tracks: guidance.tracks.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<RuntimeAdoptionSignalGuidance> for RuntimeAdoptionSignalGuidanceDto {
+    fn from(guidance: RuntimeAdoptionSignalGuidance) -> Self {
+        Self {
+            signal: guidance.signal,
+            when: guidance.when,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionTrackGuidance> for RuntimeAdoptionTrackGuidanceDto {
+    fn from(guidance: RuntimeAdoptionTrackGuidance) -> Self {
+        Self {
+            track: guidance.track,
+            when: guidance.when,
+            feature_examples: guidance.feature_examples,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -127,6 +127,99 @@ fn test_cli_phase3_adoption_record_stats_and_gate() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_guidance_json_is_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "adoption", "guidance", "--format", "json"],
+    );
+    assert!(
+        output.status.success(),
+        "guidance failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let guidance: Value = serde_json::from_slice(&output.stdout).expect("guidance json");
+    assert_eq!(guidance["version"], 1);
+    assert_eq!(
+        guidance["recording_rule"],
+        "record only concrete runtime outcomes, not speculation"
+    );
+    let required_fields = guidance["required_fields"]
+        .as_array()
+        .expect("required fields");
+    assert!(required_fields.iter().any(|field| field == "track"));
+    assert!(required_fields.iter().any(|field| field == "signal"));
+    assert!(required_fields.iter().any(|field| field == "feature"));
+    assert!(
+        guidance["signals"]
+            .as_array()
+            .expect("signals")
+            .iter()
+            .any(|signal| signal["signal"] == "used"
+                && signal["when"]
+                    .as_str()
+                    .expect("when")
+                    .contains("actually consumed"))
+    );
+    assert!(
+        guidance["signals"]
+            .as_array()
+            .expect("signals")
+            .iter()
+            .any(|signal| signal["signal"] == "rollback"
+                && signal["when"].as_str().expect("when").contains("reverted"))
+    );
+    assert!(
+        guidance["tracks"]
+            .as_array()
+            .expect("tracks")
+            .iter()
+            .any(|track| track["track"] == "card_context"
+                && track["feature_examples"]
+                    .as_array()
+                    .expect("feature examples")
+                    .iter()
+                    .any(|feature| feature == "include_cards"))
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_guidance_plain() {
+    let home = setup_cli_home();
+    let output = run_mempal(&home, &["phase3", "adoption", "guidance"]);
+    assert!(
+        output.status.success(),
+        "guidance failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("version=1"));
+    assert!(
+        stdout.contains("recording_rule=record only concrete runtime outcomes, not speculation")
+    );
+    assert!(stdout.contains("signal=used"));
+    assert!(stdout.contains("track=card_context"));
+}
+
+#[test]
+fn test_cli_phase3_adoption_guidance_rejects_invalid_format() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "adoption", "guidance", "--format", "yaml"],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 adoption format"));
+}
+
+#[test]
 fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
     let home = setup_cli_home();
     let gate = run_mempal(


### PR DESCRIPTION
## Summary

- Add P62 runtime adoption CLI guidance spec and implementation.
- Add `mempal phase3 adoption guidance --format plain|json`.
- Move runtime adoption guidance semantics into shared core code used by both CLI and MCP.
- Update `MIND-MODEL-DESIGN`, `AGENTS.md`, and `CLAUDE.md` inventories.

## Boundaries

- Read-only guidance only.
- No automatic event recording.
- No hooks/background instrumentation.
- No schema migration.
- No Phase-3 gate/default policy changes.

## Verification

- `agent-spec parse specs/p62-runtime-adoption-cli-guidance.spec.md`
- `agent-spec lint specs/p62-runtime-adoption-cli-guidance.spec.md --min-score 0.7`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_json_is_read_only`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_plain`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_rejects_invalid_format`
- `cargo test mcp::server::tests::test_mcp_phase3_guidance_action_is_read_only --lib`
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `git diff --check`
