### PR TITLE
docs: audit self-evolution completion state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
+| `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -190,6 +191,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
+- `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
+| `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -188,6 +189,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
+- `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1383,6 +1383,72 @@ explicitly set, and `quality=invalid` records are always blocked. This reduces
 low-signal self-evolution evidence without adding hooks, background
 instrumentation, schema changes, or new authority for Phase-3 gates.
 
+P70 self-evolution completion audit records the current state against the
+larger objective: a complete self-evolving agent system. Complete
+self-evolving agent system deliverables are:
+
+- evidence substrate: the system can store cited raw evidence and runtime
+  adoption outcomes without losing provenance
+- knowledge governance: evidence can be distilled into governed knowledge and
+  moved through lifecycle gates
+- runtime retrieval: agents can request context/search/card/research guidance
+  without changing defaults implicitly
+- research bridge: external research output can enter as evidence and candidate
+  insight suggestions, not as direct dao
+- feedback loop: runtime use, acceptance, rejection, misses, rollbacks, and
+  contradictions can be recorded and reviewed
+- policy hardening path: stronger defaults require evidence, readiness checks,
+  rollback criteria, and a new P-level spec
+
+Prompt-to-artifact checklist:
+
+- Evidence substrate -> P54 runtime_adoption_events plus P0-P13 raw drawer
+  storage and cited search provide durable evidence records.
+- Knowledge governance -> P12-P28 implement typed `dao_tian` / `dao_ren` /
+  `shu` / `qi` drawers, context assembly, policy surfaces, distill, gate,
+  promote, demote, and anchor publication.
+- Knowledge cards -> P31-P45 implement Phase-2 card schema, core API, CLI,
+  MCP read/lifecycle/retrieval, backfill, and explicit card-aware context.
+- Research ingestion -> P49/P59/P67/P68 preserve evidence-first research
+  boundaries: validate report, plan evidence refs, write research evidence only
+  through explicit CLI `--execute`, and expose MCP dry-run planning.
+- Runtime adoption -> P54-P69 implement event storage, CLI/MCP record/list/stats,
+  guidance, prepare/check helpers, review, readiness, and quality-gated
+  `record_checked` writes.
+- Default hardening -> P56/P57/P58/P66 define read-only gates and readiness
+  reports for card context, card embeddings, evaluator APIs, and
+  card-context-default eligibility.
+
+P70 conclusion: not complete. P12-P69 establish a governed self-evolution
+substrate, but they do not yet prove a complete self-evolving agent system.
+Remaining gaps before full self-evolution:
+
+- no automatic or semi-automatic adoption capture around actual agent tool
+  execution; evidence still depends on explicit CLI/MCP calls
+- no end-to-end replay that demonstrates research -> evidence -> distill ->
+  gated promotion -> runtime context -> checked adoption record in one audited
+  scenario
+- no evaluator advisory API with replayable output contracts; P50/P58 only keep
+  evaluators advisory and gated
+- no default-on card context or card embeddings; P66 readiness only reports
+  eligibility for a future default-on spec
+- no autonomous promotion authority; lifecycle changes still require deterministic
+  gates, evidence refs, and human/reviewer boundaries
+- no rollback executor for default/runtime policy changes; rollback criteria are
+  policy requirements, not an automated runtime mechanism
+
+Future P candidates:
+
+- P71 candidate: self-evolution loop replay, an audit/test scenario that walks
+  from research evidence through distill, promotion gate, context use, and
+  `record_checked`.
+- P72 candidate: adoption capture helper around agent tool outcomes, still
+  explicit and reviewable, not background instrumentation.
+- P73 candidate: evaluator advisory API contract with replayable outputs and no
+  lifecycle authority.
+- P74 candidate: card-context default-on proposal gated by accumulated P66
+  readiness evidence plus rollback criteria.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-13-p70-self-evolution-completion-audit.md
+++ b/docs/plans/2026-05-13-p70-self-evolution-completion-audit.md
@@ -1,0 +1,31 @@
+# P70 Self-Evolution Completion Audit
+
+Goal: audit the "complete self-evolving agent system" objective against actual
+P-level artifacts, record what is implemented, and list the remaining gaps
+without changing runtime behavior.
+
+Spec: `specs/p70-self-evolution-completion-audit.spec.md`
+
+## Steps
+
+- [x] Add P70 task contract and plan.
+- [x] Add a P70 audit section to `docs/MIND-MODEL-DESIGN.md`.
+- [x] Map objective deliverables to concrete P-level artifacts and evidence.
+- [x] Record the explicit non-completion conclusion and remaining gaps.
+- [x] Update AGENTS and CLAUDE inventories.
+- [x] Verify spec parse/lint, grep acceptance checks, audit-only boundary, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p70-self-evolution-completion-audit.spec.md
+agent-spec lint specs/p70-self-evolution-completion-audit.spec.md --min-score 0.7
+rg -n "P70 self-evolution completion audit|Complete self-evolving agent system deliverables" docs/MIND-MODEL-DESIGN.md
+rg -n "Evidence substrate.*P54|Knowledge governance.*P12-P28|Knowledge cards.*P31-P45|Research ingestion.*P49/P59/P67/P68|Runtime adoption.*P54-P69" docs/MIND-MODEL-DESIGN.md
+rg -n "P70 conclusion: not complete|Remaining gaps before full self-evolution" docs/MIND-MODEL-DESIGN.md
+rg -n "P71 candidate|P72 candidate|P73 candidate" docs/MIND-MODEL-DESIGN.md
+rg -n "p70-self-evolution-completion-audit|P70 self-evolution completion audit" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/specs/p70-self-evolution-completion-audit.spec.md
+++ b/specs/p70-self-evolution-completion-audit.spec.md
@@ -1,0 +1,100 @@
+spec: task
+name: "P70: self-evolution completion audit"
+inherits: project
+tags: [phase-3, self-evolution, audit, mind-model]
+---
+
+## Intent
+
+P69 made runtime adoption evidence safer to write, but the active objective is
+larger than any single feature: a complete self-evolving agent system. P70 adds
+an explicit completion audit that maps the objective to concrete artifacts,
+identifies which loops are implemented, and records remaining gaps without
+claiming the overall goal is complete.
+
+## Decisions
+
+- P70 is audit-only and must not change runtime behavior.
+- The audit must restate "complete self-evolving agent system" as concrete
+  deliverables.
+- The audit must map each deliverable to existing P-level artifacts and evidence.
+- The audit must explicitly state that P12-P69 do not yet prove full completion.
+- The audit must list missing or weakly verified loops as future P candidates.
+- Every future P still requires its own `specs/pNN-*.spec.md` and plan document.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p70-self-evolution-completion-audit.spec.md
+- docs/plans/2026-05-13-p70-self-evolution-completion-audit.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not add schema migrations.
+- Do not add hooks, background workers, or automatic instrumentation.
+- Do not change runtime defaults.
+- Do not mark the thread goal complete.
+- Do not claim self-evolution is complete without listing remaining gaps.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records the P70 completion audit
+  Test:
+    Filter: rg -n "P70 self-evolution completion audit|Complete self-evolving agent system deliverables" docs/MIND-MODEL-DESIGN.md
+    Targets: Design document audit section.
+  Given the MIND-MODEL design document
+  When reading the Phase-3 audit section
+  Then it identifies P70 as a self-evolution completion audit
+  And it restates the objective as concrete deliverables
+
+Scenario: Audit maps implemented deliverables to artifacts
+  Test:
+    Filter: rg -n "Evidence substrate.*P54|Knowledge governance.*P12-P28|Knowledge cards.*P31-P45|Research ingestion.*P49/P59/P67/P68|Runtime adoption.*P54-P69" docs/MIND-MODEL-DESIGN.md
+    Targets: Prompt-to-artifact checklist in MIND-MODEL.
+  Given the P70 audit checklist
+  When searching for implemented deliverables
+  Then it maps evidence substrate, knowledge governance, cards, research, and runtime adoption to concrete P artifacts
+
+Scenario: Audit states the objective is not complete yet
+  Test:
+    Filter: rg -n "P70 conclusion: not complete|Remaining gaps before full self-evolution" docs/MIND-MODEL-DESIGN.md
+    Targets: Explicit non-completion statement.
+  Given the P70 audit
+  When reading its conclusion
+  Then it states the full self-evolution objective is not complete yet
+  And it lists remaining gaps
+
+Scenario: Audit lists future P candidates
+  Test:
+    Filter: rg -n "P71 candidate|P72 candidate|P73 candidate" docs/MIND-MODEL-DESIGN.md
+    Targets: Future work candidate list.
+  Given the P70 audit
+  When reading the future work list
+  Then it names at least three future P candidates
+
+Scenario: Inventories include P70
+  Test:
+    Filter: rg -n "p70-self-evolution-completion-audit|P70 self-evolution completion audit" AGENTS.md CLAUDE.md
+    Targets: Agent inventory documents.
+  Given repo agent inventories
+  When searching for P70
+  Then both AGENTS.md and CLAUDE.md include P70 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: P70 audit-only boundary.
+  Given the P70 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+## Out of Scope
+
+- Implementing P71 or later candidates.
+- Adding automatic adoption capture.
+- Turning card context on by default.
+- Adding evaluator lifecycle APIs.
+- Marking the overall thread goal complete.


