### PR TITLE
feat: add runtime adoption record helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
+| `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -176,6 +177,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
+- `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 
 ### Spec 使用方式
 
@@ -211,7 +213,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/record/list/stats/gate/research_validate_plan（P60/P61） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/record/list/stats/gate/research_validate_plan（P60/P61/P63） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
+| `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -174,6 +175,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
+- `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 
 ### Spec 使用方式
 
@@ -209,7 +211,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/record/list/stats/gate/research_validate_plan（P60/P61） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/record/list/stats/gate/research_validate_plan（P60/P61/P63） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1320,6 +1320,13 @@ shares the guidance implementation with `mempal_phase3 action=guidance`, so MCP
 agents, humans, and non-MCP automation inspect the same semantics. This remains
 read-only and does not append adoption events or change Phase-3 gate policy.
 
+P63 adds a read-only record helper through
+`mempal phase3 adoption prepare-record` and
+`mempal_phase3 action=prepare_record`. The helper validates and normalizes
+candidate record inputs, then returns the equivalent CLI `record` command and
+MCP `record` payload with `writes=false`. It does not generate event ids unless
+the caller supplied one, and it does not append runtime adoption events.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md
+++ b/docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md
@@ -1,0 +1,42 @@
+# P63 Runtime Adoption Record Helper
+
+## Goal
+
+Add a read-only helper that prepares exact runtime adoption `record` inputs
+without appending an event.
+
+## Scope
+
+- Add `specs/p63-runtime-adoption-record-helper.spec.md`.
+- Add CLI `mempal phase3 adoption prepare-record`.
+- Add MCP `mempal_phase3 action=prepare_record`.
+- Return `writes=false`, a CLI `record_command`, and an MCP `record_payload`.
+- Update `MEMORY_PROTOCOL`, `MIND-MODEL-DESIGN.md`, `AGENTS.md`, and
+  `CLAUDE.md`.
+- Preserve read-only behavior and avoid schema/runtime default changes.
+
+## Steps
+
+- [x] Write failing CLI and MCP prepare-record tests.
+- [x] Implement shared record helper output.
+- [x] Wire CLI and MCP surfaces.
+- [x] Update protocol, design, and repository inventories.
+- [x] Run spec checks and Rust verification.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p63-runtime-adoption-record-helper.spec.md
+agent-spec lint specs/p63-runtime-adoption-record-helper.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_json_is_read_only
+cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_plain
+cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_rejects_invalid_track
+cargo test mcp::server::tests::test_mcp_phase3_prepare_record_action_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p63-runtime-adoption-record-helper.spec.md
+++ b/specs/p63-runtime-adoption-record-helper.spec.md
@@ -1,0 +1,104 @@
+spec: task
+name: "P63: runtime adoption record helper"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "cli", "mcp"]
+---
+
+## Intent
+
+P61 and P62 expose when runtime adoption evidence should be recorded, but
+agents still have to manually assemble the exact `record` parameters. P63 adds
+a read-only helper that validates and normalizes candidate record inputs, then
+returns the equivalent CLI command and MCP payload without appending an event.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption prepare-record`.
+- Add MCP `mempal_phase3 action=prepare_record`.
+- The helper validates `track`, `signal`, `feature`, and optional metadata JSON
+  using the same parsing rules as `record`.
+- The helper returns `writes=false`, a CLI `record_command`, and an MCP
+  `record_payload`.
+- The helper must not generate a runtime event id unless the caller explicitly
+  supplied one.
+- The helper is read-only and must not insert runtime adoption events.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/phase3.rs`
+- `src/main.rs`
+- `src/mcp/**`
+- `src/core/protocol.rs`
+- `tests/phase3_runtime.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md`
+- `specs/p63-runtime-adoption-record-helper.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not create runtime adoption event ids for dry-run helper calls unless an
+  explicit id was provided.
+
+## Acceptance Criteria
+
+Scenario: CLI prepare-record returns JSON without writing events
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_json_is_read_only
+  Level: integration
+  Given an empty CLI HOME
+  And `skill trigger` is the query text
+  When running `mempal phase3 adoption prepare-record --track card_context --signal accepted --feature include_cards --query "skill trigger" --format json`
+  Then stdout is valid JSON
+  And the response includes `writes=false`
+  And `record_command` starts with `mempal phase3 adoption record`
+  And `record_payload.action` is `record`
+  And `record_payload.track` is `card_context`
+  And runtime adoption event count remains zero
+
+Scenario: CLI prepare-record supports plain output
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_plain
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption prepare-record --track card_context --signal used --feature include_cards`
+  Then stdout mentions `writes=false`
+  And stdout mentions `mempal phase3 adoption record`
+  And stdout mentions `action=record`
+
+Scenario: CLI prepare-record rejects invalid track
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_rejects_invalid_track
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption prepare-record --track invalid --signal accepted --feature x`
+  Then the command fails
+  And stderr mentions `unsupported runtime adoption track`
+
+Scenario: MCP prepare_record is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_prepare_record_action_is_read_only
+  Level: unit
+  Given an empty test database
+  When `mempal_phase3` is called with `action=prepare_record`
+  Then the response includes `writes=false`
+  And the response includes a `record_payload` with `action=record`
+  And runtime adoption event count remains zero
+
+## Out of Scope
+
+- Automatic recording after helper output.
+- Adoption-event deduplication.
+- New analytics beyond existing `stats`.
+- Any default-on policy changes.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use serde_json::{Map, Value};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionGuidance {
@@ -21,6 +22,28 @@ pub struct RuntimeAdoptionTrackGuidance {
     pub track: String,
     pub when: String,
     pub feature_examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuntimeAdoptionRecordPlan {
+    pub writes: bool,
+    pub record_command: Vec<String>,
+    pub record_payload: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeAdoptionRecordPlanInput {
+    pub id: Option<String>,
+    pub track: String,
+    pub signal: String,
+    pub feature: String,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<Value>,
 }
 
 pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
@@ -104,5 +127,76 @@ pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
                 feature_examples: vec!["research_validate_plan".to_string()],
             },
         ],
+    }
+}
+
+pub fn prepare_runtime_adoption_record(
+    input: RuntimeAdoptionRecordPlanInput,
+) -> RuntimeAdoptionRecordPlan {
+    let mut command = vec![
+        "mempal".to_string(),
+        "phase3".to_string(),
+        "adoption".to_string(),
+        "record".to_string(),
+    ];
+    push_command_arg(&mut command, "--track", &input.track);
+    push_command_arg(&mut command, "--signal", &input.signal);
+    push_command_arg(&mut command, "--feature", &input.feature);
+    if let Some(value) = input.query.as_deref() {
+        push_command_arg(&mut command, "--query", value);
+    }
+    if let Some(value) = input.context_hash.as_deref() {
+        push_command_arg(&mut command, "--context-hash", value);
+    }
+    if let Some(value) = input.card_id.as_deref() {
+        push_command_arg(&mut command, "--card-id", value);
+    }
+    if let Some(value) = input.evaluator_id.as_deref() {
+        push_command_arg(&mut command, "--evaluator-id", value);
+    }
+    if let Some(value) = input.research_report_id.as_deref() {
+        push_command_arg(&mut command, "--research-report-id", value);
+    }
+    if let Some(value) = input.note.as_deref() {
+        push_command_arg(&mut command, "--note", value);
+    }
+    if let Some(value) = input.id.as_deref() {
+        push_command_arg(&mut command, "--id", value);
+    }
+    if let Some(metadata) = input.metadata.as_ref() {
+        push_command_arg(&mut command, "--metadata-json", &metadata.to_string());
+    }
+
+    let mut payload = Map::new();
+    payload.insert("action".to_string(), Value::String("record".to_string()));
+    insert_payload_string(&mut payload, "id", input.id);
+    insert_payload_string(&mut payload, "track", Some(input.track));
+    insert_payload_string(&mut payload, "signal", Some(input.signal));
+    insert_payload_string(&mut payload, "feature", Some(input.feature));
+    insert_payload_string(&mut payload, "query", input.query);
+    insert_payload_string(&mut payload, "context_hash", input.context_hash);
+    insert_payload_string(&mut payload, "card_id", input.card_id);
+    insert_payload_string(&mut payload, "evaluator_id", input.evaluator_id);
+    insert_payload_string(&mut payload, "research_report_id", input.research_report_id);
+    insert_payload_string(&mut payload, "note", input.note);
+    if let Some(metadata) = input.metadata {
+        payload.insert("metadata".to_string(), metadata);
+    }
+
+    RuntimeAdoptionRecordPlan {
+        writes: false,
+        record_command: command,
+        record_payload: Value::Object(payload),
+    }
+}
+
+fn push_command_arg(command: &mut Vec<String>, name: &str, value: &str) {
+    command.push(name.to_string());
+    command.push(value.to_string());
+}
+
+fn insert_payload_string(payload: &mut Map<String, Value>, key: &str, value: Option<String>) {
+    if let Some(value) = value {
+        payload.insert(key.to_string(), Value::String(value));
     }
 }

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,17 +213,18 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/record/list/stats/gate/research_validate_plan actions over
-   Phase-3 runtime_adoption_events. Start with action=guidance when unsure
-   whether a runtime outcome should be recorded. Record used when guidance was actually consumed,
-   accepted when it materially helped, rejected when it was
-   considered and intentionally not followed, miss when useful guidance should
-   have appeared but did not, rollback when behavior was reverted because
-   guidance degraded the outcome, contradiction when guidance conflicted with
-   stronger evidence or instructions, and neutral when no clear outcome impact
-   is known. Gate and research_validate_plan are advisory and read-only: they
-   do not enable card context by default, add card embeddings, mutate evaluator
-   lifecycle state, or promote research output into knowledge.
+   guidance/prepare_record/record/list/stats/gate/research_validate_plan
+   actions over Phase-3 runtime_adoption_events. Start with action=guidance
+   when unsure whether a runtime outcome should be recorded. Use
+   action=prepare_record to validate and assemble exact record inputs before
+   writing; prepare_record is read-only and does not append events. Record used when guidance was actually consumed,
+   accepted when it materially helped, rejected when it was considered and
+   intentionally not followed, miss when useful guidance should have appeared
+   but did not, rollback when behavior was reverted because guidance degraded the outcome, contradiction when guidance
+   conflicted with stronger evidence or instructions, and neutral when no clear
+   outcome impact is known. Gate and research_validate_plan are advisory and
+   read-only: they do not enable card context by default, add card embeddings,
+   mutate evaluator lifecycle state, or promote research output into knowledge.
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
@@ -234,7 +235,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,10 @@ use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
     config::Config,
     db::Database,
-    phase3::{RuntimeAdoptionGuidance, runtime_adoption_guidance},
+    phase3::{
+        RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        prepare_runtime_adoption_record, runtime_adoption_guidance,
+    },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
         AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
@@ -53,6 +56,7 @@ use mempal::knowledge_lifecycle::{
 use mempal::mcp::MempalMcpServer;
 use mempal::search::{SearchFilters, SearchOptions, search_with_options};
 use serde::Serialize;
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 mod longmemeval;
@@ -577,6 +581,32 @@ enum Phase3Commands {
 #[allow(clippy::large_enum_variant)] // `record` intentionally carries the full event payload.
 enum Phase3AdoptionCommands {
     Guidance {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    PrepareRecord {
+        #[arg(long)]
+        track: String,
+        #[arg(long)]
+        signal: String,
+        #[arg(long)]
+        feature: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2187,6 +2217,42 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
         Phase3AdoptionCommands::Guidance { format } => {
             print_runtime_adoption_guidance(&runtime_adoption_guidance(), &format)
         }
+        Phase3AdoptionCommands::PrepareRecord {
+            track,
+            signal,
+            feature,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            format,
+        } => {
+            let track = parse_runtime_adoption_track(&track)?;
+            let signal = parse_runtime_adoption_signal(&signal)?;
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let plan = prepare_runtime_adoption_record(RuntimeAdoptionRecordPlanInput {
+                id,
+                track: runtime_adoption_track_slug(&track).to_string(),
+                signal: runtime_adoption_signal_slug(&signal).to_string(),
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+            });
+            print_runtime_adoption_record_plan(&plan, &format)
+        }
         Phase3AdoptionCommands::Record {
             track,
             signal,
@@ -2297,6 +2363,31 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn print_runtime_adoption_record_plan(
+    plan: &RuntimeAdoptionRecordPlan,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", plan.writes);
+            println!("record_command={}", plan.record_command.join(" "));
+            if let Some(action) = plan.record_payload.get("action").and_then(Value::as_str) {
+                println!("action={action}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(plan)
+                    .context("failed to serialize runtime adoption record plan")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,7 +5,9 @@ use crate::context::assemble_context_with_vector;
 use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
-    phase3::runtime_adoption_guidance,
+    phase3::{
+        RuntimeAdoptionRecordPlanInput, prepare_runtime_adoption_record, runtime_adoption_guidance,
+    },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
         KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
@@ -672,6 +674,18 @@ fn runtime_adoption_track_slug(track: &RuntimeAdoptionTrack) -> &'static str {
     }
 }
 
+fn runtime_adoption_signal_slug(signal: &RuntimeAdoptionSignal) -> &'static str {
+    match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    }
+}
+
 fn phase3_event_id(
     track: &RuntimeAdoptionTrack,
     signal: &RuntimeAdoptionSignal,
@@ -1330,7 +1344,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1342,12 +1356,46 @@ impl MempalMcpServer {
         match action {
             "guidance" => Ok(Json(Phase3Response {
                 guidance: Some(runtime_adoption_guidance().into()),
+                record_plan: None,
                 event: None,
                 events: Vec::new(),
                 stats: None,
                 gate: None,
                 research_plan: None,
             })),
+            "prepare_record" => {
+                let track = parse_runtime_adoption_track(required_string(
+                    request.track.as_deref(),
+                    "track",
+                )?)?;
+                let signal = parse_runtime_adoption_signal(required_string(
+                    request.signal.as_deref(),
+                    "signal",
+                )?)?;
+                let feature = required_string(request.feature.as_deref(), "feature")?.to_string();
+                let plan = prepare_runtime_adoption_record(RuntimeAdoptionRecordPlanInput {
+                    id: trim_to_owned(request.id.as_deref()),
+                    track: runtime_adoption_track_slug(&track).to_string(),
+                    signal: runtime_adoption_signal_slug(&signal).to_string(),
+                    feature,
+                    query: trim_to_owned(request.query.as_deref()),
+                    context_hash: trim_to_owned(request.context_hash.as_deref()),
+                    card_id: trim_to_owned(request.card_id.as_deref()),
+                    evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                    research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                    note: trim_to_owned(request.note.as_deref()),
+                    metadata: request.metadata,
+                });
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: Some(plan.into()),
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
             "record" => {
                 let db = self.open_db()?;
                 let track = parse_runtime_adoption_track(required_string(
@@ -1383,6 +1431,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1408,6 +1457,7 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1436,6 +1486,7 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1449,6 +1500,7 @@ impl MempalMcpServer {
                 let gate = phase3_gate_report(&db, candidate)?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1462,6 +1514,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1471,7 +1524,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3695,7 +3748,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, record, list, stats, gate, research_validate_plan"
             )
         );
 
@@ -3765,6 +3818,47 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_prepare_record_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "prepare_record",
+                "track": "card_context",
+                "signal": "accepted",
+                "feature": "include_cards",
+                "query": "skill trigger"
+            }))
+            .await
+            .expect("prepare record");
+        let plan = response.record_plan.expect("record plan");
+        assert!(!plan.writes);
+        assert_eq!(plan.record_payload["action"], "record");
+        assert_eq!(plan.record_payload["track"], "card_context");
+        assert_eq!(plan.record_payload["signal"], "accepted");
+        assert_eq!(plan.record_payload["feature"], "include_cards");
+        assert_eq!(plan.record_payload["query"], "skill trigger");
+        assert_eq!(plan.record_command[0], "mempal");
+        assert_eq!(plan.record_command[1], "phase3");
+        assert_eq!(plan.record_command[2], "adoption");
+        assert_eq!(plan.record_command[3], "record");
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -3775,9 +3869,9 @@ mod tests {
             .expect("mempal_phase3 tool exists");
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
-        assert!(
-            description.contains("Actions: guidance/record/list/stats/gate/research_validate_plan")
-        );
+        assert!(description.contains(
+            "Actions: guidance/prepare_record/record/list/stats/gate/research_validate_plan"
+        ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
-    RuntimeAdoptionGuidance, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
+    RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionSignalGuidance,
+    RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
@@ -332,6 +333,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guidance: Option<RuntimeAdoptionGuidanceDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_plan: Option<RuntimeAdoptionRecordPlanDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -364,6 +367,23 @@ pub struct RuntimeAdoptionTrackGuidanceDto {
     pub track: String,
     pub when: String,
     pub feature_examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionRecordPlanDto {
+    pub writes: bool,
+    pub record_command: Vec<String>,
+    pub record_payload: serde_json::Value,
+}
+
+impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {
+    fn from(plan: RuntimeAdoptionRecordPlan) -> Self {
+        Self {
+            writes: plan.writes,
+            record_command: plan.record_command,
+            record_payload: plan.record_payload,
+        }
+    }
 }
 
 impl From<RuntimeAdoptionGuidance> for RuntimeAdoptionGuidanceDto {

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -220,6 +220,102 @@ fn test_cli_phase3_adoption_guidance_rejects_invalid_format() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_prepare_record_json_is_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "prepare-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--query",
+            "skill trigger",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "prepare-record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let plan: Value = serde_json::from_slice(&output.stdout).expect("prepare-record json");
+    assert_eq!(plan["writes"], false);
+    let command = plan["record_command"].as_array().expect("record command");
+    assert_eq!(command[0], "mempal");
+    assert_eq!(command[1], "phase3");
+    assert_eq!(command[2], "adoption");
+    assert_eq!(command[3], "record");
+    assert_eq!(plan["record_payload"]["action"], "record");
+    assert_eq!(plan["record_payload"]["track"], "card_context");
+    assert_eq!(plan["record_payload"]["signal"], "accepted");
+    assert_eq!(plan["record_payload"]["feature"], "include_cards");
+    assert_eq!(plan["record_payload"]["query"], "skill trigger");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_prepare_record_plain() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "prepare-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "used",
+            "--feature",
+            "include_cards",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "prepare-record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("writes=false"));
+    assert!(stdout.contains("mempal phase3 adoption record"));
+    assert!(stdout.contains("action=record"));
+}
+
+#[test]
+fn test_cli_phase3_adoption_prepare_record_rejects_invalid_track() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "prepare-record",
+            "--track",
+            "invalid",
+            "--signal",
+            "accepted",
+            "--feature",
+            "x",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported runtime adoption track"));
+}
+
+#[test]
 fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
     let home = setup_cli_home();
     let gate = run_mempal(


### PR DESCRIPTION
## Summary

- Add P63 runtime adoption record helper spec and implementation.
- Add CLI `mempal phase3 adoption prepare-record`.
- Add MCP `mempal_phase3 action=prepare_record`.
- Return `writes=false`, `record_command`, and `record_payload` without appending events.
- Update `MEMORY_PROTOCOL`, `MIND-MODEL-DESIGN`, `AGENTS.md`, and `CLAUDE.md` inventories.

## Boundaries

- Read-only helper only.
- No automatic event recording.
- No hooks/background instrumentation.
- No schema migration.
- No Phase-3 gate/default policy changes.
- No generated event id unless caller explicitly provides one.

## Verification

- `agent-spec parse specs/p63-runtime-adoption-record-helper.spec.md`
- `agent-spec lint specs/p63-runtime-adoption-record-helper.spec.md --min-score 0.7`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_json_is_read_only`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_plain`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_rejects_invalid_track`
- `cargo test mcp::server::tests::test_mcp_phase3_prepare_record_action_is_read_only --lib`
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `git diff --check`
