### PR TITLE
feat: add checked runtime adoption records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
+| `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -188,6 +189,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
+- `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 
 ### Spec 使用方式
 
@@ -223,7 +225,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
+| `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -186,6 +187,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
+- `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 
 ### Spec 使用方式
 
@@ -221,7 +223,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1374,6 +1374,15 @@ candidate `mempal knowledge distill` suggestions, and always reports
 not expose `--execute`, create drawers or vectors, mutate runtime adoption
 events, or promote research output into knowledge.
 
+P69 adds a quality-gated runtime adoption write path through
+`mempal phase3 adoption record-checked` and
+`mempal_phase3 action=record_checked`. The command/action runs the P64 record
+quality policy immediately before writing. `quality=ready` records are written,
+`quality=warning` records are blocked by default unless `allow_warnings` is
+explicitly set, and `quality=invalid` records are always blocked. This reduces
+low-signal self-evolution evidence without adding hooks, background
+instrumentation, schema changes, or new authority for Phase-3 gates.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md
+++ b/docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md
@@ -1,0 +1,37 @@
+# P69 Runtime Adoption Checked Record
+
+Goal: add a quality-gated runtime adoption write path so agents can append
+Phase-3 evidence only after the P64 policy has been evaluated.
+
+Spec: `specs/p69-runtime-adoption-checked-record.spec.md`
+
+## Steps
+
+- [x] Add P69 task contract and plan.
+- [x] Add RED CLI and MCP tests for ready, warning-blocked, warning-allowed, and invalid-blocked behavior.
+- [x] Add checked-record response types and core decision helper.
+- [x] Wire CLI `mempal phase3 adoption record-checked`.
+- [x] Wire MCP `mempal_phase3 action=record_checked`.
+- [x] Update MIND-MODEL, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p69-runtime-adoption-checked-record.spec.md
+agent-spec lint specs/p69-runtime-adoption-checked-record.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_writes_ready_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_warning_by_default
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_allow_warnings_writes_warning_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_invalid_even_with_allow_warnings
+cargo test mcp::server::tests::test_mcp_phase3_record_checked_quality_gated --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p69-runtime-adoption-checked-record.spec.md
+++ b/specs/p69-runtime-adoption-checked-record.spec.md
@@ -1,0 +1,129 @@
+spec: task
+name: "P69: runtime adoption checked record"
+inherits: project
+tags: [phase-3, runtime-adoption, quality, cli, mcp]
+---
+
+## Intent
+
+P63 can prepare runtime adoption record inputs and P64 can evaluate their
+quality, but agents still have to manually run `check_record` before `record`.
+P69 adds a guarded write path that evaluates the same quality policy immediately
+before appending a runtime adoption event, so self-evolution evidence capture is
+safer by default without adding automatic hooks or changing Phase-3 gates.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption record-checked`.
+- Add MCP `mempal_phase3 action=record_checked`.
+- `record_checked` reuses the same input fields as `record`.
+- `record_checked` runs the P64 quality policy before any write.
+- By default, only `quality=ready` records are written.
+- `--allow-warnings` / `allow_warnings=true` permits `quality=warning` records
+  to be written, but `quality=invalid` is always blocked.
+- The response reports `writes`, `blocked`, the quality report, and the optional
+  written event.
+- Existing `record`, `check_record`, and gate semantics remain unchanged.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p69-runtime-adoption-checked-record.spec.md
+- docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not automatically record events after context/search/research tool calls.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not change existing `record` behavior.
+- Do not let `allow_warnings` write invalid records.
+
+## Acceptance Criteria
+
+Scenario: CLI checked record writes ready evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_writes_ready_event
+    Targets: CLI checked record happy path and DB write.
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption record-checked --track runtime_adoption --signal accepted --feature context_pack --query "skill trigger" --note "context guidance helped" --format json`
+  Then stdout is valid JSON
+  And `writes=true`
+  And `blocked=false`
+  And `record_quality.quality` is `ready`
+  And a runtime adoption event is written
+
+Scenario: CLI checked record blocks warning evidence by default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_warning_by_default
+    Targets: CLI warning block and no-write side effect check.
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption record-checked --track card_context --signal accepted --feature include_cards --format json`
+  Then stdout is valid JSON
+  And `writes=false`
+  And `blocked=true`
+  And `record_quality.quality` is `warning`
+  And no runtime adoption event is written
+
+Scenario: CLI checked record allow-warnings writes warning evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_allow_warnings_writes_warning_event
+    Targets: CLI allow-warnings behavior and DB write.
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption record-checked --track card_context --signal accepted --feature include_cards --allow-warnings --format json`
+  Then stdout is valid JSON
+  And `writes=true`
+  And `blocked=false`
+  And `record_quality.quality` is `warning`
+  And a runtime adoption event is written
+
+Scenario: CLI checked record always blocks invalid evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_invalid_even_with_allow_warnings
+    Targets: CLI invalid block and no-write side effect check.
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption record-checked --track card_context --signal accepted --feature "   " --allow-warnings --format json`
+  Then stdout is valid JSON
+  And `writes=false`
+  And `blocked=true`
+  And `record_quality.quality` is `invalid`
+  And no runtime adoption event is written
+
+Scenario: MCP checked record is quality-gated
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_record_checked_quality_gated --lib
+    Targets: MCP checked record write/block behavior and DB side effects.
+  Given an empty test database
+  When `mempal_phase3` is called with `action=record_checked` and a ready record
+  Then the response includes `writes=true`
+  And one runtime adoption event is appended
+  When `mempal_phase3` is called with warning-quality input without `allow_warnings`
+  Then the response includes `writes=false`
+  And no additional event is appended
+
+Scenario: MCP registry and protocol advertise checked record
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+    Targets: MCP tool description and embedded memory protocol.
+  Given the MCP tool registry and embedded memory protocol
+  When inspecting the `mempal_phase3` surface
+  Then both mention `record_checked`
+  And the protocol states it is quality-gated.
+
+## Out of Scope
+
+- Automatic adoption recording after tool calls.
+- Runtime hooks for Claude, Codex, or other agents.
+- Event deduplication.
+- New schema, indexes, or gate thresholds.
+- Any default-on policy changes.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -51,6 +51,14 @@ pub struct RuntimeAdoptionRecordQualityReport {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuntimeAdoptionCheckedRecordReport {
+    pub writes: bool,
+    pub blocked: bool,
+    pub record_quality: RuntimeAdoptionRecordQualityReport,
+    pub event: Option<RuntimeAdoptionEvent>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
@@ -347,6 +355,14 @@ pub fn check_runtime_adoption_record(
         errors,
         warnings,
     }
+}
+
+pub fn should_write_checked_record(
+    quality: &RuntimeAdoptionRecordQualityReport,
+    allow_warnings: bool,
+) -> bool {
+    quality.valid
+        && (quality.quality == "ready" || (allow_warnings && quality.quality == "warning"))
 }
 
 pub fn review_runtime_adoption_events(

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,13 +213,15 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
    action=check_record to evaluate event quality before writing; check_record is
-   advisory, read-only, and reports errors/warnings without blocking record.
+   advisory, read-only, and reports errors/warnings without blocking record. Use
+   action=record_checked for quality-gated writes: ready records write,
+   warning records require allow_warnings=true, and invalid records are blocked.
    Use action=review to summarize accumulated evidence by track, feature, and
    signal before proposing stronger defaults; review is read-only and advisory.
    Use action=readiness with candidate=card-context-default to inspect whether
@@ -245,7 +247,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,13 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionGuidance,
-        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCheckedRecordReport,
+        RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
         RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
         RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
         card_context_default_readiness, check_runtime_adoption_record,
         prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        should_write_checked_record,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -652,6 +653,34 @@ enum Phase3AdoptionCommands {
         metadata_json: Option<String>,
         #[arg(long)]
         id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    RecordChecked {
+        #[arg(long)]
+        track: String,
+        #[arg(long)]
+        signal: String,
+        #[arg(long)]
+        feature: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long = "allow-warnings")]
+        allow_warnings: bool,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2356,6 +2385,59 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let report = check_runtime_adoption_record(&input);
             print_runtime_adoption_record_quality(&report, &format)
         }
+        Phase3AdoptionCommands::RecordChecked {
+            track,
+            signal,
+            feature,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            allow_warnings,
+            format,
+        } => {
+            let track = parse_runtime_adoption_track(&track)?;
+            let signal = parse_runtime_adoption_signal(&signal)?;
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let input = RuntimeAdoptionRecordPlanInput {
+                id,
+                track: runtime_adoption_track_slug(&track).to_string(),
+                signal: runtime_adoption_signal_slug(&signal).to_string(),
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+            };
+            let quality = check_runtime_adoption_record(&input);
+            let should_write = should_write_checked_record(&quality, allow_warnings);
+            let event = if should_write {
+                let event = runtime_adoption_event_from_input(input, track, signal);
+                db.insert_runtime_adoption_event(&event)
+                    .context("failed to insert runtime adoption event")?;
+                Some(event)
+            } else {
+                None
+            };
+            let report = RuntimeAdoptionCheckedRecordReport {
+                writes: event.is_some(),
+                blocked: event.is_none(),
+                record_quality: quality,
+                event,
+            };
+            print_runtime_adoption_checked_record(&report, &format)
+        }
         Phase3AdoptionCommands::Review {
             track,
             feature,
@@ -2418,42 +2500,24 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
                 .map(serde_json::from_str)
                 .transpose()
                 .context("failed to parse --metadata-json")?;
-            let created_at = current_timestamp();
-            let nonce = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|duration| duration.as_nanos().to_string())
-                .unwrap_or_else(|_| "0".to_string());
-            let id = id.unwrap_or_else(|| {
-                stable_cli_id(
-                    "adoption",
-                    &[
-                        runtime_adoption_track_slug(&track),
-                        runtime_adoption_signal_slug(&signal),
-                        feature.as_str(),
-                        query.as_deref().unwrap_or(""),
-                        context_hash.as_deref().unwrap_or(""),
-                        card_id.as_deref().unwrap_or(""),
-                        evaluator_id.as_deref().unwrap_or(""),
-                        research_report_id.as_deref().unwrap_or(""),
-                        created_at.as_str(),
-                        nonce.as_str(),
-                    ],
-                )
-            });
-            let event = RuntimeAdoptionEvent {
-                id: id.clone(),
+            let event = runtime_adoption_event_from_input(
+                RuntimeAdoptionRecordPlanInput {
+                    id,
+                    track: runtime_adoption_track_slug(&track).to_string(),
+                    signal: runtime_adoption_signal_slug(&signal).to_string(),
+                    feature,
+                    query,
+                    context_hash,
+                    card_id,
+                    evaluator_id,
+                    research_report_id,
+                    note,
+                    metadata,
+                },
                 track,
                 signal,
-                feature,
-                query,
-                context_hash,
-                card_id,
-                evaluator_id,
-                research_report_id,
-                note,
-                metadata,
-                created_at,
-            };
+            );
+            let id = event.id.clone();
             db.insert_runtime_adoption_event(&event)
                 .context("failed to insert runtime adoption event")?;
             match format.as_str() {
@@ -2507,6 +2571,81 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn runtime_adoption_event_from_input(
+    input: RuntimeAdoptionRecordPlanInput,
+    track: RuntimeAdoptionTrack,
+    signal: RuntimeAdoptionSignal,
+) -> RuntimeAdoptionEvent {
+    let created_at = current_timestamp();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos().to_string())
+        .unwrap_or_else(|_| "0".to_string());
+    let id = input.id.unwrap_or_else(|| {
+        stable_cli_id(
+            "adoption",
+            &[
+                runtime_adoption_track_slug(&track),
+                runtime_adoption_signal_slug(&signal),
+                input.feature.as_str(),
+                input.query.as_deref().unwrap_or(""),
+                input.context_hash.as_deref().unwrap_or(""),
+                input.card_id.as_deref().unwrap_or(""),
+                input.evaluator_id.as_deref().unwrap_or(""),
+                input.research_report_id.as_deref().unwrap_or(""),
+                created_at.as_str(),
+                nonce.as_str(),
+            ],
+        )
+    });
+    RuntimeAdoptionEvent {
+        id,
+        track,
+        signal,
+        feature: input.feature,
+        query: input.query,
+        context_hash: input.context_hash,
+        card_id: input.card_id,
+        evaluator_id: input.evaluator_id,
+        research_report_id: input.research_report_id,
+        note: input.note,
+        metadata: input.metadata,
+        created_at,
+    }
+}
+
+fn print_runtime_adoption_checked_record(
+    report: &RuntimeAdoptionCheckedRecordReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("blocked={}", report.blocked);
+            println!("quality={}", report.record_quality.quality);
+            if let Some(event) = report.event.as_ref() {
+                println!("event_id={}", event.id);
+            }
+            for error in &report.record_quality.errors {
+                println!("error={error}");
+            }
+            for warning in &report.record_quality.warnings {
+                println!("warning={warning}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption checked record report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,10 +6,11 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
-        build_research_ingest_plan_from_value, card_context_default_readiness,
-        check_runtime_adoption_record, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance,
+        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionRecordPlanInput,
+        RuntimeAdoptionReviewFilters, build_research_ingest_plan_from_value,
+        card_context_default_readiness, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        should_write_checked_record,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1347,7 +1348,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1361,6 +1362,7 @@ impl MempalMcpServer {
                 guidance: Some(runtime_adoption_guidance().into()),
                 record_plan: None,
                 record_quality: None,
+                record_checked: None,
                 review_report: None,
                 readiness_report: None,
                 event: None,
@@ -1397,6 +1399,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: Some(plan.into()),
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1434,6 +1437,84 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: Some(check_runtime_adoption_record(&input).into()),
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                }))
+            }
+            "record_checked" => {
+                let db = self.open_db()?;
+                let track = parse_runtime_adoption_track(required_string(
+                    request.track.as_deref(),
+                    "track",
+                )?)?;
+                let signal = parse_runtime_adoption_signal(required_string(
+                    request.signal.as_deref(),
+                    "signal",
+                )?)?;
+                let feature = request.feature.unwrap_or_default();
+                let input = RuntimeAdoptionRecordPlanInput {
+                    id: trim_to_owned(request.id.as_deref()),
+                    track: runtime_adoption_track_slug(&track).to_string(),
+                    signal: runtime_adoption_signal_slug(&signal).to_string(),
+                    feature,
+                    query: trim_to_owned(request.query.as_deref()),
+                    context_hash: trim_to_owned(request.context_hash.as_deref()),
+                    card_id: trim_to_owned(request.card_id.as_deref()),
+                    evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                    research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                    note: trim_to_owned(request.note.as_deref()),
+                    metadata: request.metadata,
+                };
+                let quality = check_runtime_adoption_record(&input);
+                let should_write =
+                    should_write_checked_record(&quality, request.allow_warnings.unwrap_or(false));
+                let event = if should_write {
+                    let event = RuntimeAdoptionEvent {
+                        id: input
+                            .id
+                            .unwrap_or_else(|| phase3_event_id(&track, &signal, &input.feature)),
+                        track,
+                        signal,
+                        feature: input.feature,
+                        query: input.query,
+                        context_hash: input.context_hash,
+                        card_id: input.card_id,
+                        evaluator_id: input.evaluator_id,
+                        research_report_id: input.research_report_id,
+                        note: input.note,
+                        metadata: input.metadata,
+                        created_at: current_timestamp(),
+                    };
+                    db.insert_runtime_adoption_event(&event).map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to insert runtime adoption event: {error}"),
+                            None,
+                        )
+                    })?;
+                    Some(event)
+                } else {
+                    None
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: Some(
+                        RuntimeAdoptionCheckedRecordReport {
+                            writes: event.is_some(),
+                            blocked: event.is_none(),
+                            record_quality: quality,
+                            event,
+                        }
+                        .into(),
+                    ),
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1487,6 +1568,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: Some(report.into()),
                     readiness_report: None,
                     event: None,
@@ -1529,6 +1611,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: Some(report.into()),
                     event: None,
@@ -1576,6 +1659,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
@@ -1606,6 +1690,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1639,6 +1724,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1657,6 +1743,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1675,6 +1762,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1693,6 +1781,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1707,7 +1796,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4028,7 +4117,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, prepare_record, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4180,6 +4269,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_phase3_record_checked_quality_gated() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let ready = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "record_checked",
+                "track": "runtime_adoption",
+                "signal": "accepted",
+                "feature": "context_pack",
+                "query": "skill trigger",
+                "note": "context guidance helped"
+            }))
+            .await
+            .expect("record checked ready");
+        let checked = ready.record_checked.expect("checked record");
+        assert!(checked.writes);
+        assert!(!checked.blocked);
+        assert_eq!(checked.record_quality.quality, "ready");
+        assert!(checked.event.is_some());
+
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            1
+        );
+
+        let warning = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "record_checked",
+                "track": "card_context",
+                "signal": "accepted",
+                "feature": "include_cards"
+            }))
+            .await
+            .expect("record checked warning");
+        let checked = warning.record_checked.expect("checked record");
+        assert!(!checked.writes);
+        assert!(checked.blocked);
+        assert_eq!(checked.record_quality.quality, "warning");
+        assert!(checked.event.is_none());
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_phase3_review_action_is_read_only() {
         let (_tempdir, db_path, server) = setup_server();
         let before = {
@@ -4286,11 +4428,12 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,9 +1,10 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
     Phase3ReadinessReport, ResearchCandidateInsightPlan, ResearchEvidenceDrawerPlan,
-    ResearchIngestPlanReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
-    RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
-    RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
+    ResearchIngestPlanReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
+    RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
+    RuntimeAdoptionReviewReport, RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance,
+    RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
@@ -328,6 +329,7 @@ pub struct Phase3Request {
     pub limit: Option<usize>,
     pub candidate: Option<String>,
     pub report: Option<serde_json::Value>,
+    pub allow_warnings: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -338,6 +340,8 @@ pub struct Phase3Response {
     pub record_plan: Option<RuntimeAdoptionRecordPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_quality: Option<RuntimeAdoptionRecordQualityDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_checked: Option<RuntimeAdoptionCheckedRecordDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub review_report: Option<RuntimeAdoptionReviewReportDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -393,6 +397,14 @@ pub struct RuntimeAdoptionRecordQualityDto {
     pub quality: String,
     pub errors: Vec<String>,
     pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionCheckedRecordDto {
+    pub writes: bool,
+    pub blocked: bool,
+    pub record_quality: RuntimeAdoptionRecordQualityDto,
+    pub event: Option<RuntimeAdoptionEventDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -462,6 +474,17 @@ impl From<RuntimeAdoptionRecordQualityReport> for RuntimeAdoptionRecordQualityDt
             quality: report.quality,
             errors: report.errors,
             warnings: report.warnings,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionCheckedRecordReport> for RuntimeAdoptionCheckedRecordDto {
+    fn from(report: RuntimeAdoptionCheckedRecordReport) -> Self {
+        Self {
+            writes: report.writes,
+            blocked: report.blocked,
+            record_quality: report.record_quality.into(),
+            event: report.event.map(RuntimeAdoptionEventDto::from),
         }
     }
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -617,6 +617,160 @@ fn test_cli_phase3_adoption_check_record_rejects_empty_feature() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_record_checked_writes_ready_event() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "runtime_adoption",
+            "--signal",
+            "accepted",
+            "--feature",
+            "context_pack",
+            "--query",
+            "skill trigger",
+            "--note",
+            "context guidance helped",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record-checked failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("checked record json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["blocked"], false);
+    assert_eq!(report["record_quality"]["quality"], "ready");
+    assert!(report["event"]["id"].as_str().expect("event id").len() > 8);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn test_cli_phase3_adoption_record_checked_blocks_warning_by_default() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record-checked should return blocked JSON: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("checked record json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["blocked"], true);
+    assert_eq!(report["record_quality"]["quality"], "warning");
+    assert!(report.get("event").is_none() || report["event"].is_null());
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_record_checked_allow_warnings_writes_warning_event() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--allow-warnings",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record-checked failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("checked record json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["blocked"], false);
+    assert_eq!(report["record_quality"]["quality"], "warning");
+    assert!(report["event"]["id"].as_str().expect("event id").len() > 8);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn test_cli_phase3_adoption_record_checked_blocks_invalid_even_with_allow_warnings() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "   ",
+            "--allow-warnings",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record-checked should return blocked JSON: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("checked record json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["blocked"], true);
+    assert_eq!(report["record_quality"]["quality"], "invalid");
+    assert!(report.get("event").is_none() || report["event"].is_null());
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
 fn test_cli_phase3_adoption_review_json_summarizes_events() {
     let home = setup_cli_home();
     for (id, signal) in [


### PR DESCRIPTION
## Summary
- add P69 spec and plan for quality-gated runtime adoption writes
- add CLI `mempal phase3 adoption record-checked`
- add MCP `mempal_phase3 action=record_checked`
- block warning-quality records by default, allow them only with explicit allow-warnings, and always block invalid records

## Verification
- agent-spec parse specs/p69-runtime-adoption-checked-record.spec.md
- agent-spec lint specs/p69-runtime-adoption-checked-record.spec.md --min-score 0.7
- cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_writes_ready_event
- cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_warning_by_default
- cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_allow_warnings_writes_warning_event
- cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_invalid_even_with_allow_warnings
- cargo test mcp::server::tests::test_mcp_phase3_record_checked_quality_gated --lib
- cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --workspace --all-targets --features rest -- -D warnings
- cargo test
- git diff --check