### PR TITLE
feat: add runtime adoption record quality policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
+| `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -178,6 +179,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
+- `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 
 ### Spec 使用方式
 
@@ -213,7 +215,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/record/list/stats/gate/research_validate_plan（P60/P61/P63） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
+| `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -176,6 +177,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
+- `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 
 ### Spec 使用方式
 
@@ -211,7 +213,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/record/list/stats/gate/research_validate_plan（P60/P61/P63） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1327,6 +1327,16 @@ candidate record inputs, then returns the equivalent CLI `record` command and
 MCP `record` payload with `writes=false`. It does not generate event ids unless
 the caller supplied one, and it does not append runtime adoption events.
 
+P64 adds a read-only record quality policy through
+`mempal phase3 adoption check-record` and
+`mempal_phase3 action=check_record`. The policy evaluates candidate runtime
+adoption event quality before writing and returns `writes=false`, `valid`,
+`quality`, `errors`, and `warnings`. It treats empty `feature` as an error,
+warns when outcome-bearing signals lack concrete note/query context, and warns
+when track-specific references such as `card_id`, `evaluator_id`, or
+`research_report_id` are missing. This remains advisory only: it does not append
+events and does not block the lower-level `record` command.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md
+++ b/docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md
@@ -1,0 +1,34 @@
+# P64 Runtime Adoption Record Quality Policy
+
+Goal: add a read-only preflight quality check for candidate runtime adoption
+records. The check should help agents avoid writing low-signal Phase-3 evidence,
+without adding hooks, automatic writes, schema changes, or default runtime
+policy changes.
+
+Spec: `specs/p64-runtime-adoption-record-quality-policy.spec.md`
+
+## Steps
+
+- [x] Add shared core quality report types and policy logic.
+- [x] Add CLI `mempal phase3 adoption check-record` with plain/json output.
+- [x] Add MCP `mempal_phase3 action=check_record`.
+- [x] Update protocol, MIND-MODEL design, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p64-runtime-adoption-record-quality-policy.spec.md
+agent-spec lint specs/p64-runtime-adoption-record-quality-policy.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_json_accepts_supported_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_json_warns_on_weak_evidence
+cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_rejects_empty_feature
+cargo test mcp::server::tests::test_mcp_phase3_check_record_action_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p64-runtime-adoption-record-quality-policy.spec.md
+++ b/specs/p64-runtime-adoption-record-quality-policy.spec.md
@@ -1,0 +1,116 @@
+spec: task
+name: "P64: runtime adoption record quality policy"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "quality", "cli", "mcp"]
+---
+
+## Intent
+
+P63 can prepare exact runtime adoption record inputs, but it does not tell
+agents whether the proposed event is high-quality enough to preserve as Phase-3
+evidence. P64 adds a read-only quality policy that evaluates candidate adoption
+record fields before writing, so agents can avoid low-signal evidence without
+adding automatic recording or new runtime authority.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption check-record`.
+- Add MCP `mempal_phase3 action=check_record`.
+- The quality policy reuses the same `track`, `signal`, `feature`, and optional
+  metadata parsing rules as `prepare-record` and `record`.
+- The response returns `writes=false`, `valid`, `quality`, `errors`, and
+  `warnings`.
+- Empty `feature` is an error.
+- `accepted`, `rejected`, `miss`, `rollback`, and `contradiction` should include
+  a concrete `note` or `query`; missing both is a warning.
+- Track-specific references are warnings, not hard errors:
+  `card_context`/`card_embedding` prefer `card_id`, `evaluator` prefers
+  `evaluator_id`, and `research_adapter` prefers `research_report_id`.
+- The check remains advisory and must not append runtime adoption events.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/phase3.rs`
+- `src/main.rs`
+- `src/mcp/**`
+- `src/core/protocol.rs`
+- `tests/phase3_runtime.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md`
+- `specs/p64-runtime-adoption-record-quality-policy.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not block `record`; this policy is a preflight/advisory check only.
+
+## Acceptance Criteria
+
+Scenario: CLI check-record accepts a well-supported event
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_json_accepts_supported_event
+  Level: integration
+  Given an empty CLI HOME
+  And `skill trigger` is the query text
+  And `card evidence helped` is the note text
+  When running `mempal phase3 adoption check-record --track card_context --signal accepted --feature include_cards --query "skill trigger" --card-id card_1 --note "card evidence helped" --format json`
+  Then stdout is valid JSON
+  And the response includes `writes=false`
+  And `valid` is true
+  And `quality` is `ready`
+  And `errors` is empty
+  And runtime adoption event count remains zero
+
+Scenario: CLI check-record warns on weak evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_json_warns_on_weak_evidence
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption check-record --track card_context --signal accepted --feature include_cards --format json`
+  Then stdout is valid JSON
+  And `valid` is true
+  And `quality` is `warning`
+  And `warnings` mentions missing concrete outcome context
+  And `warnings` mentions missing `card_id`
+  And runtime adoption event count remains zero
+
+Scenario: CLI check-record rejects empty feature
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_rejects_empty_feature
+  Level: integration
+  Given an empty CLI HOME
+  And the feature text contains only spaces
+  When running `mempal phase3 adoption check-record --track card_context --signal accepted --feature "   " --format json`
+  Then the command succeeds with an advisory JSON response
+  And `valid` is false
+  And `quality` is `invalid`
+  And `errors` mentions `feature must not be empty`
+  And runtime adoption event count remains zero
+
+Scenario: MCP check_record is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_check_record_action_is_read_only
+  Level: unit
+  Given an empty test database
+  When `mempal_phase3` is called with `action=check_record`
+  Then the response includes `writes=false`
+  And the response includes a quality report
+  And runtime adoption event count remains zero
+
+## Out of Scope
+
+- Automatic recording after quality checks.
+- Deduplicating or modifying existing adoption events.
+- New readiness thresholds for Phase-3 gates.
+- Default-on runtime policy changes.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -31,6 +31,15 @@ pub struct RuntimeAdoptionRecordPlan {
     pub record_payload: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionRecordQualityReport {
+    pub writes: bool,
+    pub valid: bool,
+    pub quality: String,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeAdoptionRecordPlanInput {
     pub id: Option<String>,
@@ -188,6 +197,69 @@ pub fn prepare_runtime_adoption_record(
         record_command: command,
         record_payload: Value::Object(payload),
     }
+}
+
+pub fn check_runtime_adoption_record(
+    input: &RuntimeAdoptionRecordPlanInput,
+) -> RuntimeAdoptionRecordQualityReport {
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    if is_blank(&input.feature) {
+        errors.push("feature must not be empty".to_string());
+    }
+
+    if requires_outcome_context(&input.signal)
+        && input.query.as_deref().is_none_or(is_blank)
+        && input.note.as_deref().is_none_or(is_blank)
+    {
+        warnings.push(
+            "missing concrete outcome context: provide note or query for this signal".to_string(),
+        );
+    }
+
+    match input.track.as_str() {
+        "card_context" | "card_embedding" if input.card_id.as_deref().is_none_or(is_blank) => {
+            warnings.push("missing card_id for card-related adoption evidence".to_string());
+        }
+        "evaluator" if input.evaluator_id.as_deref().is_none_or(is_blank) => {
+            warnings.push("missing evaluator_id for evaluator adoption evidence".to_string());
+        }
+        "research_adapter" if input.research_report_id.as_deref().is_none_or(is_blank) => {
+            warnings.push(
+                "missing research_report_id for research adapter adoption evidence".to_string(),
+            );
+        }
+        _ => {}
+    }
+
+    let quality = if !errors.is_empty() {
+        "invalid"
+    } else if !warnings.is_empty() {
+        "warning"
+    } else {
+        "ready"
+    }
+    .to_string();
+
+    RuntimeAdoptionRecordQualityReport {
+        writes: false,
+        valid: errors.is_empty(),
+        quality,
+        errors,
+        warnings,
+    }
+}
+
+fn requires_outcome_context(signal: &str) -> bool {
+    matches!(
+        signal,
+        "accepted" | "rejected" | "miss" | "rollback" | "contradiction"
+    )
+}
+
+fn is_blank(value: &str) -> bool {
+    value.trim().is_empty()
 }
 
 fn push_command_arg(command: &mut Vec<String>, name: &str, value: &str) {

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,11 +213,14 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/record/list/stats/gate/research_validate_plan
+   guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
-   writing; prepare_record is read-only and does not append events. Record used when guidance was actually consumed,
+   writing; prepare_record is read-only and does not append events. Use
+   action=check_record to evaluate event quality before writing; check_record is
+   advisory, read-only, and reports errors/warnings without blocking record.
+   Record used when guidance was actually consumed,
    accepted when it materially helped, rejected when it was considered and
    intentionally not followed, miss when useful guidance should have appeared
    but did not, rollback when behavior was reverted because guidance degraded the outcome, contradiction when guidance
@@ -235,7 +238,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use mempal::core::{
     db::Database,
     phase3::{
         RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        RuntimeAdoptionRecordQualityReport, check_runtime_adoption_record,
         prepare_runtime_adoption_record, runtime_adoption_guidance,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
@@ -585,6 +586,32 @@ enum Phase3AdoptionCommands {
         format: String,
     },
     PrepareRecord {
+        #[arg(long)]
+        track: String,
+        #[arg(long)]
+        signal: String,
+        #[arg(long)]
+        feature: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    CheckRecord {
         #[arg(long)]
         track: String,
         #[arg(long)]
@@ -2253,6 +2280,43 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             });
             print_runtime_adoption_record_plan(&plan, &format)
         }
+        Phase3AdoptionCommands::CheckRecord {
+            track,
+            signal,
+            feature,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            format,
+        } => {
+            let track = parse_runtime_adoption_track(&track)?;
+            let signal = parse_runtime_adoption_signal(&signal)?;
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let input = RuntimeAdoptionRecordPlanInput {
+                id,
+                track: runtime_adoption_track_slug(&track).to_string(),
+                signal: runtime_adoption_signal_slug(&signal).to_string(),
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+            };
+            let report = check_runtime_adoption_record(&input);
+            print_runtime_adoption_record_quality(&report, &format)
+        }
         Phase3AdoptionCommands::Record {
             track,
             signal,
@@ -2363,6 +2427,35 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn print_runtime_adoption_record_quality(
+    report: &RuntimeAdoptionRecordQualityReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("valid={}", report.valid);
+            println!("quality={}", report.quality);
+            for error in &report.errors {
+                println!("error={error}");
+            }
+            for warning in &report.warnings {
+                println!("warning={warning}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption record quality report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,7 +6,8 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionRecordPlanInput, prepare_runtime_adoption_record, runtime_adoption_guidance,
+        RuntimeAdoptionRecordPlanInput, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, runtime_adoption_guidance,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1344,7 +1345,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1357,6 +1358,7 @@ impl MempalMcpServer {
             "guidance" => Ok(Json(Phase3Response {
                 guidance: Some(runtime_adoption_guidance().into()),
                 record_plan: None,
+                record_quality: None,
                 event: None,
                 events: Vec::new(),
                 stats: None,
@@ -1389,6 +1391,41 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: Some(plan.into()),
+                    record_quality: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "check_record" => {
+                let track = parse_runtime_adoption_track(required_string(
+                    request.track.as_deref(),
+                    "track",
+                )?)?;
+                let signal = parse_runtime_adoption_signal(required_string(
+                    request.signal.as_deref(),
+                    "signal",
+                )?)?;
+                let feature = request.feature.unwrap_or_default();
+                let input = RuntimeAdoptionRecordPlanInput {
+                    id: trim_to_owned(request.id.as_deref()),
+                    track: runtime_adoption_track_slug(&track).to_string(),
+                    signal: runtime_adoption_signal_slug(&signal).to_string(),
+                    feature,
+                    query: trim_to_owned(request.query.as_deref()),
+                    context_hash: trim_to_owned(request.context_hash.as_deref()),
+                    card_id: trim_to_owned(request.card_id.as_deref()),
+                    evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                    research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                    note: trim_to_owned(request.note.as_deref()),
+                    metadata: request.metadata,
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: Some(check_runtime_adoption_record(&input).into()),
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1432,6 +1469,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1458,6 +1496,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1487,6 +1526,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1501,6 +1541,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1515,6 +1556,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1524,7 +1566,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3748,7 +3790,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, check_record, record, list, stats, gate, research_validate_plan"
             )
         );
 
@@ -3859,6 +3901,46 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_check_record_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "check_record",
+                "track": "card_context",
+                "signal": "accepted",
+                "feature": "include_cards"
+            }))
+            .await
+            .expect("check record");
+        let report = response.record_quality.expect("record quality");
+        assert!(!report.writes);
+        assert!(report.valid);
+        assert_eq!(report.quality, "warning");
+        assert!(report.errors.is_empty());
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("concrete outcome context"))
+        );
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -3870,7 +3952,7 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/record/list/stats/gate/research_validate_plan"
+            "Actions: guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,7 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
-    RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionSignalGuidance,
-    RuntimeAdoptionTrackGuidance,
+    RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport,
+    RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
@@ -335,6 +335,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_plan: Option<RuntimeAdoptionRecordPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_quality: Option<RuntimeAdoptionRecordQualityDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -376,12 +378,33 @@ pub struct RuntimeAdoptionRecordPlanDto {
     pub record_payload: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionRecordQualityDto {
+    pub writes: bool,
+    pub valid: bool,
+    pub quality: String,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
 impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {
     fn from(plan: RuntimeAdoptionRecordPlan) -> Self {
         Self {
             writes: plan.writes,
             record_command: plan.record_command,
             record_payload: plan.record_payload,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionRecordQualityReport> for RuntimeAdoptionRecordQualityDto {
+    fn from(report: RuntimeAdoptionRecordQualityReport) -> Self {
+        Self {
+            writes: report.writes,
+            valid: report.valid,
+            quality: report.quality,
+            errors: report.errors,
+            warnings: report.warnings,
         }
     }
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -316,6 +316,140 @@ fn test_cli_phase3_adoption_prepare_record_rejects_invalid_track() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_check_record_json_accepts_supported_event() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "check-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--query",
+            "skill trigger",
+            "--card-id",
+            "card_1",
+            "--note",
+            "card evidence helped",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "check-record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("quality report json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["quality"], "ready");
+    assert!(report["errors"].as_array().expect("errors").is_empty());
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_check_record_json_warns_on_weak_evidence() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "check-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "check-record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("quality report json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["quality"], "warning");
+    let warnings = report["warnings"].as_array().expect("warnings");
+    assert!(warnings.iter().any(|warning| {
+        warning
+            .as_str()
+            .expect("warning")
+            .contains("concrete outcome context")
+    }));
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.as_str().expect("warning").contains("card_id"))
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_check_record_rejects_empty_feature() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "check-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "   ",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "check-record should report invalid input without failing: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("quality report json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["valid"], false);
+    assert_eq!(report["quality"], "invalid");
+    let errors = report["errors"].as_array().expect("errors");
+    assert!(errors.iter().any(|error| {
+        error
+            .as_str()
+            .expect("error")
+            .contains("feature must not be empty")
+    }));
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
 fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
     let home = setup_cli_home();
     let gate = run_mempal(


### PR DESCRIPTION
## Summary

Adds P64 runtime adoption record quality policy as a read-only preflight check for candidate Phase-3 adoption records.

- Adds CLI `mempal phase3 adoption check-record`
- Adds MCP `mempal_phase3 action=check_record`
- Returns `writes=false`, `valid`, `quality`, `errors`, and `warnings`
- Warns on weak evidence context and missing track-specific references without blocking `record`
- Updates protocol, MIND-MODEL, AGENTS/CLAUDE docs, plus P64 spec and plan

## Verification

- `agent-spec parse specs/p64-runtime-adoption-record-quality-policy.spec.md`
- `agent-spec lint specs/p64-runtime-adoption-record-quality-policy.spec.md --min-score 0.7`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_check_record`
- `cargo test mcp::server::tests::test_mcp_phase3_check_record_action_is_read_only --lib`
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --features rest -- -D warnings`
- `cargo test`
- `git diff --check`