### PR TITLE
feat: add research adapter evidence ingest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
+| `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -184,6 +185,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
+- `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
+| `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -182,6 +183,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
+- `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1356,6 +1356,16 @@ embedded review, and reasons. `ready=true` only means the surface is eligible
 for a future default-on spec; it does not change `mempal context` defaults,
 enable `include_cards`, mutate lifecycle state, or create card embeddings.
 
+P67 adds explicit evidence-first research ingestion through
+`mempal phase3 research-ingest-plan`. The command accepts the same P59 report
+contract and defaults to dry-run with `writes=false`. With `--execute`, it
+writes one `memory_kind=evidence` drawer per finding using
+`provenance=research`, stable drawer ids, and idempotent skip-on-existing
+behavior. `candidate_insights` are surfaced only as `mempal knowledge distill`
+suggestions backed by the planned evidence refs; P67 does not create knowledge
+drawers, promote research output, add a schema migration, or expose MCP write
+access.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-13-p67-research-adapter-ingest.md
+++ b/docs/plans/2026-05-13-p67-research-adapter-ingest.md
@@ -1,0 +1,35 @@
+# P67 Research Adapter Evidence Ingest
+
+Goal: add an explicit evidence-first CLI bridge from validated external research
+reports into mempal evidence drawers without creating knowledge or bypassing
+lifecycle gates.
+
+Spec: `specs/p67-research-adapter-ingest.spec.md`
+
+## Steps
+
+- [x] Add P67 task contract and plan.
+- [x] Add RED CLI tests for dry-run, execute/idempotency, invalid input, and format rejection.
+- [x] Implement shared research ingest planning in `src/main.rs`.
+- [x] Implement `mempal phase3 research-ingest-plan` dry-run and `--execute` paths.
+- [x] Update MIND-MODEL, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p67-research-adapter-ingest.spec.md
+agent-spec lint specs/p67-research-adapter-ingest.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_execute_writes_research_evidence
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_invalid_report_no_write
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_rejects_invalid_format
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p67-research-adapter-ingest.spec.md
+++ b/specs/p67-research-adapter-ingest.spec.md
@@ -1,0 +1,105 @@
+spec: task
+name: "P67: research adapter evidence ingest"
+inherits: project
+tags: [phase-3, research, adapter, evidence, cli]
+---
+
+## Intent
+
+P59 validates external research report JSON, but it still stops before creating
+memory evidence. P67 adds an explicit evidence-first ingest plan/apply CLI so
+external research output can enter mempal as cited evidence drawers while
+preserving P49: research cannot directly define dao, canonical knowledge, or
+promoted knowledge.
+
+## Decisions
+
+- Add CLI `mempal phase3 research-ingest-plan <path>`.
+- The command accepts the same JSON report contract as P59: `report_id`,
+  `title`, `sources`, `findings`, and optional `candidate_insights`.
+- The command defaults to dry-run and returns `writes=false`.
+- `--execute` writes one `memory_kind=evidence` drawer per finding with
+  `provenance=research`.
+- Written evidence drawer ids are stable and idempotent; rerunning `--execute`
+  skips existing drawers instead of rewriting them.
+- `candidate_insights` are reported only as distill suggestions backed by the
+  planned evidence drawer refs; they do not create knowledge drawers.
+- The command supports `--format plain|json`, defaulting to `plain`.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p67-research-adapter-ingest.spec.md
+- docs/plans/2026-05-13-p67-research-adapter-ingest.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/main.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema v10 or any table.
+- Do not add automatic/background research ingestion.
+- Do not change `mempal phase3 research-validate-plan` behavior.
+- Do not create `memory_kind=knowledge` drawers from research reports.
+- Do not create `dao_tian`, `canonical`, or `promoted` knowledge.
+- Do not bypass `mempal knowledge distill`, lifecycle gates, or human review.
+- Do not add MCP write access for research ingestion in P67.
+
+## Acceptance Criteria
+
+Scenario: dry-run research ingest plans evidence without writing
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
+    Targets: CLI JSON output and SQLite no-write side effect check.
+  Given a valid research report with one finding and one candidate insight
+  When running `mempal phase3 research-ingest-plan <path> --format json`
+  Then the command succeeds
+  And the response has `valid=true`
+  And `writes=false`
+  And it returns one planned evidence drawer
+  And it returns one candidate insight suggestion
+  And the suggestion includes a `mempal knowledge distill` command
+  And the database has no drawers
+
+Scenario: execute writes research evidence drawers idempotently
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_execute_writes_research_evidence
+    Targets: CLI execution, SQLite drawer state, research provenance, and idempotency.
+  Given a valid research report with two findings
+  When running `mempal phase3 research-ingest-plan <path> --execute --format json`
+  Then the command succeeds
+  And `writes=true`
+  And two evidence drawers are created
+  And each created drawer has `memory_kind=evidence`
+  And each created drawer has `provenance=research`
+  And no knowledge drawer is created
+  When running the same command again
+  Then existing drawer ids are skipped and not duplicated
+
+Scenario: invalid research ingest plan does not write
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_invalid_report_no_write
+    Targets: CLI JSON output and SQLite no-write side effect check.
+  Given an invalid research report JSON file
+  When running `mempal phase3 research-ingest-plan <path> --execute --format json`
+  Then the command succeeds with `valid=false`
+  And `writes=false`
+  And errors mention required fields
+  And the database has no drawers
+
+Scenario: research ingest plan rejects unsupported format
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_rejects_invalid_format
+    Targets: CLI stderr and exit status.
+  Given a valid research report JSON file
+  When running `mempal phase3 research-ingest-plan <path> --format yaml`
+  Then the command fails
+  And stderr mentions `unsupported phase3 research ingest format`
+
+## Out of Scope
+
+- MCP research ingestion.
+- Research report fetching or browser automation.
+- Research-driven promotion/demotion.
+- Card embeddings or default card context changes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use mempal::aaak::{AaakCodec, AaakMeta};
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
 use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
