### PR TITLE
feat: add MCP research ingest planning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
+| `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -186,6 +187,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
+- `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 
 ### Spec 使用方式
 
@@ -221,7 +223,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65/P66） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
+| `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -184,6 +185,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
+- `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 
 ### Spec 使用方式
 
@@ -219,7 +221,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65/P66） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1366,6 +1366,14 @@ suggestions backed by the planned evidence refs; P67 does not create knowledge
 drawers, promote research output, add a schema migration, or expose MCP write
 access.
 
+P68 exposes the P67 dry-run planning semantics through MCP as
+`mempal_phase3 action=research_ingest_plan`. The action accepts an inline
+`report` JSON object, returns planned research evidence drawer refs plus
+candidate `mempal knowledge distill` suggestions, and always reports
+`writes=false`. It shares the same pure planner as the CLI but deliberately does
+not expose `--execute`, create drawers or vectors, mutate runtime adoption
+events, or promote research output into knowledge.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md
+++ b/docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md
@@ -1,0 +1,36 @@
+# P68 MCP Research Ingest Plan
+
+Goal: expose P67 research evidence ingest planning through `mempal_phase3` as a
+read-only MCP action, while keeping all writes limited to the existing CLI
+`--execute` path.
+
+Spec: `specs/p68-mcp-research-ingest-plan.spec.md`
+
+## Steps
+
+- [x] Add P68 task contract and plan.
+- [x] Add RED MCP tests for valid dry-run, invalid report, action list, and protocol registry.
+- [x] Move P67 pure planning helpers into shared `src/core/phase3.rs`.
+- [x] Wire CLI and MCP to the shared planner without changing P67 CLI behavior.
+- [x] Update MIND-MODEL, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p68-mcp-research-ingest-plan.spec.md
+agent-spec lint specs/p68-mcp-research-ingest-plan.spec.md --min-score 0.7
+cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_is_read_only --lib
+cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_invalid_report_no_write --lib
+cargo test mcp::server::tests::test_mcp_phase3_rejects_invalid_action_without_mutation --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p68-mcp-research-ingest-plan.spec.md
+++ b/specs/p68-mcp-research-ingest-plan.spec.md
@@ -1,0 +1,112 @@
+spec: task
+name: "P68: MCP research ingest plan"
+inherits: project
+tags: [phase-3, research, adapter, evidence, mcp]
+---
+
+## Intent
+
+P67 added an explicit CLI dry-run/apply path for converting external research
+reports into evidence drawers. P68 exposes the same dry-run planning semantics
+through `mempal_phase3` so agent runtimes can inspect planned evidence refs and
+distill suggestions without granting MCP write access or bypassing P49/P50
+governance.
+
+## Decisions
+
+- Add MCP action `mempal_phase3 action=research_ingest_plan`.
+- The request accepts the same inline `report` JSON object used by
+  `research_validate_plan`.
+- The response returns a `research_ingest_plan` object with the P67 dry-run
+  shape: `valid`, `writes=false`, report metadata, planned evidence drawers,
+  candidate insight distill suggestions, and validation errors.
+- MCP `research_ingest_plan` is always read-only and never exposes `execute`.
+- CLI `mempal phase3 research-ingest-plan` and MCP `research_ingest_plan` share
+  the same pure planning logic.
+- `research_validate_plan` remains unchanged and continues to return only
+  validation counts.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p68-mcp-research-ingest-plan.spec.md
+- docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema v10 or any table.
+- Do not add MCP `execute`, write mode, or evidence drawer creation.
+- Do not create vectors from the MCP action.
+- Do not create `memory_kind=knowledge` drawers from research reports.
+- Do not create `dao_tian`, `canonical`, or `promoted` knowledge.
+- Do not bypass `mempal knowledge distill`, lifecycle gates, or human review.
+- Do not change P67 CLI observable behavior.
+- Do not change `research_validate_plan` response semantics.
+
+## Acceptance Criteria
+
+Scenario: MCP research ingest plan returns dry-run evidence refs without writing
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_is_read_only --lib
+    Targets: MCP JSON response shape, dry-run semantics, drawer/event no-write checks.
+  Given a valid inline research report with one finding and one candidate insight
+  When calling `mempal_phase3` with `action=research_ingest_plan`
+  Then the call succeeds
+  And the response has `research_ingest_plan.valid=true`
+  And `research_ingest_plan.writes=false`
+  And it returns one planned evidence drawer
+  And it returns one candidate insight suggestion
+  And the suggestion includes a `mempal knowledge distill` command
+  And no drawer or runtime adoption event is created
+
+Scenario: MCP research ingest plan reports invalid input without writing
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_invalid_report_no_write --lib
+    Targets: MCP invalid report handling and no-write checks.
+  Given an invalid inline research report JSON object
+  When calling `mempal_phase3` with `action=research_ingest_plan`
+  Then the call succeeds with `research_ingest_plan.valid=false`
+  And `research_ingest_plan.writes=false`
+  And errors mention missing required fields
+  And no drawer or runtime adoption event is created
+
+Scenario: invalid phase3 action lists research ingest plan
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_rejects_invalid_action_without_mutation --lib
+    Targets: MCP error message and mutation guard.
+  Given an unsupported `mempal_phase3` action
+  When the action is rejected
+  Then the error lists `research_ingest_plan` among supported actions
+  And no runtime adoption event is created
+
+Scenario: MCP registry and protocol advertise research ingest plan
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+    Targets: MCP tool description and embedded memory protocol.
+  Given the MCP tool registry and embedded memory protocol
+  When inspecting the `mempal_phase3` surface
+  Then both mention `research_ingest_plan`
+  And both state that research ingest planning is read-only/advisory
+
+Scenario: CLI dry-run keeps P67 behavior after sharing planner
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
+    Targets: CLI P67 regression guard.
+  Given a valid research report file
+  When running `mempal phase3 research-ingest-plan <path> --format json`
+  Then the command still returns `writes=false`
+  And no drawer is written
+
+## Out of Scope
+
+- MCP research ingestion execution.
+- Research report fetching or browser automation.
+- Research-driven promotion/demotion.
+- Card embeddings or default card context changes.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -3,7 +3,14 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::types::{RuntimeAdoptionEvent, RuntimeAdoptionSignal};
+use super::{
+    anchor,
+    types::{
+        AnchorKind, BootstrapIdentityParts, MemoryDomain, MemoryKind, Provenance,
+        RuntimeAdoptionEvent, RuntimeAdoptionSignal,
+    },
+    utils::build_bootstrap_drawer_id_from_parts,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionGuidance {
@@ -91,6 +98,41 @@ pub struct Phase3ReadinessReport {
     pub required_feature: String,
     pub review: RuntimeAdoptionReviewReport,
     pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResearchEvidenceDrawerPlan {
+    pub drawer_id: String,
+    pub finding_index: usize,
+    pub source_file: String,
+    pub created: bool,
+    pub skipped: bool,
+    #[serde(skip)]
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResearchCandidateInsightPlan {
+    pub statement: String,
+    pub supporting_refs: Vec<String>,
+    pub suggested_command: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResearchIngestPlanReport {
+    pub valid: bool,
+    pub writes: bool,
+    pub report_id: String,
+    pub title: String,
+    pub source_count: usize,
+    pub finding_count: usize,
+    pub candidate_insight_count: usize,
+    pub planned_evidence_count: usize,
+    pub created_count: usize,
+    pub skipped_count: usize,
+    pub errors: Vec<String>,
+    pub evidence_drawers: Vec<ResearchEvidenceDrawerPlan>,
+    pub candidate_insights: Vec<ResearchCandidateInsightPlan>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -186,7 +228,10 @@ pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
                 track: "research_adapter".to_string(),
                 when: "external research report validation or ingestion planning affected behavior"
                     .to_string(),
-                feature_examples: vec!["research_validate_plan".to_string()],
+                feature_examples: vec![
+                    "research_validate_plan".to_string(),
+                    "research_ingest_plan".to_string(),
+                ],
             },
         ],
     }
@@ -436,6 +481,192 @@ pub fn card_context_default_readiness(events: &[RuntimeAdoptionEvent]) -> Phase3
         required_feature: "include_cards".to_string(),
         review,
         reasons,
+    }
+}
+
+pub fn build_research_ingest_plan_from_value(value: &Value) -> ResearchIngestPlanReport {
+    let mut errors = Vec::new();
+    let report_id = required_json_string(value, "report_id", &mut errors);
+    let title = required_json_string(value, "title", &mut errors);
+    let source_count = value
+        .get("sources")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    if source_count == 0 {
+        errors.push("sources must contain at least one item".to_string());
+    }
+    let findings = value
+        .get("findings")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if findings.is_empty() {
+        errors.push("findings must contain at least one item".to_string());
+    }
+    let candidate_values = value
+        .get("candidate_insights")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let evidence_drawers = findings
+        .iter()
+        .enumerate()
+        .map(|(index, finding)| {
+            let content = research_evidence_content_from_value(
+                report_id.as_str(),
+                title.as_str(),
+                value.get("sources"),
+                finding,
+                index,
+            );
+            let drawer_id = research_evidence_drawer_id(&content);
+            ResearchEvidenceDrawerPlan {
+                drawer_id,
+                finding_index: index,
+                source_file: format!("research://{}#finding-{index}", report_id),
+                created: false,
+                skipped: false,
+                content,
+            }
+        })
+        .collect::<Vec<_>>();
+    let supporting_refs = evidence_drawers
+        .iter()
+        .map(|plan| plan.drawer_id.clone())
+        .collect::<Vec<_>>();
+    let candidate_insights = candidate_values
+        .iter()
+        .filter_map(|candidate| candidate_statement(candidate).map(str::to_string))
+        .map(|statement| ResearchCandidateInsightPlan {
+            suggested_command: research_distill_command(&statement, &supporting_refs),
+            statement,
+            supporting_refs: supporting_refs.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    ResearchIngestPlanReport {
+        valid: errors.is_empty(),
+        writes: false,
+        report_id,
+        title,
+        source_count,
+        finding_count: findings.len(),
+        candidate_insight_count: candidate_values.len(),
+        planned_evidence_count: evidence_drawers.len(),
+        created_count: 0,
+        skipped_count: 0,
+        errors,
+        evidence_drawers,
+        candidate_insights,
+    }
+}
+
+fn research_evidence_content_from_value(
+    report_id: &str,
+    title: &str,
+    sources: Option<&Value>,
+    finding: &Value,
+    finding_index: usize,
+) -> String {
+    let summary = finding_summary(finding);
+    let sources = sources
+        .map(|value| serde_json::to_string_pretty(value).unwrap_or_else(|_| "[]".to_string()))
+        .unwrap_or_else(|| "[]".to_string());
+    let raw_finding = serde_json::to_string_pretty(finding).unwrap_or_else(|_| finding.to_string());
+    format!(
+        "# Research finding: {title}\n\nreport_id: {report_id}\nfinding_index: {finding_index}\n\nsummary: {summary}\n\nsources:\n```json\n{sources}\n```\n\nraw_finding:\n```json\n{raw_finding}\n```\n"
+    )
+}
+
+fn finding_summary(finding: &Value) -> String {
+    if let Some(raw) = finding.as_str() {
+        return raw.trim().to_string();
+    }
+    for field in ["summary", "statement", "content", "text"] {
+        if let Some(raw) = finding.get(field).and_then(Value::as_str)
+            && !raw.trim().is_empty()
+        {
+            return raw.trim().to_string();
+        }
+    }
+    serde_json::to_string(finding).unwrap_or_else(|_| finding.to_string())
+}
+
+fn candidate_statement(candidate: &Value) -> Option<&str> {
+    if let Some(raw) = candidate.as_str()
+        && !raw.trim().is_empty()
+    {
+        return Some(raw.trim());
+    }
+    for field in ["statement", "summary", "content", "text"] {
+        if let Some(raw) = candidate.get(field).and_then(Value::as_str)
+            && !raw.trim().is_empty()
+        {
+            return Some(raw.trim());
+        }
+    }
+    None
+}
+
+fn research_evidence_drawer_id(content: &str) -> String {
+    let memory_kind = MemoryKind::Evidence;
+    let domain = MemoryDomain::Project;
+    let anchor_kind = AnchorKind::Repo;
+    let provenance = Provenance::Research;
+    let empty_refs: &[String] = &[];
+    build_bootstrap_drawer_id_from_parts(
+        "mempal",
+        Some("research"),
+        content,
+        BootstrapIdentityParts {
+            memory_kind: &memory_kind,
+            domain: &domain,
+            field: "research",
+            anchor_kind: &anchor_kind,
+            anchor_id: anchor::LEGACY_REPO_ANCHOR_ID,
+            parent_anchor_id: None,
+            provenance: Some(&provenance),
+            statement: None,
+            tier: None,
+            status: None,
+            supporting_refs: empty_refs,
+            counterexample_refs: empty_refs,
+            teaching_refs: empty_refs,
+            verification_refs: empty_refs,
+            scope_constraints: None,
+            trigger_hints: None,
+        },
+    )
+}
+
+fn research_distill_command(statement: &str, supporting_refs: &[String]) -> Vec<String> {
+    let mut command = vec![
+        "mempal".to_string(),
+        "knowledge".to_string(),
+        "distill".to_string(),
+        "--tier".to_string(),
+        "qi".to_string(),
+        "--statement".to_string(),
+        statement.to_string(),
+        "--content".to_string(),
+        statement.to_string(),
+        "--field".to_string(),
+        "research".to_string(),
+    ];
+    for supporting_ref in supporting_refs {
+        push_command_arg(&mut command, "--supporting-ref", supporting_ref);
+    }
+    command
+}
+
+fn required_json_string(value: &Value, field: &'static str, errors: &mut Vec<String>) -> String {
+    match value.get(field).and_then(Value::as_str) {
+        Some(raw) if !raw.trim().is_empty() => raw.trim().to_string(),
+        _ => {
+            errors.push(format!("{field} is required"));
+            String::new()
+        }
     }
 }
 

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan
+   guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
@@ -230,9 +230,11 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    intentionally not followed, miss when useful guidance should have appeared
    but did not, rollback when behavior was reverted because guidance degraded the outcome, contradiction when guidance
    conflicted with stronger evidence or instructions, and neutral when no clear
-   outcome impact is known. Gate and research_validate_plan are advisory and
+   outcome impact is known. Gate, research_validate_plan, and
+   research_ingest_plan are advisory and
    read-only: they do not enable card context by default, add card embeddings,
-   mutate evaluator lifecycle state, or promote research output into knowledge.
+   mutate evaluator lifecycle state, ingest research output, or promote
+   research output into knowledge.
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
@@ -243,7 +245,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,24 +17,22 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        Phase3ReadinessReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
-        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
-        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport, card_context_default_readiness,
-        check_runtime_adoption_record, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance,
+        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionGuidance,
+        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
+        RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
+        card_context_default_readiness, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
-        AnchorKind, BootstrapIdentityParts, Drawer, KnowledgeCard, KnowledgeCardEvent,
-        KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
-        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
+        AnchorKind, Drawer, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter,
+        KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus,
+        KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
         RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
         TaxonomyEntry, TriggerHints, TunnelEndpoint,
     },
-    utils::{
-        build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp,
-        format_tunnel_endpoint,
-    },
+    utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
 };
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
 use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
@@ -2758,41 +2756,6 @@ struct ResearchAdapterPlanReport {
     errors: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
-struct ResearchEvidenceDrawerPlan {
-    drawer_id: String,
-    finding_index: usize,
-    source_file: String,
-    created: bool,
-    skipped: bool,
-    #[serde(skip)]
-    content: String,
-}
-
-#[derive(Debug, Serialize)]
-struct ResearchCandidateInsightPlan {
-    statement: String,
-    supporting_refs: Vec<String>,
-    suggested_command: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct ResearchIngestPlanReport {
-    valid: bool,
-    writes: bool,
-    report_id: String,
-    title: String,
-    source_count: usize,
-    finding_count: usize,
-    candidate_insight_count: usize,
-    planned_evidence_count: usize,
-    created_count: usize,
-    skipped_count: usize,
-    errors: Vec<String>,
-    evidence_drawers: Vec<ResearchEvidenceDrawerPlan>,
-    candidate_insights: Vec<ResearchCandidateInsightPlan>,
-}
-
 fn validate_research_adapter_plan(path: &Path) -> Result<ResearchAdapterPlanReport> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read research report {}", path.display()))?;
@@ -2911,162 +2874,7 @@ fn build_research_ingest_plan(path: &Path) -> Result<ResearchIngestPlanReport> {
         .with_context(|| format!("failed to read research report {}", path.display()))?;
     let value: serde_json::Value = serde_json::from_str(&raw)
         .with_context(|| format!("failed to parse research report {}", path.display()))?;
-    let mut errors = Vec::new();
-    let report_id = required_string(&value, "report_id", &mut errors);
-    let title = required_string(&value, "title", &mut errors);
-    let source_count = value
-        .get("sources")
-        .and_then(serde_json::Value::as_array)
-        .map_or(0, Vec::len);
-    if source_count == 0 {
-        errors.push("sources must contain at least one item".to_string());
-    }
-    let findings = value
-        .get("findings")
-        .and_then(serde_json::Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    if findings.is_empty() {
-        errors.push("findings must contain at least one item".to_string());
-    }
-    let candidate_values = value
-        .get("candidate_insights")
-        .and_then(serde_json::Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-
-    let evidence_drawers = findings
-        .iter()
-        .enumerate()
-        .map(|(index, finding)| {
-            let content = research_evidence_content_from_value(
-                report_id.as_str(),
-                title.as_str(),
-                value.get("sources"),
-                finding,
-                index,
-            )?;
-            let drawer_id = research_evidence_drawer_id(&content);
-            Ok(ResearchEvidenceDrawerPlan {
-                drawer_id,
-                finding_index: index,
-                source_file: format!("research://{}#finding-{index}", report_id),
-                created: false,
-                skipped: false,
-                content,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let supporting_refs = evidence_drawers
-        .iter()
-        .map(|plan| plan.drawer_id.clone())
-        .collect::<Vec<_>>();
-    let candidate_insights = candidate_values
-        .iter()
-        .filter_map(|candidate| candidate_statement(candidate).map(str::to_string))
-        .map(|statement| ResearchCandidateInsightPlan {
-            suggested_command: research_distill_command(&statement, &supporting_refs),
-            statement,
-            supporting_refs: supporting_refs.clone(),
-        })
-        .collect::<Vec<_>>();
-
-    Ok(ResearchIngestPlanReport {
-        valid: errors.is_empty(),
-        writes: false,
-        report_id,
-        title,
-        source_count,
-        finding_count: findings.len(),
-        candidate_insight_count: candidate_values.len(),
-        planned_evidence_count: evidence_drawers.len(),
-        created_count: 0,
-        skipped_count: 0,
-        errors,
-        evidence_drawers,
-        candidate_insights,
-    })
-}
-
-fn research_evidence_content_from_value(
-    report_id: &str,
-    title: &str,
-    sources: Option<&serde_json::Value>,
-    finding: &serde_json::Value,
-    finding_index: usize,
-) -> Result<String> {
-    let summary = finding_summary(finding)?;
-    let sources = sources
-        .map(serde_json::to_string_pretty)
-        .transpose()
-        .context("failed to serialize research sources")?
-        .unwrap_or_else(|| "[]".to_string());
-    let raw_finding =
-        serde_json::to_string_pretty(finding).context("failed to serialize research finding")?;
-    Ok(format!(
-        "# Research finding: {title}\n\nreport_id: {report_id}\nfinding_index: {finding_index}\n\nsummary: {summary}\n\nsources:\n```json\n{sources}\n```\n\nraw_finding:\n```json\n{raw_finding}\n```\n"
-    ))
-}
-
-fn finding_summary(finding: &serde_json::Value) -> Result<String> {
-    if let Some(raw) = finding.as_str() {
-        return Ok(raw.trim().to_string());
-    }
-    for field in ["summary", "statement", "content", "text"] {
-        if let Some(raw) = finding.get(field).and_then(serde_json::Value::as_str)
-            && !raw.trim().is_empty()
-        {
-            return Ok(raw.trim().to_string());
-        }
-    }
-    serde_json::to_string(finding).context("failed to serialize research finding summary")
-}
-
-fn candidate_statement(candidate: &serde_json::Value) -> Option<&str> {
-    if let Some(raw) = candidate.as_str()
-        && !raw.trim().is_empty()
-    {
-        return Some(raw.trim());
-    }
-    for field in ["statement", "summary", "content", "text"] {
-        if let Some(raw) = candidate.get(field).and_then(serde_json::Value::as_str)
-            && !raw.trim().is_empty()
-        {
-            return Some(raw.trim());
-        }
-    }
-    None
-}
-
-fn research_evidence_drawer_id(content: &str) -> String {
-    let memory_kind = MemoryKind::Evidence;
-    let domain = MemoryDomain::Project;
-    let anchor_kind = AnchorKind::Repo;
-    let provenance = Provenance::Research;
-    let empty_refs: &[String] = &[];
-    build_bootstrap_drawer_id_from_parts(
-        "mempal",
-        Some("research"),
-        content,
-        BootstrapIdentityParts {
-            memory_kind: &memory_kind,
-            domain: &domain,
-            field: "research",
-            anchor_kind: &anchor_kind,
-            anchor_id: anchor::LEGACY_REPO_ANCHOR_ID,
-            parent_anchor_id: None,
-            provenance: Some(&provenance),
-            statement: None,
-            tier: None,
-            status: None,
-            supporting_refs: empty_refs,
-            counterexample_refs: empty_refs,
-            teaching_refs: empty_refs,
-            verification_refs: empty_refs,
-            scope_constraints: None,
-            trigger_hints: None,
-        },
-    )
+    Ok(build_research_ingest_plan_from_value(&value))
 }
 
 fn research_evidence_drawer(
@@ -3106,27 +2914,6 @@ fn research_evidence_drawer(
         scope_constraints: None,
         trigger_hints: None,
     }
-}
-
-fn research_distill_command(statement: &str, supporting_refs: &[String]) -> Vec<String> {
-    let mut command = vec![
-        "mempal".to_string(),
-        "knowledge".to_string(),
-        "distill".to_string(),
-        "--tier".to_string(),
-        "qi".to_string(),
-        "--statement".to_string(),
-        statement.to_string(),
-        "--content".to_string(),
-        statement.to_string(),
-        "--field".to_string(),
-        "research".to_string(),
-    ];
-    for supporting_ref in supporting_refs {
-        command.push("--supporting-ref".to_string());
-        command.push(supporting_ref.clone());
-    }
-    command
 }
 
 fn required_string(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,8 +7,9 @@ use crate::core::{
     db::Database,
     phase3::{
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
-        card_context_default_readiness, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        build_research_ingest_plan_from_value, card_context_default_readiness,
+        check_runtime_adoption_record, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -67,7 +68,7 @@ use super::tools::{
     KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
-    Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto,
+    Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto, ResearchIngestPlanDto,
     RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount,
     SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
     TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
@@ -1346,7 +1347,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1367,6 +1368,7 @@ impl MempalMcpServer {
                 stats: None,
                 gate: None,
                 research_plan: None,
+                research_ingest_plan: None,
             })),
             "prepare_record" => {
                 let track = parse_runtime_adoption_track(required_string(
@@ -1402,6 +1404,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "check_record" => {
@@ -1438,6 +1441,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "review" => {
@@ -1490,6 +1494,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "readiness" => {
@@ -1531,6 +1536,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "record" => {
@@ -1577,6 +1583,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "list" => {
@@ -1609,6 +1616,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "stats" => {
@@ -1638,6 +1646,7 @@ impl MempalMcpServer {
                     stats: Some(runtime_adoption_stats(&events)),
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "gate" => {
@@ -1655,6 +1664,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: Some(gate),
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "research_validate_plan" => {
@@ -1672,11 +1682,32 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: Some(validate_research_adapter_plan_value(&report)),
+                    research_ingest_plan: None,
+                }))
+            }
+            "research_ingest_plan" => {
+                let report = request.report.ok_or_else(|| {
+                    ErrorData::invalid_params("report is required for research_ingest_plan", None)
+                })?;
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: Some(ResearchIngestPlanDto::from(
+                        build_research_ingest_plan_from_value(&report),
+                    )),
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -3883,6 +3914,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_phase3_research_ingest_plan_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "research_ingest_plan",
+                "report": {
+                    "report_id": "research_001",
+                    "title": "Agent memory retrieval notes",
+                    "sources": [{ "url": "https://example.invalid/report" }],
+                    "findings": [{ "summary": "Measure card context before defaults." }],
+                    "candidate_insights": [{ "statement": "Measure before defaulting cards." }]
+                }
+            }))
+            .await
+            .expect("plan research ingest");
+        let plan = response.research_ingest_plan.expect("research ingest plan");
+        assert!(plan.valid);
+        assert!(!plan.writes);
+        assert_eq!(plan.report_id, "research_001");
+        assert_eq!(plan.planned_evidence_count, 1);
+        assert_eq!(plan.evidence_drawers.len(), 1);
+        assert!(
+            plan.evidence_drawers[0]
+                .drawer_id
+                .starts_with("drawer_mempal_research_")
+        );
+        assert_eq!(plan.candidate_insights.len(), 1);
+        assert_eq!(
+            &plan.candidate_insights[0].suggested_command[0..3],
+            ["mempal", "knowledge", "distill"]
+        );
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_research_ingest_plan_invalid_report_no_write() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "research_ingest_plan",
+                "report": {}
+            }))
+            .await
+            .expect("plan invalid research ingest");
+        let plan = response.research_ingest_plan.expect("research ingest plan");
+        assert!(!plan.valid);
+        assert!(!plan.writes);
+        assert!(
+            plan.errors
+                .iter()
+                .any(|error| error.contains("report_id is required"))
+        );
+        assert!(
+            plan.errors
+                .iter()
+                .any(|error| error.contains("findings must contain at least one item"))
+        );
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_phase3_rejects_invalid_action_without_mutation() {
         let (_tempdir, db_path, server) = setup_server();
         let before = {
@@ -3900,7 +4028,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4158,11 +4286,12 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan"
+            "Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL
                 .contains("used when guidance was actually consumed")

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
-    Phase3ReadinessReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+    Phase3ReadinessReport, ResearchCandidateInsightPlan, ResearchEvidenceDrawerPlan,
+    ResearchIngestPlanReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
     RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
     RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
 };
@@ -351,6 +352,8 @@ pub struct Phase3Response {
     pub gate: Option<Phase3GateDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub research_plan: Option<ResearchAdapterPlanDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub research_ingest_plan: Option<ResearchIngestPlanDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -603,6 +606,89 @@ pub struct ResearchAdapterPlanDto {
     pub finding_count: usize,
     pub candidate_insight_count: usize,
     pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ResearchIngestPlanDto {
+    pub valid: bool,
+    pub writes: bool,
+    pub report_id: String,
+    pub title: String,
+    pub source_count: usize,
+    pub finding_count: usize,
+    pub candidate_insight_count: usize,
+    pub planned_evidence_count: usize,
+    pub created_count: usize,
+    pub skipped_count: usize,
+    pub errors: Vec<String>,
+    pub evidence_drawers: Vec<ResearchEvidenceDrawerPlanDto>,
+    pub candidate_insights: Vec<ResearchCandidateInsightPlanDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ResearchEvidenceDrawerPlanDto {
+    pub drawer_id: String,
+    pub finding_index: usize,
+    pub source_file: String,
+    pub created: bool,
+    pub skipped: bool,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ResearchCandidateInsightPlanDto {
+    pub statement: String,
+    pub supporting_refs: Vec<String>,
+    pub suggested_command: Vec<String>,
+}
+
+impl From<ResearchIngestPlanReport> for ResearchIngestPlanDto {
+    fn from(report: ResearchIngestPlanReport) -> Self {
+        Self {
+            valid: report.valid,
+            writes: report.writes,
+            report_id: report.report_id,
+            title: report.title,
+            source_count: report.source_count,
+            finding_count: report.finding_count,
+            candidate_insight_count: report.candidate_insight_count,
+            planned_evidence_count: report.planned_evidence_count,
+            created_count: report.created_count,
+            skipped_count: report.skipped_count,
+            errors: report.errors,
+            evidence_drawers: report
+                .evidence_drawers
+                .into_iter()
+                .map(ResearchEvidenceDrawerPlanDto::from)
+                .collect(),
+            candidate_insights: report
+                .candidate_insights
+                .into_iter()
+                .map(ResearchCandidateInsightPlanDto::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<ResearchEvidenceDrawerPlan> for ResearchEvidenceDrawerPlanDto {
+    fn from(plan: ResearchEvidenceDrawerPlan) -> Self {
+        Self {
+            drawer_id: plan.drawer_id,
+            finding_index: plan.finding_index,
+            source_file: plan.source_file,
+            created: plan.created,
+            skipped: plan.skipped,
+        }
+    }
+}
+
+impl From<ResearchCandidateInsightPlan> for ResearchCandidateInsightPlanDto {
+    fn from(plan: ResearchCandidateInsightPlan) -> Self {
+        Self {
+            statement: plan.statement,
+            supporting_refs: plan.supporting_refs,
+            suggested_command: plan.suggested_command,
+        }
+    }
 }
 
 impl From<RuntimeAdoptionEvent> for RuntimeAdoptionEventDto {


### PR DESCRIPTION
## Summary
- add P68 spec and plan for read-only MCP research ingest planning
- move P67 pure research ingest planner into core so CLI and MCP share semantics
- add `mempal_phase3 action=research_ingest_plan` returning planned evidence refs and distill suggestions with `writes=false`

## Verification
- agent-spec parse specs/p68-mcp-research-ingest-plan.spec.md
- agent-spec lint specs/p68-mcp-research-ingest-plan.spec.md --min-score 0.7
- cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_is_read_only --lib
- cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_invalid_report_no_write --lib
- cargo test mcp::server::tests::test_mcp_phase3_rejects_invalid_action_without_mutation --lib
- cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
- cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --workspace --all-targets --features rest -- -D warnings
- cargo test
- git diff --check