### PR TITLE
feat: add card context default readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
+| `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -182,6 +183,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
+- `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 
 ### Spec 使用方式
 
@@ -217,7 +219,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65/P66） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
+| `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -180,6 +181,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
+- `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 
 ### Spec 使用方式
 
@@ -215,7 +217,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65/P66） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1301,10 +1301,11 @@ does not create promoted/canonical knowledge.
 P60 exposes the Phase-3 runtime evidence baseline to MCP-connected agents
 through `mempal_phase3`. The MCP tool uses `action` values
 `record/list/stats/gate/research_validate_plan`, mirroring the P54-P59 CLI
-surfaces without adding new authority. `record` appends
-`runtime_adoption_events`; `list`, `stats`, `gate`, and
-`research_validate_plan` remain read-only. MCP research validation accepts a
-JSON report object and still does not ingest or promote knowledge.
+surfaces without adding new authority. Later Phase-3 actions extend this same
+bounded MCP surface. `record` appends `runtime_adoption_events`; `list`,
+`stats`, `gate`, and `research_validate_plan` remain read-only. MCP research
+validation accepts a JSON report object and still does not ingest or promote
+knowledge.
 
 P61 adds a read-only runtime adoption recording protocol through
 `mempal_phase3 action=guidance`. The guidance tells agents when to record
@@ -1345,6 +1346,15 @@ track, feature, and signal filtering without schema changes; signal filtering is
 applied after DB retrieval. This gives future default-on specs a compact
 evidence artifact while preserving the Phase-3 boundary: review reports do not
 write events, change gates, or authorize runtime default changes.
+
+P66 adds a read-only card-context default readiness report through
+`mempal phase3 readiness card-context-default` and
+`mempal_phase3 action=readiness` with `candidate=card-context-default`. The
+report reuses P65 review semantics filtered to `track=card_context` and
+`feature=include_cards`, then returns `writes=false`, `ready`, `decision`, the
+embedded review, and reasons. `ready=true` only means the surface is eligible
+for a future default-on spec; it does not change `mempal context` defaults,
+enable `include_cards`, mutate lifecycle state, or create card embeddings.
 
 ## Closing Summary
 

