### PR TITLE
feat: add runtime adoption capture helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
+| `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -194,6 +195,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
+- `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 
 ### Spec 使用方式
 
@@ -229,7 +231,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
+| `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -192,6 +193,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
+- `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 
 ### Spec 使用方式
 
@@ -227,7 +229,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1443,8 +1443,10 @@ Future P candidates:
   walks research -> evidence -> knowledge card -> gate/promote -> context ->
   checked adoption record. This proves the existing pieces can compose, but it
   does not add automatic runtime capture.
-- P72 candidate: adoption capture helper around agent tool outcomes, still
-  explicit and reviewable, not background instrumentation.
+- P72 runtime adoption capture helper: implemented as explicit CLI/MCP
+  `capture` surfaces that map `surface/outcome` observations into existing
+  checked runtime adoption records. It is dry-run by default, writes only with
+  explicit execute, and does not add background instrumentation.
 - P73 candidate: evaluator advisory API contract with replayable outputs and no
   lifecycle authority.
 - P74 candidate: card-context default-on proposal gated by accumulated P66

--- a/docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md
+++ b/docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md
@@ -1,0 +1,39 @@
+# P72 Runtime Adoption Capture Helper
+
+Goal: add an explicit capture helper that turns low-friction
+`surface/outcome` runtime observations into existing checked runtime adoption
+records.
+
+Spec: `specs/p72-runtime-adoption-capture-helper.spec.md`
+
+## Steps
+
+- [x] Add P72 task contract and plan.
+- [x] Add failing CLI capture tests for dry-run, execute, warning block, and invalid surface.
+- [x] Add failing MCP capture test for dry-run and execute.
+- [x] Implement pure capture mapping and checked-write reuse in `src/core/phase3.rs`.
+- [x] Wire CLI `mempal phase3 adoption capture`.
+- [x] Wire MCP `mempal_phase3 action=capture`.
+- [x] Update protocol/tool descriptions and inventories.
+- [x] Verify spec parse/lint, targeted tests, formatting, clippy, full tests, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p72-runtime-adoption-capture-helper.spec.md
+agent-spec lint specs/p72-runtime-adoption-capture-helper.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_capture_card_context_dry_run
+cargo test --test phase3_runtime test_cli_phase3_adoption_capture_execute_writes_ready_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_capture_blocks_warning_by_default
+cargo test --test phase3_runtime test_cli_phase3_adoption_capture_rejects_unknown_surface
+cargo test mcp::server::tests::test_mcp_phase3_capture_action_dry_run_and_execute --lib
+rg -n "p72-runtime-adoption-capture-helper|P72 runtime adoption capture helper" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p72-runtime-adoption-capture-helper.spec.md
+++ b/specs/p72-runtime-adoption-capture-helper.spec.md
@@ -1,0 +1,114 @@
+spec: task
+name: "P72: runtime adoption capture helper"
+inherits: project
+tags: [phase-3, self-evolution, runtime-adoption, capture]
+---
+
+## Intent
+
+P71 proved the self-evolution pieces can be composed, but adoption evidence is
+still too manual: an agent must know the exact `track/signal/feature` tuple for
+every runtime outcome. P72 adds an explicit capture helper that maps a small
+surface/outcome vocabulary into the existing P69 checked-record path, lowering
+recording friction without adding background hooks or autonomous capture.
+
+## Decisions
+
+- P72 must leave its own `specs/p72-*.spec.md` and plan document.
+- Add CLI `mempal phase3 adoption capture`.
+- Add MCP `mempal_phase3 action=capture`.
+- Capture inputs use `surface` and `outcome`; the helper maps them to existing
+  `track`, `signal`, and `feature` values.
+- Capture defaults to dry-run/read-only and returns a record plan plus quality
+  report.
+- Capture writes only when `--execute` / `execute=true` is set, and writes must
+  reuse the P69 checked-record policy.
+- Warning-quality captures remain blocked by default and require
+  `--allow-warnings` / `allow_warnings=true` to write.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p72-runtime-adoption-capture-helper.spec.md
+- docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema migrations.
+- Do not add background hooks or automatic instrumentation.
+- Do not bypass `check_record` / `record_checked` quality policy.
+- Do not change existing `record`, `prepare-record`, `check-record`, or
+  `record-checked` behavior.
+- Do not mark the overall self-evolution objective complete.
+
+## Acceptance Criteria
+
+Scenario: CLI capture dry-run maps card context outcome through src/main.rs without writing
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_capture_card_context_dry_run
+    Targets: CLI capture dry-run behavior.
+  Given a card-context accepted outcome with query "skill trigger" and note "card helped"
+  When running `mempal phase3 adoption capture --surface card-context --outcome accepted --card-id card_1 --query "skill trigger" --note "card helped" --format json`
+  Then stdout contains `writes=false`
+  And stdout contains a record plan with `track=card_context`, `signal=accepted`, and `feature=include_cards`
+  And the quality report is `ready`
+  And no runtime adoption event is persisted
+
+Scenario: CLI capture execute writes through checked policy
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_capture_execute_writes_ready_event
+    Targets: CLI capture execute behavior.
+  Given a ready card-context accepted outcome
+  When running capture with `--execute --format json`
+  Then stdout contains `writes=true`
+  And exactly one runtime adoption event is persisted
+
+Scenario: CLI capture blocks warning by default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_capture_blocks_warning_by_default
+    Targets: CLI capture warning policy.
+  Given a card-context accepted outcome without `card_id`
+  When running capture with `--execute --format json`
+  Then stdout contains `writes=false` and `blocked=true`
+  And no runtime adoption event is persisted
+
+Scenario: MCP capture supports dry-run and execute through src/mcp/server.rs
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_capture_action_dry_run_and_execute --lib
+    Targets: MCP capture action in `src/mcp/server.rs`.
+  Given `mempal_phase3 action=capture`
+  When called once without `execute` and once with `execute=true`
+  Then the dry-run response has no DB side effect
+  And the execute response writes through checked-record policy
+
+Scenario: Capture rejects unknown surface
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_capture_rejects_unknown_surface
+    Targets: CLI capture input validation in `src/main.rs`.
+  Given an unsupported capture surface
+  When running capture
+  Then the command fails
+  And stderr mentions `unsupported adoption capture surface`
+
+Scenario: Inventories include P72
+  Test:
+    Filter: rg -n "p72-runtime-adoption-capture-helper|P72 runtime adoption capture helper" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Agent inventories and design document.
+  Given project documentation
+  When searching for P72
+  Then the spec, plan, and design status are recorded
+
+## Out of Scope
+
+- Automatic capture from live agent tool calls.
+- Hook installation or shell/TUI instrumentation.
+- New runtime adoption tables or schema changes.
+- Evaluator advisory API.
+- Default-on card context.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -59,6 +59,17 @@ pub struct RuntimeAdoptionCheckedRecordReport {
     pub event: Option<RuntimeAdoptionEvent>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuntimeAdoptionCaptureReport {
+    pub writes: bool,
+    pub execute: bool,
+    pub surface: String,
+    pub outcome: String,
+    pub record_plan: RuntimeAdoptionRecordPlan,
+    pub record_quality: RuntimeAdoptionRecordQualityReport,
+    pub record_checked: Option<RuntimeAdoptionCheckedRecordReport>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
@@ -149,6 +160,20 @@ pub struct RuntimeAdoptionRecordPlanInput {
     pub track: String,
     pub signal: String,
     pub feature: String,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeAdoptionCaptureInput {
+    pub id: Option<String>,
+    pub surface: String,
+    pub outcome: String,
     pub query: Option<String>,
     pub context_hash: Option<String>,
     pub card_id: Option<String>,
@@ -305,6 +330,45 @@ pub fn prepare_runtime_adoption_record(
     }
 }
 
+pub fn capture_runtime_adoption_record_input(
+    input: RuntimeAdoptionCaptureInput,
+) -> Result<RuntimeAdoptionRecordPlanInput, String> {
+    let (track, feature) = capture_surface_mapping(&input.surface)?;
+    let signal = capture_outcome_signal(&input.outcome)?;
+    Ok(RuntimeAdoptionRecordPlanInput {
+        id: input.id,
+        track,
+        signal,
+        feature,
+        query: input.query,
+        context_hash: input.context_hash,
+        card_id: input.card_id,
+        evaluator_id: input.evaluator_id,
+        research_report_id: input.research_report_id,
+        note: input.note,
+        metadata: input.metadata,
+    })
+}
+
+pub fn prepare_runtime_adoption_capture(
+    surface: String,
+    outcome: String,
+    execute: bool,
+    record_input: RuntimeAdoptionRecordPlanInput,
+) -> RuntimeAdoptionCaptureReport {
+    let record_plan = prepare_runtime_adoption_record(record_input.clone());
+    let record_quality = check_runtime_adoption_record(&record_input);
+    RuntimeAdoptionCaptureReport {
+        writes: false,
+        execute,
+        surface,
+        outcome,
+        record_plan,
+        record_quality,
+        record_checked: None,
+    }
+}
+
 pub fn check_runtime_adoption_record(
     input: &RuntimeAdoptionRecordPlanInput,
 ) -> RuntimeAdoptionRecordQualityReport {
@@ -354,6 +418,40 @@ pub fn check_runtime_adoption_record(
         quality,
         errors,
         warnings,
+    }
+}
+
+fn capture_surface_mapping(surface: &str) -> Result<(String, String), String> {
+    match surface.trim() {
+        "card-context" | "card_context" => {
+            Ok(("card_context".to_string(), "include_cards".to_string()))
+        }
+        "card-embedding" | "card_embedding" => Ok((
+            "card_embedding".to_string(),
+            "card_statement_recall".to_string(),
+        )),
+        "research-adapter" | "research_adapter" => Ok((
+            "research_adapter".to_string(),
+            "research_ingest_plan".to_string(),
+        )),
+        "evaluator" => Ok(("evaluator".to_string(), "advisory_gate".to_string())),
+        "runtime-context" | "runtime_context" => {
+            Ok(("runtime_adoption".to_string(), "context_pack".to_string()))
+        }
+        "skill-selection" | "skill_selection" => Ok((
+            "runtime_adoption".to_string(),
+            "skill_selection".to_string(),
+        )),
+        other => Err(format!("unsupported adoption capture surface: {other}")),
+    }
+}
+
+fn capture_outcome_signal(outcome: &str) -> Result<String, String> {
+    match outcome.trim() {
+        "used" | "accepted" | "rejected" | "miss" | "rollback" | "contradiction" | "neutral" => {
+            Ok(outcome.trim().to_string())
+        }
+        other => Err(format!("unsupported adoption capture outcome: {other}")),
     }
 }
 

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,11 +213,15 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
+   action=capture when you have a concrete runtime outcome but do not want to
+   manually choose track/signal/feature: capture maps surface/outcome to the
+   checked-record path, is read-only by default, and writes only with
+   execute=true. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,
@@ -247,7 +251,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,13 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCheckedRecordReport,
-        RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCaptureInput,
+        RuntimeAdoptionCaptureReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
+        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
         RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
         RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
-        card_context_default_readiness, check_runtime_adoption_record,
+        capture_runtime_adoption_record_input, card_context_default_readiness,
+        check_runtime_adoption_record, prepare_runtime_adoption_capture,
         prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
         should_write_checked_record,
     },
@@ -627,6 +629,34 @@ enum Phase3AdoptionCommands {
         metadata_json: Option<String>,
         #[arg(long)]
         id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Capture {
+        #[arg(long)]
+        surface: String,
+        #[arg(long)]
+        outcome: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long)]
+        execute: bool,
+        #[arg(long = "allow-warnings")]
+        allow_warnings: bool,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2348,6 +2378,64 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             });
             print_runtime_adoption_record_plan(&plan, &format)
         }
