### PR TITLE
feat: add evaluator advisory api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
+| `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -196,6 +197,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
+- `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 
 ### Spec 使用方式
 
@@ -231,7 +233,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
+| `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -194,6 +195,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
+- `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 
 ### Spec 使用方式
 
@@ -229,7 +231,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1447,8 +1447,13 @@ Future P candidates:
   `capture` surfaces that map `surface/outcome` observations into existing
   checked runtime adoption records. It is dry-run by default, writes only with
   explicit execute, and does not add background instrumentation.
-- P73 candidate: evaluator advisory API contract with replayable outputs and no
-  lifecycle authority.
+- P73 evaluator advisory API: implemented as deterministic CLI/MCP advice
+  surfaces through `mempal phase3 evaluator advise` and
+  `mempal_phase3 action=evaluator_advise`. Advice output is replayable from
+  request fields, returns `writes=false`, `lifecycle_authority=false`,
+  `deterministic_gate_required=true`, reasons, and a `surface=evaluator`
+  adoption capture plan. It cannot mutate lifecycle state, satisfy reviewer
+  requirements, bypass gates, or call LLM/network evaluators.
 - P74 candidate: card-context default-on proposal gated by accumulated P66
   readiness evidence plus rollback criteria.
 

--- a/docs/plans/2026-05-13-p73-evaluator-advisory-api.md
+++ b/docs/plans/2026-05-13-p73-evaluator-advisory-api.md
@@ -1,0 +1,40 @@
+# P73 Evaluator Advisory API
+
+Goal: add a deterministic, replayable evaluator advice surface that preserves
+the P50 advisory-only lifecycle boundary.
+
+Spec: `specs/p73-evaluator-advisory-api.spec.md`
+
+## Steps
+
+- [x] Add P73 task contract and plan.
+- [x] Add failing CLI tests for supportive advice, dao_tian human review,
+  weak/risky recommendations, and missing evaluator validation.
+- [x] Add failing MCP test for read-only `evaluator_advise`.
+- [x] Implement pure evaluator advice policy in `src/core/phase3.rs`.
+- [x] Wire CLI `mempal phase3 evaluator advise`.
+- [x] Wire MCP `mempal_phase3 action=evaluator_advise`.
+- [x] Update protocol/tool descriptions and inventories.
+- [x] Verify spec parse/lint, targeted tests, formatting, clippy, full tests,
+  and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p73-evaluator-advisory-api.spec.md
+agent-spec lint specs/p73-evaluator-advisory-api.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_supportive_read_only
+cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_dao_tian_requires_human_review
+cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_needs_evidence_and_blocks_risk
+cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_rejects_missing_evaluator
+cargo test mcp::server::tests::test_mcp_phase3_evaluator_advise_action_is_read_only --lib
+rg -n "p73-evaluator-advisory-api|P73 evaluator advisory API" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p73-evaluator-advisory-api.spec.md
+++ b/specs/p73-evaluator-advisory-api.spec.md
@@ -1,0 +1,120 @@
+spec: task
+name: "P73: evaluator advisory API"
+inherits: project
+tags: [phase-3, evaluator, self-evolution, advisory]
+---
+
+## Intent
+
+P50 fixed evaluator boundaries as advisory-only, and P58 added a read-only gate
+for deciding whether evaluator APIs are mature enough to implement. P73 adds the
+first evaluator advice surface with replayable deterministic output: agents can
+ask for an advisory lifecycle recommendation and receive reasons plus a runtime
+adoption capture plan, but no lifecycle state is mutated.
+
+## Decisions
+
+- P73 must leave its own `specs/p73-*.spec.md` and plan document.
+- Add CLI `mempal phase3 evaluator advise`.
+- Add MCP `mempal_phase3 action=evaluator_advise`.
+- Advice output must be deterministic from request fields and existing policy,
+  with no LLM calls, network calls, or hidden runtime state.
+- Advice output must include `writes=false`, `lifecycle_authority=false`,
+  `deterministic_gate_required=true`, recommendation, reasons, and an adoption
+  capture plan for `surface=evaluator`.
+- `dao_tian` canonicalization advice must always require human review.
+- Evidence-free advice must recommend more evidence instead of promotion.
+- Counterexamples or risk notes must block supportive recommendation.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p73-evaluator-advisory-api.spec.md
+- docs/plans/2026-05-13-p73-evaluator-advisory-api.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema migrations.
+- Do not write runtime adoption events from evaluator advice.
+- Do not mutate knowledge drawers, knowledge cards, lifecycle refs, or audit
+  events.
+- Do not satisfy reviewer requirements through evaluator output.
+- Do not bypass deterministic promotion/card gates.
+- Do not add evaluator scoring, LLM calls, or network calls.
+- Do not mark the overall self-evolution objective complete.
+
+## Acceptance Criteria
+
+Scenario: CLI evaluator advice is replayable and read-only
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_supportive_read_only
+    Targets: CLI evaluator advice behavior in `src/main.rs`.
+  Given evaluator `eval_policy` advises on a `dao_ren` promotion with two evidence refs
+  When running `mempal phase3 evaluator advise --evaluator-id eval_policy --subject-kind dao_ren --subject-id k1 --proposed-action promote --evidence-ref e1 --evidence-ref e2 --format json`
+  Then stdout contains `writes=false` and `lifecycle_authority=false`
+  And stdout contains `deterministic_gate_required=true`
+  And stdout recommends `advisory_support`
+  And no runtime adoption event is persisted
+  And this verifies the `src/main.rs` CLI entry point
+
+Scenario: CLI evaluator advice requires human review for dao_tian canonicalization
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_dao_tian_requires_human_review
+    Targets: CLI evaluator human-review policy.
+  Given evaluator advice for `dao_tian` `canonical`
+  When running evaluator advice with supporting evidence
+  Then stdout contains `requires_human_review=true`
+  And reasons mention `dao_tian canonicalization requires human review`
+
+Scenario: CLI evaluator advice rejects weak or risky recommendations
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_needs_evidence_and_blocks_risk
+    Targets: CLI evaluator evidence/risk policy.
+  Given evaluator advice without evidence refs
+  When running evaluator advice
+  Then recommendation is `needs_evidence`
+  Given evaluator advice with a risk note or counterexample ref
+  When running evaluator advice
+  Then recommendation is `do_not_promote`
+
+Scenario: MCP evaluator advice mirrors CLI read-only contract
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_evaluator_advise_action_is_read_only --lib
+    Targets: MCP evaluator advice action in `src/mcp/server.rs`.
+  Given `mempal_phase3 action=evaluator_advise`
+  When called with evaluator id, subject, proposed action, and evidence refs
+  Then the response contains the same advisory fields
+  And no runtime adoption event is persisted
+  And this verifies the `src/mcp/server.rs` MCP entry point
+
+Scenario: Evaluator advice validates required fields
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_rejects_missing_evaluator
+    Targets: CLI evaluator input validation in `src/main.rs`.
+  Given a request without evaluator id
+  When running evaluator advice
+  Then the command fails
+  And stderr mentions `evaluator-id is required`
+
+Scenario: Inventories include P73
+  Test:
+    Filter: rg -n "p73-evaluator-advisory-api|P73 evaluator advisory API" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Agent inventories and design document.
+  Given project documentation
+  When searching for P73
+  Then the spec, plan, and design status are recorded
+
+## Out of Scope
+
+- Evaluator-driven promotion or demotion.
+- Automatic evaluator invocation.
+- Evaluator scoring or model integration.
+- New persistence tables.
+- Default-on card context.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -70,6 +70,36 @@ pub struct RuntimeAdoptionCaptureReport {
     pub record_checked: Option<RuntimeAdoptionCheckedRecordReport>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvaluatorAdviceInput {
+    pub evaluator_id: String,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub proposed_action: String,
+    pub evidence_refs: Vec<String>,
+    pub counterexample_refs: Vec<String>,
+    pub risk_notes: Vec<String>,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct EvaluatorAdviceReport {
+    pub writes: bool,
+    pub evaluator_id: String,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub proposed_action: String,
+    pub recommendation: String,
+    pub lifecycle_authority: bool,
+    pub deterministic_gate_required: bool,
+    pub requires_human_review: bool,
+    pub evidence_refs: Vec<String>,
+    pub counterexample_refs: Vec<String>,
+    pub risk_notes: Vec<String>,
+    pub reasons: Vec<String>,
+    pub adoption_capture: RuntimeAdoptionRecordPlan,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
@@ -369,6 +399,92 @@ pub fn prepare_runtime_adoption_capture(
     }
 }
 
+pub fn evaluator_advice(input: EvaluatorAdviceInput) -> Result<EvaluatorAdviceReport, String> {
+    if is_blank(&input.evaluator_id) {
+        return Err("evaluator-id is required".to_string());
+    }
+    if is_blank(&input.subject_kind) {
+        return Err("subject-kind is required".to_string());
+    }
+    if is_blank(&input.subject_id) {
+        return Err("subject-id is required".to_string());
+    }
+    if is_blank(&input.proposed_action) {
+        return Err("proposed-action is required".to_string());
+    }
+
+    let evidence_refs = normalize_non_empty(input.evidence_refs);
+    let counterexample_refs = normalize_non_empty(input.counterexample_refs);
+    let risk_notes = normalize_non_empty(input.risk_notes);
+    let subject_kind = input.subject_kind.trim().to_string();
+    let proposed_action = input.proposed_action.trim().to_string();
+    let requires_human_review = subject_kind == "dao_tian" && proposed_action.contains("canonical");
+
+    let mut reasons = Vec::new();
+    reasons.push("evaluator output is advisory-only and has no lifecycle authority".to_string());
+    reasons
+        .push("deterministic promotion gates remain required before lifecycle changes".to_string());
+    if requires_human_review {
+        reasons.push("dao_tian canonicalization requires human review".to_string());
+    }
+
+    let recommendation = if !counterexample_refs.is_empty() || !risk_notes.is_empty() {
+        reasons
+            .push("counterexample refs or risk notes block supportive recommendation".to_string());
+        "do_not_promote"
+    } else if evidence_refs.is_empty() {
+        reasons.push("supporting evidence refs are required before promotion advice".to_string());
+        "needs_evidence"
+    } else if requires_human_review {
+        "requires_human_review"
+    } else {
+        reasons.push(
+            "supporting evidence refs are present and no risk blockers were supplied".to_string(),
+        );
+        "advisory_support"
+    }
+    .to_string();
+
+    let adoption_capture = prepare_runtime_adoption_record(RuntimeAdoptionRecordPlanInput {
+        id: None,
+        track: "evaluator".to_string(),
+        signal: "used".to_string(),
+        feature: "advisory_gate".to_string(),
+        query: Some(format!(
+            "{subject_kind}:{} {proposed_action}",
+            input.subject_id.trim()
+        )),
+        context_hash: None,
+        card_id: None,
+        evaluator_id: Some(input.evaluator_id.trim().to_string()),
+        research_report_id: None,
+        note: input.note,
+        metadata: Some(evaluator_advice_metadata(
+            &subject_kind,
+            input.subject_id.trim(),
+            &proposed_action,
+            &recommendation,
+        )),
+    });
+
+    Ok(EvaluatorAdviceReport {
+        writes: false,
+        evaluator_id: input.evaluator_id.trim().to_string(),
+        subject_kind,
+        subject_id: input.subject_id.trim().to_string(),
+        proposed_action,
+        recommendation,
+        lifecycle_authority: false,
+        deterministic_gate_required: true,
+        requires_human_review,
+        evidence_refs,
+        counterexample_refs,
+        risk_notes,
+        reasons,
+        adoption_capture,
+    })
+}
+
 pub fn check_runtime_adoption_record(
     input: &RuntimeAdoptionRecordPlanInput,
 ) -> RuntimeAdoptionRecordQualityReport {
@@ -419,6 +535,40 @@ pub fn check_runtime_adoption_record(
         errors,
         warnings,
     }
+}
+
+fn normalize_non_empty(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn evaluator_advice_metadata(
+    subject_kind: &str,
+    subject_id: &str,
+    proposed_action: &str,
+    recommendation: &str,
+) -> Value {
+    let mut metadata = Map::new();
+    metadata.insert(
+        "subject_kind".to_string(),
+        Value::String(subject_kind.to_string()),
+    );
+    metadata.insert(
+        "subject_id".to_string(),
+        Value::String(subject_id.to_string()),
+    );
+    metadata.insert(
+        "proposed_action".to_string(),
+        Value::String(proposed_action.to_string()),
+    );
+    metadata.insert(
+        "recommendation".to_string(),
+        Value::String(recommendation.to_string()),
+    );
+    Value::Object(metadata)
 }
 
 fn capture_surface_mapping(surface: &str) -> Result<(String, String), String> {

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
@@ -221,7 +221,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    action=capture when you have a concrete runtime outcome but do not want to
    manually choose track/signal/feature: capture maps surface/outcome to the
    checked-record path, is read-only by default, and writes only with
-   execute=true. Use
+   execute=true. Use action=evaluator_advise for deterministic evaluator advice:
+   it returns replayable advisory output and a surface=evaluator capture plan,
+   but writes=false, has no lifecycle authority, cannot satisfy reviewer
+   requirements, and cannot bypass gates. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,
@@ -251,7 +254,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,15 +17,15 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCaptureInput,
-        RuntimeAdoptionCaptureReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
-        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
-        RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
-        capture_runtime_adoption_record_input, card_context_default_readiness,
-        check_runtime_adoption_record, prepare_runtime_adoption_capture,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
-        should_write_checked_record,
+        EvaluatorAdviceInput, EvaluatorAdviceReport, Phase3ReadinessReport,
+        ResearchIngestPlanReport, RuntimeAdoptionCaptureInput, RuntimeAdoptionCaptureReport,
+        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
+        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
+        build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
+        card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
+        prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -575,6 +575,10 @@ enum Phase3Commands {
         #[command(subcommand)]
         command: Phase3AdoptionCommands,
     },
+    Evaluator {
+        #[command(subcommand)]
+        command: Phase3EvaluatorCommands,
+    },
     Gate {
         candidate: String,
         #[arg(long, default_value = "plain")]
@@ -594,6 +598,30 @@ enum Phase3Commands {
         path: PathBuf,
         #[arg(long)]
         execute: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum Phase3EvaluatorCommands {
+    Advise {
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "subject-kind")]
+        subject_kind: String,
+        #[arg(long = "subject-id")]
+        subject_id: String,
+        #[arg(long = "proposed-action")]
+        proposed_action: String,
+        #[arg(long = "evidence-ref")]
+        evidence_refs: Vec<String>,
+        #[arg(long = "counterexample-ref")]
+        counterexample_refs: Vec<String>,
+        #[arg(long = "risk-note")]
+        risk_notes: Vec<String>,
+        #[arg(long)]
+        note: Option<String>,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2317,6 +2345,7 @@ async fn knowledge_card_command(
 async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands) -> Result<()> {
     match command {
         Phase3Commands::Adoption { command } => phase3_adoption_command(db, command),
+        Phase3Commands::Evaluator { command } => phase3_evaluator_command(command),
         Phase3Commands::Gate { candidate, format } => {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
@@ -2334,6 +2363,35 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
             execute,
             format,
         } => research_ingest_plan_command(db, config, &path, execute, &format).await,
+    }
+}
+
+fn phase3_evaluator_command(command: Phase3EvaluatorCommands) -> Result<()> {
+    match command {
+        Phase3EvaluatorCommands::Advise {
+            evaluator_id,
+            subject_kind,
+            subject_id,
+            proposed_action,
+            evidence_refs,
+            counterexample_refs,
+            risk_notes,
+            note,
+            format,
+        } => {
+            let report = evaluator_advice(EvaluatorAdviceInput {
+                evaluator_id: evaluator_id.unwrap_or_default(),
+                subject_kind,
+                subject_id,
+                proposed_action,
+                evidence_refs,
+                counterexample_refs,
+                risk_notes,
+                note,
+            })
+            .map_err(anyhow::Error::msg)?;
+            print_evaluator_advice(&report, &format)
+        }
     }
 }
 
@@ -3307,6 +3365,38 @@ fn print_phase3_readiness_report(report: &Phase3ReadinessReport, format: &str) -
             Ok(())
         }
         other => bail!("unsupported phase3 readiness format: {other}"),
+    }
+}
+
+fn print_evaluator_advice(report: &EvaluatorAdviceReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("evaluator_id={}", report.evaluator_id);
+            println!("subject_kind={}", report.subject_kind);
+            println!("subject_id={}", report.subject_id);
+            println!("proposed_action={}", report.proposed_action);
+            println!("recommendation={}", report.recommendation);
+            println!("lifecycle_authority={}", report.lifecycle_authority);
+            println!(
+                "deterministic_gate_required={}",
+                report.deterministic_gate_required
+            );
+            println!("requires_human_review={}", report.requires_human_review);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize evaluator advice")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 evaluator format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,10 +6,10 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
+        EvaluatorAdviceInput, RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
         build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
-        card_context_default_readiness, check_runtime_adoption_record,
+        card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
         prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
         review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
     },
@@ -1349,7 +1349,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1372,6 +1372,7 @@ impl MempalMcpServer {
                 gate: None,
                 research_plan: None,
                 research_ingest_plan: None,
+                evaluator_advice: None,
             })),
             "prepare_record" => {
                 let track = parse_runtime_adoption_track(required_string(
@@ -1409,6 +1410,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "capture" => {
@@ -1490,6 +1492,42 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
+                }))
+            }
+            "evaluator_advise" => {
+                let report = evaluator_advice(EvaluatorAdviceInput {
+                    evaluator_id: required_string(request.evaluator_id.as_deref(), "evaluator_id")?
+                        .to_string(),
+                    subject_kind: required_string(request.subject_kind.as_deref(), "subject_kind")?
+                        .to_string(),
+                    subject_id: required_string(request.subject_id.as_deref(), "subject_id")?
+                        .to_string(),
+                    proposed_action: required_string(
+                        request.proposed_action.as_deref(),
+                        "proposed_action",
+                    )?
+                    .to_string(),
+                    evidence_refs: request.evidence_refs.unwrap_or_default(),
+                    counterexample_refs: request.counterexample_refs.unwrap_or_default(),
+                    risk_notes: request.risk_notes.unwrap_or_default(),
+                    note: trim_to_owned(request.note.as_deref()),
+                })
+                .map_err(|error| ErrorData::invalid_params(error, None))?;
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                    evaluator_advice: Some(report.into()),
                 }))
             }
             "check_record" => {
@@ -1528,6 +1566,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "record_checked" => {
@@ -1605,6 +1644,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "review" => {
@@ -1659,6 +1699,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "readiness" => {
@@ -1702,6 +1743,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "record" => {
@@ -1750,6 +1792,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "list" => {
@@ -1784,6 +1827,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "stats" => {
@@ -1815,6 +1859,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "gate" => {
@@ -1834,6 +1879,7 @@ impl MempalMcpServer {
                     gate: Some(gate),
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "research_validate_plan" => {
@@ -1853,6 +1899,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: Some(validate_research_adapter_plan_value(&report)),
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "research_ingest_plan" => {
@@ -1874,11 +1921,12 @@ impl MempalMcpServer {
                     research_ingest_plan: Some(ResearchIngestPlanDto::from(
                         build_research_ingest_plan_from_value(&report),
                     )),
+                    evaluator_advice: None,
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, evaluator_advise, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4199,7 +4247,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, capture, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, prepare_record, capture, evaluator_advise, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4418,6 +4466,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_phase3_evaluator_advise_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "evaluator_advise",
+                "evaluator_id": "eval_policy",
+                "subject_kind": "dao_ren",
+                "subject_id": "k1",
+                "proposed_action": "promote",
+                "evidence_refs": ["e1", "e2"]
+            }))
+            .await
+            .expect("evaluator advice");
+        let advice = response.evaluator_advice.expect("evaluator advice");
+        assert!(!advice.writes);
+        assert!(!advice.lifecycle_authority);
+        assert!(advice.deterministic_gate_required);
+        assert_eq!(advice.recommendation, "advisory_support");
+        assert_eq!(advice.adoption_capture.record_payload["track"], "evaluator");
+
+        let db = Database::open(&db_path).expect("open db");
+        assert!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_phase3_record_checked_quality_gated() {
         let (_tempdir, db_path, server) = setup_server();
 
@@ -4577,12 +4655,13 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -318,6 +318,12 @@ pub struct Phase3Request {
     pub id: Option<String>,
     pub surface: Option<String>,
     pub outcome: Option<String>,
+    pub subject_kind: Option<String>,
+    pub subject_id: Option<String>,
+    pub proposed_action: Option<String>,
+    pub evidence_refs: Option<Vec<String>>,
+    pub counterexample_refs: Option<Vec<String>>,
+    pub risk_notes: Option<Vec<String>>,
     pub track: Option<String>,
     pub signal: Option<String>,
     pub feature: Option<String>,
@@ -361,6 +367,8 @@ pub struct Phase3Response {
     pub research_plan: Option<ResearchAdapterPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub research_ingest_plan: Option<ResearchIngestPlanDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evaluator_advice: Option<EvaluatorAdviceDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -457,6 +465,45 @@ pub struct Phase3ReadinessReportDto {
     pub required_feature: String,
     pub review: RuntimeAdoptionReviewReportDto,
     pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct EvaluatorAdviceDto {
+    pub writes: bool,
+    pub evaluator_id: String,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub proposed_action: String,
+    pub recommendation: String,
+    pub lifecycle_authority: bool,
+    pub deterministic_gate_required: bool,
+    pub requires_human_review: bool,
+    pub evidence_refs: Vec<String>,
+    pub counterexample_refs: Vec<String>,
+    pub risk_notes: Vec<String>,
+    pub reasons: Vec<String>,
+    pub adoption_capture: RuntimeAdoptionRecordPlanDto,
+}
+
+impl From<crate::core::phase3::EvaluatorAdviceReport> for EvaluatorAdviceDto {
+    fn from(report: crate::core::phase3::EvaluatorAdviceReport) -> Self {
+        Self {
+            writes: report.writes,
+            evaluator_id: report.evaluator_id,
+            subject_kind: report.subject_kind,
+            subject_id: report.subject_id,
+            proposed_action: report.proposed_action,
+            recommendation: report.recommendation,
+            lifecycle_authority: report.lifecycle_authority,
+            deterministic_gate_required: report.deterministic_gate_required,
+            requires_human_review: report.requires_human_review,
+            evidence_refs: report.evidence_refs,
+            counterexample_refs: report.counterexample_refs,
+            risk_notes: report.risk_notes,
+            reasons: report.reasons,
+            adoption_capture: report.adoption_capture.into(),
+        }
+    }
 }
 
 impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -1141,6 +1141,180 @@ fn test_cli_phase3_evaluator_gate_exists_and_is_read_only() {
 }
 
 #[test]
+fn test_cli_phase3_evaluator_advise_supportive_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--evaluator-id",
+            "eval_policy",
+            "--subject-kind",
+            "dao_ren",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "promote",
+            "--evidence-ref",
+            "e1",
+            "--evidence-ref",
+            "e2",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "advise failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("advice json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["lifecycle_authority"], false);
+    assert_eq!(report["deterministic_gate_required"], true);
+    assert_eq!(report["recommendation"], "advisory_support");
+    assert_eq!(
+        report["adoption_capture"]["record_payload"]["track"],
+        "evaluator"
+    );
+    assert_eq!(
+        report["adoption_capture"]["record_payload"]["feature"],
+        "advisory_gate"
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_evaluator_advise_dao_tian_requires_human_review() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--evaluator-id",
+            "eval_policy",
+            "--subject-kind",
+            "dao_tian",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "canonical",
+            "--evidence-ref",
+            "e1",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "advise failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("advice json");
+    assert_eq!(report["requires_human_review"], true);
+    assert_eq!(report["recommendation"], "requires_human_review");
+    let reasons = report["reasons"].as_array().expect("reasons");
+    assert!(reasons.iter().any(|reason| {
+        reason
+            .as_str()
+            .is_some_and(|value| value.contains("dao_tian canonicalization requires human review"))
+    }));
+}
+
+#[test]
+fn test_cli_phase3_evaluator_advise_needs_evidence_and_blocks_risk() {
+    let home = setup_cli_home();
+    let weak = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--evaluator-id",
+            "eval_policy",
+            "--subject-kind",
+            "dao_ren",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "promote",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        weak.status.success(),
+        "weak advise failed: {}",
+        String::from_utf8_lossy(&weak.stderr)
+    );
+    let weak_report: Value = serde_json::from_slice(&weak.stdout).expect("weak advice json");
+    assert_eq!(weak_report["recommendation"], "needs_evidence");
+
+    let risky = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--evaluator-id",
+            "eval_policy",
+            "--subject-kind",
+            "dao_ren",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "promote",
+            "--evidence-ref",
+            "e1",
+            "--counterexample-ref",
+            "c1",
+            "--risk-note",
+            "contradiction risk",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        risky.status.success(),
+        "risky advise failed: {}",
+        String::from_utf8_lossy(&risky.stderr)
+    );
+    let risky_report: Value = serde_json::from_slice(&risky.stdout).expect("risky advice json");
+    assert_eq!(risky_report["recommendation"], "do_not_promote");
+}
+
+#[test]
+fn test_cli_phase3_evaluator_advise_rejects_missing_evaluator() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--subject-kind",
+            "dao_ren",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "promote",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("evaluator-id is required"));
+}
+
+#[test]
 fn test_cli_phase3_adoption_record_rejects_invalid_track() {
     let home = setup_cli_home();
     let output = run_mempal(


### PR DESCRIPTION
## Summary

- Add P73 spec and plan for evaluator advisory API.
- Add deterministic CLI `mempal phase3 evaluator advise`.
- Add MCP `mempal_phase3 action=evaluator_advise`.
- Return replayable advisory output with no lifecycle authority and a runtime adoption capture plan.
- Preserve P50 boundaries: no lifecycle mutation, no reviewer bypass, no evaluator scoring/LLM/network calls.

## Verification

- `agent-spec parse specs/p73-evaluator-advisory-api.spec.md`
- `agent-spec lint specs/p73-evaluator-advisory-api.spec.md --min-score 0.7`
- `cargo test --test phase3_runtime test_cli_phase3_evaluator_advise -- --nocapture`
- `cargo test mcp::server::tests::test_mcp_phase3_evaluator_advise_action_is_read_only --lib -- --nocapture`
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy -- -D warnings`
- `cargo clippy --features rest -- -D warnings`
- `cargo test`
- `git diff --check`