--- a/docs/plans/2026-05-13-p66-card-context-default-readiness.md
+++ b/docs/plans/2026-05-13-p66-card-context-default-readiness.md
@@ -1,0 +1,36 @@
+# P66 Card Context Default Readiness
+
+Goal: add a read-only readiness report that uses existing `card_context`
+runtime adoption evidence for `include_cards` to decide whether card-aware
+context is eligible for a future default-on spec. This does not enable cards by
+default.
+
+Spec: `specs/p66-card-context-default-readiness.spec.md`
+
+## Steps
+
+- [x] Add shared readiness report types and card-context default readiness logic.
+- [x] Add CLI `mempal phase3 readiness card-context-default`.
+- [x] Add MCP `mempal_phase3 action=readiness`.
+- [x] Update protocol, MIND-MODEL design, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p66-card-context-default-readiness.spec.md
+agent-spec lint specs/p66-card-context-default-readiness.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_ready
+cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_without_evidence
+cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_rollback
+cargo test --test phase3_runtime test_cli_phase3_readiness_rejects_unknown_candidate
+cargo test mcp::server::tests::test_mcp_phase3_readiness_card_context_default_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p66-card-context-default-readiness.spec.md
+++ b/specs/p66-card-context-default-readiness.spec.md
@@ -1,0 +1,125 @@
+spec: task
+name: "P66: card context default readiness"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "card-context", "cli", "mcp"]
+---
+
+## Intent
+
+P65 can summarize runtime adoption evidence, but agents still need a focused
+answer to whether card-aware context is ready to be considered for default
+runtime behavior. P66 adds a read-only readiness report for `include_cards` that
+uses the existing card-context adoption evidence without changing defaults or
+relaxing the Phase-3 evidence-first boundary.
+
+## Decisions
+
+- Add CLI `mempal phase3 readiness card-context-default`.
+- Add MCP `mempal_phase3 action=readiness` with `candidate=card-context-default`.
+- The readiness report is read-only and returns `writes=false`, `candidate`,
+  `ready`, `decision`, `required_track`, `required_feature`, `review`, and
+  `reasons`.
+- The report reuses P65 review aggregation filtered to
+  `track=card_context` and `feature=include_cards`.
+- `ready=true` requires at least 3 accepted signals, zero rollback signals,
+  zero contradiction signals, and accepted signals greater than or equal to
+  rejected plus misses.
+- `ready=true` only means eligible for a future default-on spec; it must not
+  enable cards by default.
+- Unsupported readiness candidates are rejected without mutation.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/phase3.rs`
+- `src/main.rs`
+- `src/mcp/**`
+- `src/core/protocol.rs`
+- `tests/phase3_runtime.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-13-p66-card-context-default-readiness.md`
+- `specs/p66-card-context-default-readiness.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change `mempal context` default `include_cards=false`.
+- Do not add card embeddings.
+- Do not mutate knowledge lifecycle, card lifecycle, or runtime defaults.
+- Do not treat readiness as sufficient authority to implement default-on card
+  context without a later explicit spec.
+
+## Acceptance Criteria
+
+Scenario: CLI readiness reports ready with sufficient evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_ready
+  Level: integration
+  Given an empty CLI HOME
+  And three accepted card context events exist for feature `include_cards`
+  When running `mempal phase3 readiness card-context-default --format json`
+  Then stdout is valid JSON
+  And `writes` is false
+  And `ready` is true
+  And `decision` is `eligible_for_future_default_spec`
+  And `review.stats.accepted` is 3
+  And runtime adoption event count remains 3
+
+Scenario: CLI readiness blocks without evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_without_evidence
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 readiness card-context-default --format json`
+  Then stdout is valid JSON
+  And `writes` is false
+  And `ready` is false
+  And `decision` is `keep_opt_in`
+  And `reasons` mentions insufficient accepted evidence
+  And runtime adoption event count remains zero
+
+Scenario: CLI readiness blocks rollback evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_rollback
+  Level: integration
+  Given an empty CLI HOME
+  And card context evidence includes accepted and rollback signals
+  When running `mempal phase3 readiness card-context-default --format json`
+  Then stdout is valid JSON
+  And `ready` is false
+  And `decision` is `keep_opt_in`
+  And `reasons` mentions rollback evidence
+
+Scenario: MCP readiness is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_readiness_card_context_default_is_read_only
+  Level: unit
+  Given an empty test database with card context evidence
+  When `mempal_phase3` is called with `action=readiness` and `candidate=card-context-default`
+  Then the response includes `writes=false`
+  And the response includes a readiness report
+  And runtime adoption event count remains unchanged
+
+Scenario: Unsupported readiness candidate is rejected
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_readiness_rejects_unknown_candidate
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 readiness unknown --format json`
+  Then the command fails
+  And stderr mentions `unsupported phase3 readiness candidate`
+
+## Out of Scope
+
+- Turning `include_cards` on by default.
+- Changing existing Phase-3 gate thresholds.
+- New adoption event write paths.
+- New schema, embeddings, or retrieval ranking changes.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -81,6 +81,18 @@ pub struct RuntimeAdoptionReviewReport {
     pub reasons: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Phase3ReadinessReport {
+    pub writes: bool,
+    pub candidate: String,
+    pub ready: bool,
+    pub decision: String,
+    pub required_track: String,
+    pub required_feature: String,
+    pub review: RuntimeAdoptionReviewReport,
+    pub reasons: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeAdoptionRecordPlanInput {
     pub id: Option<String>,
@@ -378,6 +390,53 @@ fn review_conclusion(stats: &RuntimeAdoptionSignalCounts) -> (String, Vec<String
         "mixed".to_string(),
         vec!["evidence is present but not clearly positive".to_string()],
     )
+}
+
+pub fn card_context_default_readiness(events: &[RuntimeAdoptionEvent]) -> Phase3ReadinessReport {
+    let review = review_runtime_adoption_events(
+        events,
+        RuntimeAdoptionReviewFilters {
+            track: Some("card_context".to_string()),
+            feature: Some("include_cards".to_string()),
+            signal: None,
+            limit: 10_000,
+        },
+    );
+    let stats = &review.stats;
+    let mut reasons = Vec::new();
+    if stats.accepted < 3 {
+        reasons.push("insufficient accepted evidence for include_cards default".to_string());
+    }
+    if stats.rollbacks > 0 {
+        reasons.push("rollback evidence blocks card context default readiness".to_string());
+    }
+    if stats.contradictions > 0 {
+        reasons.push("contradiction evidence requires review before defaulting".to_string());
+    }
+    if stats.accepted < stats.rejected + stats.misses {
+        reasons.push("negative evidence outweighs accepted evidence".to_string());
+    }
+
+    let ready = reasons.is_empty();
+    if ready {
+        reasons.push("card context default readiness threshold satisfied".to_string());
+    }
+
+    Phase3ReadinessReport {
+        writes: false,
+        candidate: "card-context-default".to_string(),
+        ready,
+        decision: if ready {
+            "eligible_for_future_default_spec"
+        } else {
+            "keep_opt_in"
+        }
+        .to_string(),
+        required_track: "card_context".to_string(),
+        required_feature: "include_cards".to_string(),
+        review,
+        reasons,
+    }
 }
 
 fn requires_outcome_context(signal: &str) -> bool {

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan
+   guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
@@ -222,6 +222,9 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    advisory, read-only, and reports errors/warnings without blocking record.
    Use action=review to summarize accumulated evidence by track, feature, and
    signal before proposing stronger defaults; review is read-only and advisory.
+   Use action=readiness with candidate=card-context-default to inspect whether
+   card-aware context is eligible for a future default-on spec; readiness is
+   read-only and does not enable the default.
    Record used when guidance was actually consumed,
    accepted when it materially helped, rejected when it was considered and
    intentionally not followed, miss when useful guidance should have appeared
@@ -240,7 +243,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,11 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
-        RuntimeAdoptionReviewReport, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        Phase3ReadinessReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
+        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport, card_context_default_readiness,
+        check_runtime_adoption_record, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -568,6 +569,11 @@ enum Phase3Commands {
         command: Phase3AdoptionCommands,
     },
     Gate {
+        candidate: String,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Readiness {
         candidate: String,
         #[arg(long, default_value = "plain")]
         format: String,
@@ -2245,6 +2251,10 @@ fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
         }
+        Phase3Commands::Readiness { candidate, format } => {
+            let report = phase3_readiness_report(db, &candidate)?;
+            print_phase3_readiness_report(&report, &format)
+        }
         Phase3Commands::ResearchValidatePlan { path, format } => {
             let report = validate_research_adapter_plan(&path)?;
             print_research_adapter_plan(&report, &format)
@@ -2701,6 +2711,24 @@ fn phase3_gate_report(db: &Database, candidate: &str) -> Result<Phase3GateReport
     })
 }
 
+fn phase3_readiness_report(db: &Database, candidate: &str) -> Result<Phase3ReadinessReport> {
+    match candidate {
+        "card-context-default" => {
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: Some(RuntimeAdoptionTrack::CardContext),
+                        feature: Some("include_cards".to_string()),
+                    },
+                    10_000,
+                )
+                .context("failed to list runtime adoption events")?;
+            Ok(card_context_default_readiness(&events))
+        }
+        other => bail!("unsupported phase3 readiness candidate: {other}"),
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct ResearchAdapterPlanReport {
     valid: bool,
@@ -2845,6 +2873,37 @@ fn print_phase3_gate_report(report: &Phase3GateReport, format: &str) -> Result<(
             Ok(())
         }
         other => bail!("unsupported phase3 gate format: {other}"),
+    }
+}
+
+fn print_phase3_readiness_report(report: &Phase3ReadinessReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("candidate={}", report.candidate);
+            println!("ready={}", report.ready);
+            println!("decision={}", report.decision);
+            println!("required_track={}", report.required_track);
+            println!("required_feature={}", report.required_feature);
+            println!("accepted={}", report.review.stats.accepted);
+            println!("rejected={}", report.review.stats.rejected);
+            println!("misses={}", report.review.stats.misses);
+            println!("rollbacks={}", report.review.stats.rollbacks);
+            println!("contradictions={}", report.review.stats.contradictions);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize phase3 readiness report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 readiness format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,8 +7,8 @@ use crate::core::{
     db::Database,
     phase3::{
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
-        check_runtime_adoption_record, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance,
+        card_context_default_readiness, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1346,7 +1346,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1361,6 +1361,7 @@ impl MempalMcpServer {
                 record_plan: None,
                 record_quality: None,
                 review_report: None,
+                readiness_report: None,
                 event: None,
                 events: Vec::new(),
                 stats: None,
@@ -1395,6 +1396,7 @@ impl MempalMcpServer {
                     record_plan: Some(plan.into()),
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1430,6 +1432,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: Some(check_runtime_adoption_record(&input).into()),
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1481,6 +1484,48 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: Some(report.into()),
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "readiness" => {
+                let db = self.open_db()?;
+                let candidate = required_string(request.candidate.as_deref(), "candidate")?;
+                let report = match candidate {
+                    "card-context-default" => {
+                        let events = db
+                            .list_runtime_adoption_events(
+                                &RuntimeAdoptionFilter {
+                                    track: Some(RuntimeAdoptionTrack::CardContext),
+                                    feature: Some("include_cards".to_string()),
+                                },
+                                10_000,
+                            )
+                            .map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("failed to list runtime adoption events: {error}"),
+                                    None,
+                                )
+                            })?;
+                        card_context_default_readiness(&events)
+                    }
+                    other => {
+                        return Err(ErrorData::invalid_params(
+                            format!("unsupported phase3 readiness candidate: {other}"),
+                            None,
+                        ));
+                    }
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    review_report: None,
+                    readiness_report: Some(report.into()),
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1526,6 +1571,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1554,6 +1600,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1585,6 +1632,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1601,6 +1649,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1617,6 +1666,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1626,7 +1676,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3850,7 +3900,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, review, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan"
             )
         );
 
@@ -4048,6 +4098,55 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_readiness_card_context_default_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            for i in 0..3 {
+                db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                    id: format!("readiness_event_{i}"),
+                    track: RuntimeAdoptionTrack::CardContext,
+                    signal: RuntimeAdoptionSignal::Accepted,
+                    feature: "include_cards".to_string(),
+                    query: Some("skill trigger".to_string()),
+                    context_hash: None,
+                    card_id: None,
+                    evaluator_id: None,
+                    research_report_id: None,
+                    note: Some("helped".to_string()),
+                    metadata: None,
+                    created_at: "1777710000".to_string(),
+                })
+                .expect("insert event");
+            }
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "readiness",
+                "candidate": "card-context-default"
+            }))
+            .await
+            .expect("readiness");
+        let report = response.readiness_report.expect("readiness report");
+        assert!(!report.writes);
+        assert!(report.ready);
+        assert_eq!(report.decision, "eligible_for_future_default_spec");
+        assert_eq!(report.review.stats.accepted, 3);
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -4059,10 +4158,11 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan"
+            "Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL
                 .contains("used when guidance was actually consumed")

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,8 +1,8 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
-    RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport,
-    RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport, RuntimeAdoptionSignalCounts,
-    RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
+    Phase3ReadinessReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+    RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
+    RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
@@ -340,6 +340,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub review_report: Option<RuntimeAdoptionReviewReportDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_report: Option<Phase3ReadinessReportDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -427,6 +429,18 @@ pub struct RuntimeAdoptionFeatureReviewDto {
     pub stats: RuntimeAdoptionSignalCountsDto,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Phase3ReadinessReportDto {
+    pub writes: bool,
+    pub candidate: String,
+    pub ready: bool,
+    pub decision: String,
+    pub required_track: String,
+    pub required_feature: String,
+    pub review: RuntimeAdoptionReviewReportDto,
+    pub reasons: Vec<String>,
+}
+
 impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {
     fn from(plan: RuntimeAdoptionRecordPlan) -> Self {
         Self {
@@ -465,6 +479,21 @@ impl From<RuntimeAdoptionReviewReport> for RuntimeAdoptionReviewReportDto {
                 })
                 .collect(),
             conclusion: report.conclusion,
+            reasons: report.reasons,
+        }
+    }
+}
+
+impl From<Phase3ReadinessReport> for Phase3ReadinessReportDto {
+    fn from(report: Phase3ReadinessReport) -> Self {
+        Self {
+            writes: report.writes,
+            candidate: report.candidate,
+            ready: report.ready,
+            decision: report.decision,
+            required_track: report.required_track,
+            required_feature: report.required_feature,
+            review: report.review.into(),
             reasons: report.reasons,
         }
     }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -127,6 +127,172 @@ fn test_cli_phase3_adoption_record_stats_and_gate() {
 }
 
 #[test]
+fn test_cli_phase3_readiness_card_context_default_ready() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        let id = format!("readiness_accept_{i}");
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                &id,
+                "--track",
+                "card_context",
+                "--signal",
+                "accepted",
+                "--feature",
+                "include_cards",
+                "--query",
+                "skill trigger context",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "readiness",
+            "card-context-default",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "readiness failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("readiness json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["ready"], true);
+    assert_eq!(report["decision"], "eligible_for_future_default_spec");
+    assert_eq!(report["review"]["stats"]["accepted"], 3);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 3);
+}
+
+#[test]
+fn test_cli_phase3_readiness_card_context_default_blocks_without_evidence() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "readiness",
+            "card-context-default",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "readiness failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("readiness json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["ready"], false);
+    assert_eq!(report["decision"], "keep_opt_in");
+    let reasons = report["reasons"].as_array().expect("reasons");
+    assert!(reasons.iter().any(|reason| {
+        reason
+            .as_str()
+            .expect("reason")
+            .contains("insufficient accepted evidence")
+    }));
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_readiness_card_context_default_blocks_rollback() {
+    let home = setup_cli_home();
+    for (id, signal) in [
+        ("readiness_accept_1", "accepted"),
+        ("readiness_accept_2", "accepted"),
+        ("readiness_accept_3", "accepted"),
+        ("readiness_rollback_1", "rollback"),
+    ] {
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                id,
+                "--track",
+                "card_context",
+                "--signal",
+                signal,
+                "--feature",
+                "include_cards",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "readiness",
+            "card-context-default",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "readiness failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("readiness json");
+    assert_eq!(report["ready"], false);
+    assert_eq!(report["decision"], "keep_opt_in");
+    let reasons = report["reasons"].as_array().expect("reasons");
+    assert!(reasons.iter().any(|reason| {
+        reason
+            .as_str()
+            .expect("reason")
+            .contains("rollback evidence")
+    }));
+}
+
+#[test]
+fn test_cli_phase3_readiness_rejects_unknown_candidate() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "readiness", "unknown", "--format", "json"],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 readiness candidate"));
+}
+
+#[test]
 fn test_cli_phase3_adoption_guidance_json_is_read_only() {
     let home = setup_cli_home();
     let output = run_mempal(


### PR DESCRIPTION
## Summary
- add P66 spec and implementation plan for card-context default readiness
- add read-only CLI `mempal phase3 readiness card-context-default`
- add read-only MCP `mempal_phase3 action=readiness` with `candidate=card-context-default`
- document protocol and mind-model design boundaries

## Verification
- agent-spec parse specs/p66-card-context-default-readiness.spec.md
- agent-spec lint specs/p66-card-context-default-readiness.spec.md --min-score 0.7
- cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_ready
- cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_without_evidence
- cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_rollback
- cargo test --test phase3_runtime test_cli_phase3_readiness_rejects_unknown_candidate
- cargo test mcp::server::tests::test_mcp_phase3_readiness_card_context_default_is_read_only --lib
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --workspace --all-targets --features rest -- -D warnings
- cargo test
- git diff --check