+        Phase3AdoptionCommands::Capture {
+            surface,
+            outcome,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            execute,
+            allow_warnings,
+            format,
+        } => {
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let record_input = capture_runtime_adoption_record_input(RuntimeAdoptionCaptureInput {
+                id,
+                surface: surface.clone(),
+                outcome: outcome.clone(),
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+            })
+            .map_err(anyhow::Error::msg)?;
+            let mut report =
+                prepare_runtime_adoption_capture(surface, outcome, execute, record_input.clone());
+            if execute {
+                let track = parse_runtime_adoption_track(&record_input.track)?;
+                let signal = parse_runtime_adoption_signal(&record_input.signal)?;
+                let should_write =
+                    should_write_checked_record(&report.record_quality, allow_warnings);
+                let event = if should_write {
+                    let event = runtime_adoption_event_from_input(record_input, track, signal);
+                    db.insert_runtime_adoption_event(&event)
+                        .context("failed to insert runtime adoption event")?;
+                    Some(event)
+                } else {
+                    None
+                };
+                report.writes = event.is_some();
+                report.record_checked = Some(RuntimeAdoptionCheckedRecordReport {
+                    writes: event.is_some(),
+                    blocked: event.is_none(),
+                    record_quality: report.record_quality.clone(),
+                    event,
+                });
+            }
+            print_runtime_adoption_capture(&report, &format)
+        }
         Phase3AdoptionCommands::CheckRecord {
             track,
             signal,
@@ -2642,6 +2730,43 @@ fn print_runtime_adoption_checked_record(
                 "{}",
                 serde_json::to_string_pretty(report)
                     .context("failed to serialize runtime adoption checked record report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
+    }
+}
+
+fn print_runtime_adoption_capture(
+    report: &RuntimeAdoptionCaptureReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("execute={}", report.execute);
+            println!("surface={}", report.surface);
+            println!("outcome={}", report.outcome);
+            println!("quality={}", report.record_quality.quality);
+            if let Some(checked) = report.record_checked.as_ref() {
+                println!("blocked={}", checked.blocked);
+                if let Some(event) = checked.event.as_ref() {
+                    println!("event_id={}", event.id);
+                }
+            }
+            for error in &report.record_quality.errors {
+                println!("error={error}");
+            }
+            for warning in &report.record_quality.warnings {
+                println!("warning={warning}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption capture report")?
             );
             Ok(())
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,11 +6,12 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionReviewFilters, build_research_ingest_plan_from_value,
+        RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
+        build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
         card_context_default_readiness, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
-        should_write_checked_record,
+        prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1348,7 +1349,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1400,6 +1401,87 @@ impl MempalMcpServer {
                     record_plan: Some(plan.into()),
                     record_quality: None,
                     record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                }))