+    anchor,
     config::Config,
     db::Database,
     phase3::{
@@ -24,17 +25,22 @@ use mempal::core::{
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
-        AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
-        KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain,
-        MemoryKind, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
-        RuntimeAdoptionTrack, TaxonomyEntry, TriggerHints, TunnelEndpoint,
+        AnchorKind, BootstrapIdentityParts, Drawer, KnowledgeCard, KnowledgeCardEvent,
+        KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
+        RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
+        TaxonomyEntry, TriggerHints, TunnelEndpoint,
     },
-    utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
+    utils::{
+        build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp,
+        format_tunnel_endpoint,
+    },
 };
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
 use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
 use mempal::ingest::{
     IngestOptions, IngestStats, ingest_dir_with_options, ingest_file_with_options,
+    normalize::CURRENT_NORMALIZE_VERSION,
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
 use mempal::knowledge_anchor::{PublishAnchorRequest, publish_anchor};
@@ -583,6 +589,13 @@ enum Phase3Commands {
         #[arg(long, default_value = "plain")]
         format: String,
     },
+    ResearchIngestPlan {
+        path: PathBuf,
+        #[arg(long)]
+        execute: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -891,7 +904,7 @@ async fn run() -> Result<()> {
         Commands::Kg { command } => kg_command(&db, command),
         Commands::Knowledge { command } => knowledge_command(&db, &config, command).await,
         Commands::KnowledgeCard { command } => knowledge_card_command(&db, &config, command).await,
-        Commands::Phase3 { command } => phase3_command(&db, command),
+        Commands::Phase3 { command } => phase3_command(&db, &config, command).await,
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::FieldTaxonomy { format } => field_taxonomy_command(&format),
@@ -2244,7 +2257,7 @@ async fn knowledge_card_command(
     Ok(())
 }
 
-fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
+async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands) -> Result<()> {
     match command {
         Phase3Commands::Adoption { command } => phase3_adoption_command(db, command),
         Phase3Commands::Gate { candidate, format } => {
@@ -2259,6 +2272,11 @@ fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
             let report = validate_research_adapter_plan(&path)?;
             print_research_adapter_plan(&report, &format)
         }
+        Phase3Commands::ResearchIngestPlan {
+            path,
+            execute,
+            format,
+        } => research_ingest_plan_command(db, config, &path, execute, &format).await,
     }
 }
 
@@ -2740,6 +2758,41 @@ struct ResearchAdapterPlanReport {
     errors: Vec<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct ResearchEvidenceDrawerPlan {
+    drawer_id: String,
+    finding_index: usize,
+    source_file: String,
+    created: bool,
+    skipped: bool,
+    #[serde(skip)]
+    content: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ResearchCandidateInsightPlan {
+    statement: String,
+    supporting_refs: Vec<String>,
+    suggested_command: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResearchIngestPlanReport {
+    valid: bool,
+    writes: bool,
+    report_id: String,
+    title: String,
+    source_count: usize,
+    finding_count: usize,
+    candidate_insight_count: usize,
+    planned_evidence_count: usize,
+    created_count: usize,
+    skipped_count: usize,
+    errors: Vec<String>,
+    evidence_drawers: Vec<ResearchEvidenceDrawerPlan>,
+    candidate_insights: Vec<ResearchCandidateInsightPlan>,
+}
+
 fn validate_research_adapter_plan(path: &Path) -> Result<ResearchAdapterPlanReport> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read research report {}", path.display()))?;
@@ -2775,6 +2828,305 @@ fn validate_research_adapter_plan(path: &Path) -> Result<ResearchAdapterPlanRepo
         candidate_insight_count: candidate_insights,
         errors,
     })
+}
+
+async fn research_ingest_plan_command(
+    db: &Database,
+    config: &Config,
+    path: &Path,
+    execute: bool,
+    format: &str,
+) -> Result<()> {
+    let mut report = build_research_ingest_plan(path)?;
+    if report.valid && execute {
+        let existing = report
+            .evidence_drawers
+            .iter()
+            .filter_map(|plan| {
+                db.get_drawer(&plan.drawer_id)
+                    .ok()
+                    .flatten()
+                    .map(|_| plan.drawer_id.clone())
+            })
+            .collect::<BTreeSet<_>>();
+        let pending = report
+            .evidence_drawers
+            .iter()
+            .enumerate()
+            .filter(|(_, plan)| !existing.contains(&plan.drawer_id))
+            .map(|(index, plan)| (index, plan.drawer_id.clone(), plan.content.clone()))
+            .collect::<Vec<_>>();
+
+        let mut created_indices = BTreeSet::new();
+        if !pending.is_empty() {
+            let embedder = build_embedder(config).await?;
+            let content_refs = pending
+                .iter()
+                .map(|(_, _, content)| content.as_str())
+                .collect::<Vec<_>>();
+            let vectors = embedder
+                .embed(&content_refs)
+                .await
+                .context("failed to embed research evidence drawers")?;
+
+            for ((index, drawer_id, content), vector) in pending.into_iter().zip(vectors) {
+                let source_file = report.evidence_drawers[index].source_file.clone();
+                let drawer = research_evidence_drawer(
+                    drawer_id.clone(),
+                    content,
+                    source_file,
+                    report.report_id.as_str(),
+                    index,
+                );
+                db.insert_drawer(&drawer).with_context(|| {
+                    format!("failed to insert research evidence drawer {drawer_id}")
+                })?;
+                db.insert_vector(&drawer_id, &vector)
+                    .with_context(|| format!("failed to insert vector for {drawer_id}"))?;
+                created_indices.insert(index);
+            }
+        }
+
+        for (index, plan) in report.evidence_drawers.iter_mut().enumerate() {
+            plan.created = created_indices.contains(&index);
+            plan.skipped = existing.contains(&plan.drawer_id);
+        }
+        report.created_count = report
+            .evidence_drawers
+            .iter()
+            .filter(|plan| plan.created)
+            .count();
+        report.skipped_count = report
+            .evidence_drawers
+            .iter()
+            .filter(|plan| plan.skipped)
+            .count();
+        report.writes = report.created_count > 0;
+    }
+    print_research_ingest_plan(&report, format)
+}
+
+fn build_research_ingest_plan(path: &Path) -> Result<ResearchIngestPlanReport> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read research report {}", path.display()))?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse research report {}", path.display()))?;
+    let mut errors = Vec::new();
+    let report_id = required_string(&value, "report_id", &mut errors);
+    let title = required_string(&value, "title", &mut errors);
+    let source_count = value
+        .get("sources")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    if source_count == 0 {
+        errors.push("sources must contain at least one item".to_string());
+    }
+    let findings = value
+        .get("findings")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if findings.is_empty() {
+        errors.push("findings must contain at least one item".to_string());
+    }
+    let candidate_values = value
+        .get("candidate_insights")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let evidence_drawers = findings
+        .iter()
+        .enumerate()
+        .map(|(index, finding)| {
+            let content = research_evidence_content_from_value(
+                report_id.as_str(),
+                title.as_str(),
+                value.get("sources"),
+                finding,
+                index,
+            )?;
+            let drawer_id = research_evidence_drawer_id(&content);
+            Ok(ResearchEvidenceDrawerPlan {
+                drawer_id,
+                finding_index: index,
+                source_file: format!("research://{}#finding-{index}", report_id),
+                created: false,
+                skipped: false,
+                content,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let supporting_refs = evidence_drawers
+        .iter()
+        .map(|plan| plan.drawer_id.clone())
+        .collect::<Vec<_>>();
+    let candidate_insights = candidate_values
+        .iter()
+        .filter_map(|candidate| candidate_statement(candidate).map(str::to_string))
+        .map(|statement| ResearchCandidateInsightPlan {
+            suggested_command: research_distill_command(&statement, &supporting_refs),
+            statement,
+            supporting_refs: supporting_refs.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(ResearchIngestPlanReport {
+        valid: errors.is_empty(),
+        writes: false,
+        report_id,
+        title,
+        source_count,
+        finding_count: findings.len(),
+        candidate_insight_count: candidate_values.len(),
+        planned_evidence_count: evidence_drawers.len(),
+        created_count: 0,
+        skipped_count: 0,
+        errors,
+        evidence_drawers,
+        candidate_insights,
+    })
+}
+
+fn research_evidence_content_from_value(
+    report_id: &str,
+    title: &str,
+    sources: Option<&serde_json::Value>,
+    finding: &serde_json::Value,
+    finding_index: usize,
+) -> Result<String> {
+    let summary = finding_summary(finding)?;
+    let sources = sources
+        .map(serde_json::to_string_pretty)
+        .transpose()
+        .context("failed to serialize research sources")?
+        .unwrap_or_else(|| "[]".to_string());
+    let raw_finding =
+        serde_json::to_string_pretty(finding).context("failed to serialize research finding")?;
+    Ok(format!(
+        "# Research finding: {title}\n\nreport_id: {report_id}\nfinding_index: {finding_index}\n\nsummary: {summary}\n\nsources:\n```json\n{sources}\n```\n\nraw_finding:\n```json\n{raw_finding}\n```\n"
+    ))
+}
+
+fn finding_summary(finding: &serde_json::Value) -> Result<String> {
+    if let Some(raw) = finding.as_str() {
+        return Ok(raw.trim().to_string());
+    }
+    for field in ["summary", "statement", "content", "text"] {
+        if let Some(raw) = finding.get(field).and_then(serde_json::Value::as_str)
+            && !raw.trim().is_empty()
+        {
+            return Ok(raw.trim().to_string());
+        }
+    }
+    serde_json::to_string(finding).context("failed to serialize research finding summary")
+}
+
+fn candidate_statement(candidate: &serde_json::Value) -> Option<&str> {
+    if let Some(raw) = candidate.as_str()
+        && !raw.trim().is_empty()
+    {
+        return Some(raw.trim());
+    }
+    for field in ["statement", "summary", "content", "text"] {
+        if let Some(raw) = candidate.get(field).and_then(serde_json::Value::as_str)
+            && !raw.trim().is_empty()
+        {
+            return Some(raw.trim());
+        }
+    }
+    None
+}
+
+fn research_evidence_drawer_id(content: &str) -> String {
+    let memory_kind = MemoryKind::Evidence;
+    let domain = MemoryDomain::Project;
+    let anchor_kind = AnchorKind::Repo;
+    let provenance = Provenance::Research;
+    let empty_refs: &[String] = &[];
+    build_bootstrap_drawer_id_from_parts(
+        "mempal",
+        Some("research"),
+        content,
+        BootstrapIdentityParts {
+            memory_kind: &memory_kind,
+            domain: &domain,
+            field: "research",
+            anchor_kind: &anchor_kind,
+            anchor_id: anchor::LEGACY_REPO_ANCHOR_ID,
+            parent_anchor_id: None,
+            provenance: Some(&provenance),
+            statement: None,
+            tier: None,
+            status: None,
+            supporting_refs: empty_refs,
+            counterexample_refs: empty_refs,
+            teaching_refs: empty_refs,
+            verification_refs: empty_refs,
+            scope_constraints: None,
+            trigger_hints: None,
+        },
+    )
+}
+
+fn research_evidence_drawer(
+    drawer_id: String,
+    content: String,
+    source_file: String,
+    report_id: &str,
+    finding_index: usize,
+) -> Drawer {
+    Drawer {
+        id: drawer_id,
+        content,
+        wing: "mempal".to_string(),
+        room: Some("research".to_string()),
+        source_file: Some(source_file),
+        source_type: SourceType::Project,
+        added_at: current_timestamp(),
+        chunk_index: Some(finding_index as i64),
+        normalize_version: CURRENT_NORMALIZE_VERSION,
+        importance: 3,
+        memory_kind: MemoryKind::Evidence,
+        domain: MemoryDomain::Project,
+        field: "research".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        provenance: Some(Provenance::Research),
+        statement: Some(format!(
+            "Research finding from {report_id} #{finding_index}"
+        )),
+        tier: None,
+        status: None,
+        supporting_refs: Vec::new(),
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn research_distill_command(statement: &str, supporting_refs: &[String]) -> Vec<String> {
+    let mut command = vec![
+        "mempal".to_string(),
+        "knowledge".to_string(),
+        "distill".to_string(),
+        "--tier".to_string(),
+        "qi".to_string(),
+        "--statement".to_string(),
+        statement.to_string(),
+        "--content".to_string(),
+        statement.to_string(),
+        "--field".to_string(),
+        "research".to_string(),
+    ];
+    for supporting_ref in supporting_refs {
+        command.push("--supporting-ref".to_string());
+        command.push(supporting_ref.clone());
+    }
+    command
 }
 
 fn required_string(
@@ -2930,6 +3282,40 @@ fn print_research_adapter_plan(report: &ResearchAdapterPlanReport, format: &str)
             Ok(())
         }
         other => bail!("unsupported research adapter plan format: {other}"),
+    }
+}
+
+fn print_research_ingest_plan(report: &ResearchIngestPlanReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("valid={}", report.valid);
+            println!("writes={}", report.writes);
+            println!("report_id={}", report.report_id);
+            println!("title={}", report.title);
+            println!("planned_evidence_count={}", report.planned_evidence_count);
+            println!("created_count={}", report.created_count);
+            println!("skipped_count={}", report.skipped_count);
+            println!("candidate_insight_count={}", report.candidate_insight_count);
+            for error in &report.errors {
+                println!("error={error}");
+            }
+            for drawer in &report.evidence_drawers {
+                println!(
+                    "drawer={} finding_index={} created={} skipped={}",
+                    drawer.drawer_id, drawer.finding_index, drawer.created, drawer.skipped
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize research ingest plan")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 research ingest format: {other}"),
     }
 }
 

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -3,7 +3,8 @@ use std::process::Command;
 
 use mempal::core::db::Database;
 use mempal::core::types::{
-    RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack,
+    MemoryKind, Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
+    RuntimeAdoptionTrack,
 };
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -883,4 +884,213 @@ fn test_cli_phase3_research_validate_plan_reports_missing_fields() {
     assert!(stdout.contains("valid=false"));
     assert!(stdout.contains("error=report_id is required"));
     assert!(stdout.contains("error=sources must contain at least one item"));
+}
+
+#[test]
+fn test_cli_phase3_research_ingest_plan_dry_run_json_no_write() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("research-report.json");
+    fs::write(
+        &report_path,
+        json!({
+            "report_id": "research_p67_001",
+            "title": "Agent self-evolution research",
+            "sources": [{"id": "src_1", "url": "https://example.invalid/research"}],
+            "findings": [{"summary": "Research findings must enter memory as evidence first."}],
+            "candidate_insights": [{"statement": "Research output should be distilled only from evidence refs."}]
+        })
+        .to_string(),
+    )
+    .expect("write report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "research-ingest-plan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("ingest plan json");
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["planned_evidence_count"], 1);
+    assert_eq!(report["candidate_insight_count"], 1);
+    assert_eq!(
+        report["evidence_drawers"]
+            .as_array()
+            .expect("drawers")
+            .len(),
+        1
+    );
+    assert_eq!(
+        report["candidate_insights"]
+            .as_array()
+            .expect("insights")
+            .len(),
+        1
+    );
+    assert_eq!(
+        report["candidate_insights"][0]["suggested_command"][0],
+        "mempal"
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 0);
+}
+
+#[test]
+fn test_cli_phase3_research_ingest_plan_execute_writes_research_evidence() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("research-report.json");
+    fs::write(
+        &report_path,
+        json!({
+            "report_id": "research_p67_002",
+            "title": "Research adapter evidence",
+            "sources": [{"id": "src_1", "url": "https://example.invalid/a"}],
+            "findings": [
+                {"summary": "First finding becomes research evidence."},
+                {"summary": "Second finding becomes research evidence."}
+            ],
+            "candidate_insights": []
+        })
+        .to_string(),
+    )
+    .expect("write report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "research-ingest-plan execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("ingest plan json");
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["created_count"], 2);
+    assert_eq!(report["skipped_count"], 0);
+    let drawers = report["evidence_drawers"].as_array().expect("drawers");
+    assert_eq!(drawers.len(), 2);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 2);
+    for drawer in drawers {
+        let drawer_id = drawer["drawer_id"].as_str().expect("drawer id");
+        let stored = db
+            .get_drawer(drawer_id)
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(stored.memory_kind, MemoryKind::Evidence);
+        assert_eq!(stored.provenance, Some(Provenance::Research));
+        assert!(stored.tier.is_none());
+        assert!(stored.status.is_none());
+    }
+
+    let second = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        second.status.success(),
+        "second execute failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_report: Value = serde_json::from_slice(&second.stdout).expect("second json");
+    assert_eq!(second_report["created_count"], 0);
+    assert_eq!(second_report["skipped_count"], 2);
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 2);
+}
+
+#[test]
+fn test_cli_phase3_research_ingest_plan_invalid_report_no_write() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("bad-research-report.json");
+    fs::write(&report_path, "{}").expect("write bad report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "invalid ingest plan should report invalid input without failing: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("invalid json");
+    assert_eq!(report["valid"], false);
+    assert_eq!(report["writes"], false);
+    assert!(
+        report["errors"]
+            .as_array()
+            .expect("errors")
+            .iter()
+            .any(|error| error.as_str().expect("error") == "report_id is required")
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 0);
+}
+
+#[test]
+fn test_cli_phase3_research_ingest_plan_rejects_invalid_format() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("research-report.json");
+    fs::write(
+        &report_path,
+        json!({
+            "report_id": "research_p67_003",
+            "title": "Research adapter evidence",
+            "sources": [{"url": "https://example.invalid/a"}],
+            "findings": [{"summary": "Finding."}]
+        })
+        .to_string(),
+    )
+    .expect("write report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--format",
+            "yaml",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 research ingest format"));
 }


### PR DESCRIPTION
## Summary
- add P67 spec and implementation plan for research adapter evidence ingest
- add `mempal phase3 research-ingest-plan` dry-run and explicit `--execute` paths
- write research findings as evidence drawers with research provenance and stable ids
- keep candidate insights as distill suggestions only; no knowledge creation or schema changes

## Verification
- agent-spec parse specs/p67-research-adapter-ingest.spec.md
- agent-spec lint specs/p67-research-adapter-ingest.spec.md --min-score 0.7
- cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
- cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_execute_writes_research_evidence
- cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_invalid_report_no_write
- cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_rejects_invalid_format
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --workspace --all-targets --features rest -- -D warnings
- cargo test
- git diff --check