### PR DESCRIPTION
## Summary
- add P70 spec and plan for self-evolution completion audit
- map the complete self-evolving agent system objective to concrete P-level artifacts
- record explicit non-completion conclusion and remaining gaps
- list future P candidates for loop replay, adoption capture, evaluator advisory APIs, and default-on card context

## Verification
- agent-spec parse specs/p70-self-evolution-completion-audit.spec.md
- agent-spec lint specs/p70-self-evolution-completion-audit.spec.md --min-score 0.7
- rg -n "P70 self-evolution completion audit|Complete self-evolving agent system deliverables" docs/MIND-MODEL-DESIGN.md
- rg -n "Evidence substrate.*P54|Knowledge governance.*P12-P28|Knowledge cards.*P31-P45|Research ingestion.*P49/P59/P67/P68|Runtime adoption.*P54-P69" docs/MIND-MODEL-DESIGN.md
- rg -n "P70 conclusion: not complete|Remaining gaps before full self-evolution" docs/MIND-MODEL-DESIGN.md
- rg -n "P71 candidate|P72 candidate|P73 candidate" docs/MIND-MODEL-DESIGN.md
- rg -n "p70-self-evolution-completion-audit|P70 self-evolution completion audit" AGENTS.md CLAUDE.md
- git diff --name-only
- git diff --check