+            }
+            "capture" => {
+                let surface = required_string(request.surface.as_deref(), "surface")?.to_string();
+                let outcome = required_string(request.outcome.as_deref(), "outcome")?.to_string();
+                let record_input =
+                    capture_runtime_adoption_record_input(RuntimeAdoptionCaptureInput {
+                        id: trim_to_owned(request.id.as_deref()),
+                        surface: surface.clone(),
+                        outcome: outcome.clone(),
+                        query: trim_to_owned(request.query.as_deref()),
+                        context_hash: trim_to_owned(request.context_hash.as_deref()),
+                        card_id: trim_to_owned(request.card_id.as_deref()),
+                        evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                        research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                        note: trim_to_owned(request.note.as_deref()),
+                        metadata: request.metadata,
+                    })
+                    .map_err(|error| ErrorData::invalid_params(error, None))?;
+                let mut capture = prepare_runtime_adoption_capture(
+                    surface,
+                    outcome,
+                    request.execute.unwrap_or(false),
+                    record_input.clone(),
+                );
+                if request.execute.unwrap_or(false) {
+                    let db = self.open_db()?;
+                    let track = parse_runtime_adoption_track(&record_input.track)?;
+                    let signal = parse_runtime_adoption_signal(&record_input.signal)?;
+                    let should_write = should_write_checked_record(
+                        &capture.record_quality,
+                        request.allow_warnings.unwrap_or(false),
+                    );
+                    let event = if should_write {
+                        let event = RuntimeAdoptionEvent {
+                            id: record_input.id.unwrap_or_else(|| {
+                                phase3_event_id(&track, &signal, &record_input.feature)
+                            }),
+                            track,
+                            signal,
+                            feature: record_input.feature,
+                            query: record_input.query,
+                            context_hash: record_input.context_hash,
+                            card_id: record_input.card_id,
+                            evaluator_id: record_input.evaluator_id,
+                            research_report_id: record_input.research_report_id,
+                            note: record_input.note,
+                            metadata: record_input.metadata,
+                            created_at: current_timestamp(),
+                        };
+                        db.insert_runtime_adoption_event(&event).map_err(|error| {
+                            ErrorData::internal_error(
+                                format!("failed to insert runtime adoption event: {error}"),
+                                None,
+                            )
+                        })?;
+                        Some(event)
+                    } else {
+                        None
+                    };
+                    capture.writes = event.is_some();
+                    capture.record_checked = Some(RuntimeAdoptionCheckedRecordReport {
+                        writes: event.is_some(),
+                        blocked: event.is_none(),
+                        record_quality: capture.record_quality.clone(),
+                        event,
+                    });
+                }
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: Some(capture.record_plan.into()),
+                    record_quality: Some(capture.record_quality.into()),
+                    record_checked: capture.record_checked.map(Into::into),
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1796,7 +1878,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4117,7 +4199,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, prepare_record, capture, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4266,6 +4348,73 @@ mod tests {
                 .len(),
             before
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_capture_action_dry_run_and_execute() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let dry_run = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "capture",
+                "surface": "card-context",
+                "outcome": "accepted",
+                "card_id": "card_1",
+                "query": "skill trigger",
+                "note": "card helped"
+            }))
+            .await
+            .expect("capture dry run");
+        let plan = dry_run.record_plan.expect("record plan");
+        assert!(!plan.writes);
+        assert_eq!(plan.record_payload["track"], "card_context");
+        assert_eq!(plan.record_payload["signal"], "accepted");
+        assert_eq!(plan.record_payload["feature"], "include_cards");
+        assert_eq!(
+            dry_run.record_quality.expect("record quality").quality,
+            "ready"
+        );
+        assert!(dry_run.record_checked.is_none());
+
+        let db = Database::open(&db_path).expect("open db");
+        assert!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .is_empty()
+        );
+        insert_knowledge_card(
+            &db_path,
+            knowledge_card(
+                "card_1",
+                KnowledgeTier::Shu,
+                KnowledgeStatus::Promoted,
+                "general",
+            ),
+        );
+
+        let executed = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "capture",
+                "surface": "card-context",
+                "outcome": "accepted",
+                "card_id": "card_1",
+                "query": "skill trigger",
+                "note": "card helped",
+                "execute": true
+            }))
+            .await
+            .expect("capture execute");
+        let checked = executed.record_checked.expect("checked record");
+        assert!(checked.writes);
+        assert!(!checked.blocked);
+        assert_eq!(checked.record_quality.quality, "ready");
+
+        let db = Database::open(&db_path).expect("reopen db");
+        let events = db
+            .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].feature, "include_cards");
     }
 
     #[tokio::test]
