### PR TITLE
feat: add runtime adoption review report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
+| `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -180,6 +181,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
+- `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 
 ### Spec 使用方式
 
@@ -215,7 +217,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
+| `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -178,6 +179,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
+- `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 
 ### Spec 使用方式
 
@@ -213,7 +215,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1337,6 +1337,15 @@ when track-specific references such as `card_id`, `evaluator_id`, or
 `research_report_id` are missing. This remains advisory only: it does not append
 events and does not block the lower-level `record` command.
 
+P65 adds a read-only runtime adoption review report through
+`mempal phase3 adoption review` and `mempal_phase3 action=review`. The report
+summarizes accumulated adoption evidence with applied filters, aggregate signal
+counts, per-feature counts, an advisory conclusion, and reasons. It supports
+track, feature, and signal filtering without schema changes; signal filtering is
+applied after DB retrieval. This gives future default-on specs a compact
+evidence artifact while preserving the Phase-3 boundary: review reports do not
+write events, change gates, or authorize runtime default changes.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-13-p65-runtime-adoption-review-report.md
+++ b/docs/plans/2026-05-13-p65-runtime-adoption-review-report.md
@@ -1,0 +1,36 @@
+# P65 Runtime Adoption Review Report
+
+Goal: add a read-only report for accumulated Phase-3 runtime adoption evidence,
+so agents can review track/feature/signal evidence before proposing stronger
+runtime defaults.
+
+Spec: `specs/p65-runtime-adoption-review-report.spec.md`
+
+## Steps
+
+- [x] Add shared review report types and aggregation logic.
+- [x] Add CLI `mempal phase3 adoption review` with plain/json output.
+- [x] Add MCP `mempal_phase3 action=review`.
+- [x] Update protocol, MIND-MODEL design, AGENTS, and CLAUDE docs.
+- [x] Stabilize the existing CLI knowledge-card retrieval test harness timeout
+  observed during full verification; production code unchanged.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p65-runtime-adoption-review-report.spec.md
+agent-spec lint specs/p65-runtime-adoption-review-report.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_summarizes_events
+cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_filters_signal
+cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_no_evidence_read_only
+cargo test mcp::server::tests::test_mcp_phase3_review_action_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p65-runtime-adoption-review-report.spec.md
+++ b/specs/p65-runtime-adoption-review-report.spec.md
@@ -1,0 +1,115 @@
+spec: task
+name: "P65: runtime adoption review report"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "review", "cli", "mcp"]
+---
+
+## Intent
+
+P54-P64 can collect and preflight runtime adoption events, but agents still need
+a compact way to review accumulated evidence before proposing stronger runtime
+defaults. P65 adds a read-only review report that summarizes adoption events by
+track, feature, and signal so future defaulting specs can cite concrete evidence
+instead of raw event lists.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption review`.
+- Add MCP `mempal_phase3 action=review`.
+- Review accepts optional `track`, `feature`, `signal`, `limit`, and `format`
+  filters.
+- Review returns `writes=false`, applied filters, aggregate signal counts,
+  per-feature signal counts, `conclusion`, and `reasons`.
+- `signal` filtering is applied after DB retrieval; it must not require schema
+  changes or new indexes.
+- Review is read-only and must not append runtime adoption events.
+- Review conclusions are advisory: `no_evidence`, `positive`, `rollback_risk`,
+  or `mixed`.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/phase3.rs`
+- `src/main.rs`
+- `src/mcp/**`
+- `src/core/protocol.rs`
+- `tests/phase3_runtime.rs`
+- `tests/knowledge_card_retrieval.rs` (test harness timeout robustness only)
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md`
+- `specs/p65-runtime-adoption-review-report.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not treat review conclusions as authority to mutate knowledge lifecycle or
+  runtime defaults.
+
+## Acceptance Criteria
+
+Scenario: CLI review summarizes card context evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_summarizes_events
+  Level: integration
+  Given an empty CLI HOME
+  And card context events include accepted and rejected signals
+  When running `mempal phase3 adoption review --track card_context --format json`
+  Then stdout is valid JSON
+  And the response includes `writes=false`
+  And `total` is 3
+  And `stats.accepted` is 2
+  And `stats.rejected` is 1
+  And `features[0].feature` is `include_cards`
+  And runtime adoption event count remains 3
+
+Scenario: CLI review supports signal filtering
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_filters_signal
+  Level: integration
+  Given an empty CLI HOME
+  And mixed card context events exist
+  When running `mempal phase3 adoption review --track card_context --signal accepted --format json`
+  Then stdout is valid JSON
+  And `total` is 2
+  And `stats.accepted` is 2
+  And `stats.rejected` is 0
+
+Scenario: CLI review reports no evidence without mutation
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_no_evidence_read_only
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption review --track evaluator --format json`
+  Then stdout is valid JSON
+  And `writes=false`
+  And `total` is 0
+  And `conclusion` is `no_evidence`
+  And runtime adoption event count remains zero
+
+Scenario: MCP review is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_review_action_is_read_only
+  Level: unit
+  Given an empty test database with one runtime adoption event
+  When `mempal_phase3` is called with `action=review`
+  Then the response includes `writes=false`
+  And the response includes a review report
+  And runtime adoption event count remains unchanged
+
+## Out of Scope
+
+- New write paths or automatic event capture.
+- New DB tables, migrations, or indexes.
+- Changing readiness gate thresholds.
+- Enabling card context, card embeddings, evaluator authority, or research
+  ingestion by default.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -1,5 +1,9 @@
+use std::collections::BTreeMap;
+
 use serde::Serialize;
 use serde_json::{Map, Value};
+
+use super::types::{RuntimeAdoptionEvent, RuntimeAdoptionSignal};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionGuidance {
@@ -38,6 +42,43 @@ pub struct RuntimeAdoptionRecordQualityReport {
     pub quality: String,
     pub errors: Vec<String>,
     pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionReviewFilters {
+    pub track: Option<String>,
+    pub feature: Option<String>,
+    pub signal: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct RuntimeAdoptionSignalCounts {
+    pub total: usize,
+    pub used: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub misses: usize,
+    pub rollbacks: usize,
+    pub contradictions: usize,
+    pub neutral: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionFeatureReview {
+    pub feature: String,
+    pub stats: RuntimeAdoptionSignalCounts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionReviewReport {
+    pub writes: bool,
+    pub filters: RuntimeAdoptionReviewFilters,
+    pub total: usize,
+    pub stats: RuntimeAdoptionSignalCounts,
+    pub features: Vec<RuntimeAdoptionFeatureReview>,
+    pub conclusion: String,
+    pub reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -251,6 +292,94 @@ pub fn check_runtime_adoption_record(
     }
 }
 
+pub fn review_runtime_adoption_events(
+    events: &[RuntimeAdoptionEvent],
+    filters: RuntimeAdoptionReviewFilters,
+) -> RuntimeAdoptionReviewReport {
+    let filtered_events = events
+        .iter()
+        .filter(|event| {
+            filters
+                .signal
+                .as_deref()
+                .is_none_or(|signal| runtime_adoption_signal_slug(&event.signal) == signal)
+        })
+        .collect::<Vec<_>>();
+
+    let stats = RuntimeAdoptionSignalCounts::from_events(filtered_events.iter().copied());
+    let mut by_feature = BTreeMap::<String, Vec<&RuntimeAdoptionEvent>>::new();
+    for event in &filtered_events {
+        by_feature
+            .entry(event.feature.clone())
+            .or_default()
+            .push(event);
+    }
+    let features = by_feature
+        .into_iter()
+        .map(|(feature, events)| RuntimeAdoptionFeatureReview {
+            feature,
+            stats: RuntimeAdoptionSignalCounts::from_events(events),
+        })
+        .collect::<Vec<_>>();
+
+    let (conclusion, reasons) = review_conclusion(&stats);
+
+    RuntimeAdoptionReviewReport {
+        writes: false,
+        filters,
+        total: stats.total,
+        stats,
+        features,
+        conclusion,
+        reasons,
+    }
+}
+
+impl RuntimeAdoptionSignalCounts {
+    fn from_events<'a>(events: impl IntoIterator<Item = &'a RuntimeAdoptionEvent>) -> Self {
+        let mut stats = Self::default();
+        for event in events {
+            stats.total += 1;
+            match event.signal {
+                RuntimeAdoptionSignal::Used => stats.used += 1,
+                RuntimeAdoptionSignal::Accepted => stats.accepted += 1,
+                RuntimeAdoptionSignal::Rejected => stats.rejected += 1,
+                RuntimeAdoptionSignal::Miss => stats.misses += 1,
+                RuntimeAdoptionSignal::Rollback => stats.rollbacks += 1,
+                RuntimeAdoptionSignal::Contradiction => stats.contradictions += 1,
+                RuntimeAdoptionSignal::Neutral => stats.neutral += 1,
+            }
+        }
+        stats
+    }
+}
+
+fn review_conclusion(stats: &RuntimeAdoptionSignalCounts) -> (String, Vec<String>) {
+    if stats.total == 0 {
+        return (
+            "no_evidence".to_string(),
+            vec!["no runtime adoption events match the requested filters".to_string()],
+        );
+    }
+    if stats.rollbacks > 0 {
+        return (
+            "rollback_risk".to_string(),
+            vec!["rollback evidence exists for this adoption surface".to_string()],
+        );
+    }
+    if stats.accepted > 0 && stats.accepted >= stats.rejected + stats.misses + stats.contradictions
+    {
+        return (
+            "positive".to_string(),
+            vec!["accepted evidence is at least as strong as negative evidence".to_string()],
+        );
+    }
+    (
+        "mixed".to_string(),
+        vec!["evidence is present but not clearly positive".to_string()],
+    )
+}
+
 fn requires_outcome_context(signal: &str) -> bool {
     matches!(
         signal,
@@ -260,6 +389,18 @@ fn requires_outcome_context(signal: &str) -> bool {
 
 fn is_blank(value: &str) -> bool {
     value.trim().is_empty()
+}
+
+fn runtime_adoption_signal_slug(signal: &RuntimeAdoptionSignal) -> &'static str {
+    match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    }
 }
 
 fn push_command_arg(command: &mut Vec<String>, name: &str, value: &str) {

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,13 +213,15 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan
+   guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record.
+   Use action=review to summarize accumulated evidence by track, feature, and
+   signal before proposing stronger defaults; review is read-only and advisory.
    Record used when guidance was actually consumed,
    accepted when it materially helped, rejected when it was considered and
    intentionally not followed, miss when useful guidance should have appeared
@@ -238,7 +240,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,9 @@ use mempal::core::{
     db::Database,
     phase3::{
         RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionRecordQualityReport, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, runtime_adoption_guidance,
+        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
+        RuntimeAdoptionReviewReport, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -634,6 +635,18 @@ enum Phase3AdoptionCommands {
         metadata_json: Option<String>,
         #[arg(long)]
         id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Review {
+        #[arg(long)]
+        track: Option<String>,
+        #[arg(long)]
+        feature: Option<String>,
+        #[arg(long)]
+        signal: Option<String>,
+        #[arg(long, default_value_t = 10_000)]
+        limit: usize,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2317,6 +2330,47 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let report = check_runtime_adoption_record(&input);
             print_runtime_adoption_record_quality(&report, &format)
         }
+        Phase3AdoptionCommands::Review {
+            track,
+            feature,
+            signal,
+            limit,
+            format,
+        } => {
+            let track = track
+                .as_deref()
+                .map(parse_runtime_adoption_track)
+                .transpose()?;
+            let signal = signal
+                .as_deref()
+                .map(parse_runtime_adoption_signal)
+                .transpose()?;
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: track.clone(),
+                        feature: feature.clone(),
+                    },
+                    limit,
+                )
+                .context("failed to list runtime adoption events")?;
+            let report = review_runtime_adoption_events(
+                &events,
+                RuntimeAdoptionReviewFilters {
+                    track: track
+                        .as_ref()
+                        .map(runtime_adoption_track_slug)
+                        .map(str::to_string),
+                    feature,
+                    signal: signal
+                        .as_ref()
+                        .map(runtime_adoption_signal_slug)
+                        .map(str::to_string),
+                    limit,
+                },
+            );
+            print_runtime_adoption_review(&report, &format)
+        }
         Phase3AdoptionCommands::Record {
             track,
             signal,
@@ -2427,6 +2481,40 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn print_runtime_adoption_review(report: &RuntimeAdoptionReviewReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("total={}", report.total);
+            println!("conclusion={}", report.conclusion);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            for feature in &report.features {
+                println!(
+                    "feature={} total={} accepted={} rejected={} misses={} rollbacks={}",
+                    feature.feature,
+                    feature.stats.total,
+                    feature.stats.accepted,
+                    feature.stats.rejected,
+                    feature.stats.misses,
+                    feature.stats.rollbacks
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption review report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,8 +6,9 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionRecordPlanInput, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, runtime_adoption_guidance,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
+        check_runtime_adoption_record, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1345,7 +1346,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1359,6 +1360,7 @@ impl MempalMcpServer {
                 guidance: Some(runtime_adoption_guidance().into()),
                 record_plan: None,
                 record_quality: None,
+                review_report: None,
                 event: None,
                 events: Vec::new(),
                 stats: None,
@@ -1392,6 +1394,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: Some(plan.into()),
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1426,6 +1429,58 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: Some(check_runtime_adoption_record(&input).into()),
+                    review_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "review" => {
+                let db = self.open_db()?;
+                let track = parse_runtime_adoption_track_opt(request.track.as_deref())?;
+                let signal = request
+                    .signal
+                    .as_deref()
+                    .map(parse_runtime_adoption_signal)
+                    .transpose()?;
+                let feature = trim_to_owned(request.feature.as_deref());
+                let limit = request.limit.unwrap_or(10_000);
+                let events = db
+                    .list_runtime_adoption_events(
+                        &RuntimeAdoptionFilter {
+                            track: track.clone(),
+                            feature: feature.clone(),
+                        },
+                        limit,
+                    )
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to list runtime adoption events: {error}"),
+                            None,
+                        )
+                    })?;
+                let report = review_runtime_adoption_events(
+                    &events,
+                    RuntimeAdoptionReviewFilters {
+                        track: track
+                            .as_ref()
+                            .map(runtime_adoption_track_slug)
+                            .map(str::to_string),
+                        feature,
+                        signal: signal
+                            .as_ref()
+                            .map(runtime_adoption_signal_slug)
+                            .map(str::to_string),
+                        limit,
+                    },
+                );
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    review_report: Some(report.into()),
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1470,6 +1525,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1497,6 +1553,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1527,6 +1584,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1542,6 +1600,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1557,6 +1616,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1566,7 +1626,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3790,7 +3850,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, check_record, review, record, list, stats, gate, research_validate_plan"
             )
         );
 
@@ -3941,6 +4001,53 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_review_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                id: "review_event".to_string(),
+                track: RuntimeAdoptionTrack::CardContext,
+                signal: RuntimeAdoptionSignal::Accepted,
+                feature: "include_cards".to_string(),
+                query: Some("skill trigger".to_string()),
+                context_hash: None,
+                card_id: None,
+                evaluator_id: None,
+                research_report_id: None,
+                note: Some("helped".to_string()),
+                metadata: None,
+                created_at: "1777710000".to_string(),
+            })
+            .expect("insert event");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "review",
+                "track": "card_context"
+            }))
+            .await
+            .expect("review");
+        let report = response.review_report.expect("review report");
+        assert!(!report.writes);
+        assert_eq!(report.total, 1);
+        assert_eq!(report.stats.accepted, 1);
+        assert_eq!(report.features[0].feature, "include_cards");
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -3952,7 +4059,7 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan"
+            "Actions: guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
     RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport,
+    RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport, RuntimeAdoptionSignalCounts,
     RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
@@ -337,6 +338,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_quality: Option<RuntimeAdoptionRecordQualityDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_report: Option<RuntimeAdoptionReviewReportDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -387,6 +390,43 @@ pub struct RuntimeAdoptionRecordQualityDto {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionReviewReportDto {
+    pub writes: bool,
+    pub filters: RuntimeAdoptionReviewFiltersDto,
+    pub total: usize,
+    pub stats: RuntimeAdoptionSignalCountsDto,
+    pub features: Vec<RuntimeAdoptionFeatureReviewDto>,
+    pub conclusion: String,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionReviewFiltersDto {
+    pub track: Option<String>,
+    pub feature: Option<String>,
+    pub signal: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionSignalCountsDto {
+    pub total: usize,
+    pub used: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub misses: usize,
+    pub rollbacks: usize,
+    pub contradictions: usize,
+    pub neutral: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionFeatureReviewDto {
+    pub feature: String,
+    pub stats: RuntimeAdoptionSignalCountsDto,
+}
+
 impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {
     fn from(plan: RuntimeAdoptionRecordPlan) -> Self {
         Self {
@@ -405,6 +445,53 @@ impl From<RuntimeAdoptionRecordQualityReport> for RuntimeAdoptionRecordQualityDt
             quality: report.quality,
             errors: report.errors,
             warnings: report.warnings,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionReviewReport> for RuntimeAdoptionReviewReportDto {
+    fn from(report: RuntimeAdoptionReviewReport) -> Self {
+        Self {
+            writes: report.writes,
+            filters: report.filters.into(),
+            total: report.total,
+            stats: report.stats.into(),
+            features: report
+                .features
+                .into_iter()
+                .map(|feature| RuntimeAdoptionFeatureReviewDto {
+                    feature: feature.feature,
+                    stats: feature.stats.into(),
+                })
+                .collect(),
+            conclusion: report.conclusion,
+            reasons: report.reasons,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionReviewFilters> for RuntimeAdoptionReviewFiltersDto {
+    fn from(filters: RuntimeAdoptionReviewFilters) -> Self {
+        Self {
+            track: filters.track,
+            feature: filters.feature,
+            signal: filters.signal,
+            limit: filters.limit,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionSignalCounts> for RuntimeAdoptionSignalCountsDto {
+    fn from(stats: RuntimeAdoptionSignalCounts) -> Self {
+        Self {
+            total: stats.total,
+            used: stats.used,
+            accepted: stats.accepted,
+            rejected: stats.rejected,
+            misses: stats.misses,
+            rollbacks: stats.rollbacks,
+            contradictions: stats.contradictions,
+            neutral: stats.neutral,
         }
     }
 }

--- a/tests/knowledge_card_retrieval.rs
+++ b/tests/knowledge_card_retrieval.rs
@@ -174,7 +174,7 @@ fn start_openai_embedding_stub(
     let expected_query = expected_query.to_string();
 
     let handle = thread::spawn(move || {
-        let (mut stream, _) = (0..50)
+        let (mut stream, _) = (0..250)
             .find_map(|_| match listener.accept() {
                 Ok(pair) => Some(pair),
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -450,6 +450,156 @@ fn test_cli_phase3_adoption_check_record_rejects_empty_feature() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_review_json_summarizes_events() {
+    let home = setup_cli_home();
+    for (id, signal) in [
+        ("review_accept_1", "accepted"),
+        ("review_accept_2", "accepted"),
+        ("review_reject_1", "rejected"),
+    ] {
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                id,
+                "--track",
+                "card_context",
+                "--signal",
+                signal,
+                "--feature",
+                "include_cards",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "review",
+            "--track",
+            "card_context",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "review failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("review json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["total"], 3);
+    assert_eq!(report["stats"]["accepted"], 2);
+    assert_eq!(report["stats"]["rejected"], 1);
+    assert_eq!(report["features"][0]["feature"], "include_cards");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 3);
+}
+
+#[test]
+fn test_cli_phase3_adoption_review_json_filters_signal() {
+    let home = setup_cli_home();
+    for (id, signal) in [
+        ("review_accept_1", "accepted"),
+        ("review_accept_2", "accepted"),
+        ("review_reject_1", "rejected"),
+    ] {
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                id,
+                "--track",
+                "card_context",
+                "--signal",
+                signal,
+                "--feature",
+                "include_cards",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "review",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "review failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("review json");
+    assert_eq!(report["total"], 2);
+    assert_eq!(report["stats"]["accepted"], 2);
+    assert_eq!(report["stats"]["rejected"], 0);
+}
+
+#[test]
+fn test_cli_phase3_adoption_review_json_no_evidence_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "review",
+            "--track",
+            "evaluator",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "review failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("review json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["total"], 0);
+    assert_eq!(report["conclusion"], "no_evidence");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
 fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
     let home = setup_cli_home();
     let gate = run_mempal(


### PR DESCRIPTION
## Summary

Adds P65 runtime adoption review reporting as a read-only evidence summary surface.

- Adds CLI `mempal phase3 adoption review`
- Adds MCP `mempal_phase3 action=review`
- Summarizes runtime adoption events by filters, aggregate signal counts, per-feature counts, conclusion, and reasons
- Supports track/feature/signal/limit filters without schema changes
- Keeps conclusions advisory: no automatic recording, no gate changes, no runtime defaults
- Stabilizes the existing CLI knowledge-card retrieval test harness timeout; production code unchanged

## Verification

- `agent-spec parse specs/p65-runtime-adoption-review-report.spec.md`
- `agent-spec lint specs/p65-runtime-adoption-review-report.spec.md --min-score 0.7`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_review_json`
- `cargo test mcp::server::tests::test_mcp_phase3_review_action_is_read_only --lib`
- `cargo test --test knowledge_card_retrieval test_cli_knowledge_card_retrieve_json_returns_active_card`
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --features rest -- -D warnings`
- `cargo test`
- `git diff --check`