@@ -4428,11 +4577,12 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -316,6 +316,8 @@ pub struct KnowledgeCardsResponse {
 pub struct Phase3Request {
     pub action: String,
     pub id: Option<String>,
+    pub surface: Option<String>,
+    pub outcome: Option<String>,
     pub track: Option<String>,
     pub signal: Option<String>,
     pub feature: Option<String>,
@@ -329,6 +331,7 @@ pub struct Phase3Request {
     pub limit: Option<usize>,
     pub candidate: Option<String>,
     pub report: Option<serde_json::Value>,
+    pub execute: Option<bool>,
     pub allow_warnings: Option<bool>,
 }
 

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -3,7 +3,8 @@ use std::process::Command;
 
 use mempal::core::db::Database;
 use mempal::core::types::{
-    MemoryKind, Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
+    AnchorKind, KnowledgeCard, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
+    Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
     RuntimeAdoptionTrack,
 };
 use serde_json::{Value, json};
@@ -25,6 +26,27 @@ fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
         .env("HOME", home.path())
         .output()
         .expect("run mempal")
+}
+
+fn insert_test_card(home: &TempDir, card_id: &str) {
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    db.insert_knowledge_card(&KnowledgeCard {
+        id: card_id.to_string(),
+        statement: format!("Statement for {card_id}."),
+        content: format!("Content for {card_id}."),
+        tier: KnowledgeTier::Shu,
+        status: KnowledgeStatus::Promoted,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        scope_constraints: None,
+        trigger_hints: None,
+        created_at: "1713000000".to_string(),
+        updated_at: "1713000000".to_string(),
+    })
+    .expect("insert test card");
 }
 
 #[test]
@@ -480,6 +502,169 @@ fn test_cli_phase3_adoption_prepare_record_rejects_invalid_track() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unsupported runtime adoption track"));
+}
+
+#[test]
+fn test_cli_phase3_adoption_capture_card_context_dry_run() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "capture",
+            "--surface",
+            "card-context",
+            "--outcome",
+            "accepted",
+            "--card-id",
+            "card_1",
+            "--query",
+            "skill trigger",
+            "--note",
+            "card helped",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "capture failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("capture json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["execute"], false);
+    assert_eq!(report["surface"], "card-context");
+    assert_eq!(report["outcome"], "accepted");
+    assert_eq!(report["record_plan"]["writes"], false);
+    assert_eq!(
+        report["record_plan"]["record_payload"]["track"],
+        "card_context"
+    );
+    assert_eq!(
+        report["record_plan"]["record_payload"]["signal"],
+        "accepted"
+    );
+    assert_eq!(
+        report["record_plan"]["record_payload"]["feature"],
+        "include_cards"
+    );
+    assert_eq!(report["record_quality"]["quality"], "ready");
+    assert!(report["record_checked"].is_null());
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events")
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_cli_phase3_adoption_capture_execute_writes_ready_event() {
+    let home = setup_cli_home();
+    insert_test_card(&home, "card_1");
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "capture",
+            "--surface",
+            "card-context",
+            "--outcome",
+            "accepted",
+            "--card-id",
+            "card_1",
+            "--query",
+            "skill trigger",
+            "--note",
+            "card helped",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "capture execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("capture json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["execute"], true);
+    assert_eq!(report["record_checked"]["writes"], true);
+    assert_eq!(report["record_checked"]["blocked"], false);
+    assert_eq!(
+        report["record_checked"]["record_quality"]["quality"],
+        "ready"
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].feature, "include_cards");
+}
+
+#[test]
+fn test_cli_phase3_adoption_capture_blocks_warning_by_default() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "capture",
+            "--surface",
+            "card-context",
+            "--outcome",
+            "accepted",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "capture warning should return blocked JSON: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("capture json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["execute"], true);
+    assert_eq!(report["record_quality"]["quality"], "warning");
+    assert_eq!(report["record_checked"]["writes"], false);
+    assert_eq!(report["record_checked"]["blocked"], true);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events")
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_cli_phase3_adoption_capture_rejects_unknown_surface() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "capture",
+            "--surface",
+            "unknown",
+            "--outcome",
+            "accepted",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported adoption capture surface"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add P72 spec and plan for explicit runtime adoption capture
- add CLI `mempal phase3 adoption capture` mapping surface/outcome to checked runtime adoption records
- add MCP `mempal_phase3 action=capture` with dry-run default and execute-gated writes
- update protocol/docs and cover capture dry-run, execute, warning block, invalid surface, and MCP parity

## Verification
- agent-spec parse specs/p72-runtime-adoption-capture-helper.spec.md
- agent-spec lint specs/p72-runtime-adoption-capture-helper.spec.md --min-score 0.7
- cargo test --test phase3_runtime test_cli_phase3_adoption_capture
- cargo test mcp::server::tests::test_mcp_phase3_capture_action_dry_run_and_execute --lib
- cargo fmt -- --check
- cargo check
- cargo check --features rest
- cargo clippy -- -D warnings
- cargo clippy --features rest -- -D warnings
- cargo test
- git diff --check
