### PR TITLE
feat: add card context default proposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
+| `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -198,6 +199,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
+- `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 
 ### Spec 使用方式
 
@@ -233,7 +235,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
+| `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -196,6 +197,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
+- `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 
 ### Spec 使用方式
 
@@ -231,7 +233,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1454,8 +1454,14 @@ Future P candidates:
   `deterministic_gate_required=true`, reasons, and a `surface=evaluator`
   adoption capture plan. It cannot mutate lifecycle state, satisfy reviewer
   requirements, bypass gates, or call LLM/network evaluators.
-- P74 candidate: card-context default-on proposal gated by accumulated P66
-  readiness evidence plus rollback criteria.
+- P74 card context default-on proposal: implemented as read-only CLI/MCP
+  proposal surfaces through `mempal phase3 default-proposal card-context` and
+  `mempal_phase3 action=default_proposal`. The proposal embeds P66 readiness,
+  requires explicit rollback criteria, returns `writes=false`, and only marks
+  `proposal_ready=true` when both readiness and rollback criteria are present.
+  It deliberately keeps `mempal context` / `mempal_context` default
+  `include_cards=false`; any actual default change still requires a future
+  explicit spec.
 
 ## Closing Summary
 

--- a/docs/plans/2026-05-13-p74-card-context-default-proposal.md
+++ b/docs/plans/2026-05-13-p74-card-context-default-proposal.md
@@ -1,0 +1,42 @@
+# P74 Card Context Default-On Proposal
+
+Goal: add a read-only proposal artifact for card-context default-on readiness
+that combines P66 readiness with explicit rollback criteria while keeping
+`include_cards` opt-in.
+
+Spec: `specs/p74-card-context-default-proposal.spec.md`
+
+## Steps
+
+- [x] Add P74 task contract and plan.
+- [x] Add failing CLI tests for ready proposal, missing rollback criteria,
+  missing readiness, context default unchanged, and unknown candidate.
+- [x] Add failing MCP test for read-only `default_proposal`.
+- [x] Implement pure default proposal policy in `src/core/phase3.rs`.
+- [x] Wire CLI `mempal phase3 default-proposal card-context`.
+- [x] Wire MCP `mempal_phase3 action=default_proposal`.
+- [x] Update protocol/tool descriptions and inventories.
+- [x] Verify spec parse/lint, targeted tests, formatting, clippy, full tests,
+  and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p74-card-context-default-proposal.spec.md
+agent-spec lint specs/p74-card-context-default-proposal.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_card_context_ready
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_requires_rollback_criteria
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_blocks_without_readiness
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_keeps_context_cards_opt_in
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_rejects_unknown_candidate
+cargo test mcp::server::tests::test_mcp_phase3_default_proposal_card_context_is_read_only --lib
+rg -n "p74-card-context-default-proposal|P74 card context default-on proposal" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p74-card-context-default-proposal.spec.md
+++ b/specs/p74-card-context-default-proposal.spec.md
@@ -1,0 +1,127 @@
+spec: task
+name: "P74: card context default-on proposal"
+inherits: project
+tags: [phase-3, self-evolution, card-context, default-policy]
+---
+
+## Intent
+
+P66 can report whether card-aware context is ready for a future default-on spec,
+but it does not produce a complete proposal artifact. P74 adds a read-only
+default-on proposal surface for card context that combines P66 readiness evidence
+with explicit rollback criteria while preserving the current `include_cards`
+opt-in runtime default.
+
+## Decisions
+
+- P74 must leave its own `specs/p74-*.spec.md` and plan document.
+- Add CLI `mempal phase3 default-proposal card-context`.
+- Add MCP `mempal_phase3 action=default_proposal` with `candidate=card-context`.
+- The proposal reuses P66 `card_context_default_readiness`.
+- The proposal requires at least one explicit rollback criterion before it can
+  be marked `proposal_ready=true`.
+- The proposal output must include `writes=false`, `candidate`,
+  `proposal_ready`, `decision`, embedded readiness, rollback criteria, and
+  reasons.
+- P74 must not change `mempal context` or `mempal_context` default
+  `include_cards=false`.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p74-card-context-default-proposal.spec.md
+- docs/plans/2026-05-13-p74-card-context-default-proposal.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema migrations.
+- Do not change `mempal context` default `include_cards=false`.
+- Do not change `mempal_context` default `include_cards=false`.
+- Do not write runtime adoption events.
+- Do not mutate knowledge cards or knowledge lifecycle state.
+- Do not enable card embeddings.
+- Do not mark the overall self-evolution objective complete.
+
+## Acceptance Criteria
+
+Scenario: CLI proposal is ready when readiness and rollback criteria are satisfied
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_card_context_ready
+    Targets: CLI default proposal behavior in `src/main.rs`.
+  Given three accepted `card_context/include_cards` adoption events
+  And rollback criterion is `rollback on contradiction or user-visible degradation`
+  When running `mempal phase3 default-proposal card-context --rollback-criterion "rollback on contradiction or user-visible degradation" --format json`
+  Then stdout contains `writes=false`
+  And stdout contains `proposal_ready=true`
+  And stdout contains decision `eligible_for_default_on_spec`
+  And no runtime adoption event is persisted by the proposal command
+  And this verifies the `src/main.rs` CLI entry point
+
+Scenario: CLI proposal blocks without rollback criteria
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_requires_rollback_criteria
+    Targets: CLI rollback-criteria gate.
+  Given readiness evidence is satisfied
+  When running default proposal without `--rollback-criterion`
+  Then stdout contains `proposal_ready=false`
+  And reasons mention `rollback criteria are required`
+
+Scenario: CLI proposal blocks when readiness is not satisfied
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_blocks_without_readiness
+    Targets: CLI readiness gate.
+  Given no `card_context/include_cards` adoption evidence
+  When running default proposal with rollback criteria
+  Then stdout contains `proposal_ready=false`
+  And embedded readiness has `ready=false`
+
+Scenario: CLI proposal does not change context default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_keeps_context_cards_opt_in
+    Targets: Runtime context default behavior.
+  Given a promoted active card exists
+  And a ready default proposal is generated
+  And query is `card-aware`
+  When running `mempal context "card-aware" --format json` without `--include-cards`
+  Then the context output omits card items
+
+Scenario: MCP proposal mirrors CLI read-only contract
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_default_proposal_card_context_is_read_only --lib
+    Targets: MCP default proposal action in `src/mcp/server.rs`.
+  Given `mempal_phase3 action=default_proposal` and `candidate=card-context`
+  When called with rollback criteria
+  Then the response contains a default proposal report
+  And no runtime adoption event is persisted by the action
+  And this verifies the `src/mcp/server.rs` MCP entry point
+
+Scenario: Default proposal rejects unknown candidate
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_rejects_unknown_candidate
+    Targets: CLI default proposal input validation.
+  Given an unsupported default proposal candidate
+  When running default proposal
+  Then the command fails
+  And stderr mentions `unsupported phase3 default proposal candidate`
+
+Scenario: Inventories include P74
+  Test:
+    Filter: rg -n "p74-card-context-default-proposal|P74 card context default-on proposal" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Agent inventories and design document.
+  Given project documentation
+  When searching for P74
+  Then the spec, plan, and design status are recorded
+
+## Out of Scope
+
+- Actually changing `include_cards` defaults.
+- Card embeddings.
+- Automatic rollback executor.
+- New database tables.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -101,6 +101,17 @@ pub struct EvaluatorAdviceReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CardContextDefaultProposalReport {
+    pub writes: bool,
+    pub candidate: String,
+    pub proposal_ready: bool,
+    pub decision: String,
+    pub readiness: Phase3ReadinessReport,
+    pub rollback_criteria: Vec<String>,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
     pub feature: Option<String>,
@@ -483,6 +494,44 @@ pub fn evaluator_advice(input: EvaluatorAdviceInput) -> Result<EvaluatorAdviceRe
         reasons,
         adoption_capture,
     })
+}
+
+pub fn card_context_default_proposal(
+    events: &[RuntimeAdoptionEvent],
+    rollback_criteria: Vec<String>,
+) -> CardContextDefaultProposalReport {
+    let readiness = card_context_default_readiness(events);
+    let rollback_criteria = normalize_non_empty(rollback_criteria);
+    let mut reasons = Vec::new();
+    if readiness.ready {
+        reasons.push("card context default readiness threshold satisfied".to_string());
+    } else {
+        reasons.push("card context default readiness threshold not satisfied".to_string());
+    }
+    if rollback_criteria.is_empty() {
+        reasons.push("rollback criteria are required before default-on proposal".to_string());
+    } else {
+        reasons.push("explicit rollback criteria are present".to_string());
+    }
+    let proposal_ready = readiness.ready && !rollback_criteria.is_empty();
+    if proposal_ready {
+        reasons.push("proposal is eligible for a future default-on spec".to_string());
+    }
+
+    CardContextDefaultProposalReport {
+        writes: false,
+        candidate: "card-context".to_string(),
+        proposal_ready,
+        decision: if proposal_ready {
+            "eligible_for_default_on_spec"
+        } else {
+            "keep_opt_in"
+        }
+        .to_string(),
+        readiness,
+        rollback_criteria,
+        reasons,
+    }
 }
 
 pub fn check_runtime_adoption_record(

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
@@ -224,7 +224,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    execute=true. Use action=evaluator_advise for deterministic evaluator advice:
    it returns replayable advisory output and a surface=evaluator capture plan,
    but writes=false, has no lifecycle authority, cannot satisfy reviewer
-   requirements, and cannot bypass gates. Use
+   requirements, and cannot bypass gates. Use action=default_proposal with
+   candidate=card-context to combine card-context readiness with explicit
+   rollback criteria before writing a future default-on spec; it is read-only
+   and does not change include_cards defaults. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,
@@ -254,7 +257,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,13 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        EvaluatorAdviceInput, EvaluatorAdviceReport, Phase3ReadinessReport,
-        ResearchIngestPlanReport, RuntimeAdoptionCaptureInput, RuntimeAdoptionCaptureReport,
-        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
-        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
-        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
-        build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
+        CardContextDefaultProposalReport, EvaluatorAdviceInput, EvaluatorAdviceReport,
+        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCaptureInput,
+        RuntimeAdoptionCaptureReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
+        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
+        RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
+        capture_runtime_adoption_record_input, card_context_default_proposal,
         card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
         prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
         review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
@@ -578,6 +579,13 @@ enum Phase3Commands {
     Evaluator {
         #[command(subcommand)]
         command: Phase3EvaluatorCommands,
+    },
+    DefaultProposal {
+        candidate: String,
+        #[arg(long = "rollback-criterion")]
+        rollback_criteria: Vec<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
     },
     Gate {
         candidate: String,
@@ -2346,6 +2354,14 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
     match command {
         Phase3Commands::Adoption { command } => phase3_adoption_command(db, command),
         Phase3Commands::Evaluator { command } => phase3_evaluator_command(command),
+        Phase3Commands::DefaultProposal {
+            candidate,
+            rollback_criteria,
+            format,
+        } => {
+            let report = phase3_default_proposal(db, &candidate, rollback_criteria)?;
+            print_card_context_default_proposal(&report, &format)
+        }
         Phase3Commands::Gate { candidate, format } => {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
@@ -2363,6 +2379,28 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
             execute,
             format,
         } => research_ingest_plan_command(db, config, &path, execute, &format).await,
+    }
+}
+
+fn phase3_default_proposal(
+    db: &Database,
+    candidate: &str,
+    rollback_criteria: Vec<String>,
+) -> Result<CardContextDefaultProposalReport> {
+    match candidate {
+        "card-context" => {
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: Some(RuntimeAdoptionTrack::CardContext),
+                        feature: Some("include_cards".to_string()),
+                    },
+                    10_000,
+                )
+                .context("failed to list runtime adoption events")?;
+            Ok(card_context_default_proposal(&events, rollback_criteria))
+        }
+        other => bail!("unsupported phase3 default proposal candidate: {other}"),
     }
 }
 
@@ -3397,6 +3435,37 @@ fn print_evaluator_advice(report: &EvaluatorAdviceReport, format: &str) -> Resul
             Ok(())
         }
         other => bail!("unsupported phase3 evaluator format: {other}"),
+    }
+}
+
+fn print_card_context_default_proposal(
+    report: &CardContextDefaultProposalReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("candidate={}", report.candidate);
+            println!("proposal_ready={}", report.proposal_ready);
+            println!("decision={}", report.decision);
+            println!("readiness_ready={}", report.readiness.ready);
+            for criterion in &report.rollback_criteria {
+                println!("rollback_criterion={criterion}");
+            }
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize card context default proposal")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 default proposal format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,9 +9,10 @@ use crate::core::{
         EvaluatorAdviceInput, RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
         build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
-        card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
-        prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
+        card_context_default_proposal, card_context_default_readiness,
+        check_runtime_adoption_record, evaluator_advice, prepare_runtime_adoption_capture,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        should_write_checked_record,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1349,7 +1350,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1373,6 +1374,7 @@ impl MempalMcpServer {
                 research_plan: None,
                 research_ingest_plan: None,
                 evaluator_advice: None,
+                default_proposal: None,
             })),
             "prepare_record" => {
                 let track = parse_runtime_adoption_track(required_string(
@@ -1411,6 +1413,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "capture" => {
@@ -1493,6 +1496,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "evaluator_advise" => {
@@ -1528,6 +1532,55 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: Some(report.into()),
+                    default_proposal: None,
+                }))
+            }
+            "default_proposal" => {
+                let candidate = required_string(request.candidate.as_deref(), "candidate")?;
+                let report = match candidate {
+                    "card-context" => {
+                        let db = self.open_db()?;
+                        let events = db
+                            .list_runtime_adoption_events(
+                                &RuntimeAdoptionFilter {
+                                    track: Some(RuntimeAdoptionTrack::CardContext),
+                                    feature: Some("include_cards".to_string()),
+                                },
+                                10_000,
+                            )
+                            .map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("failed to list runtime adoption events: {error}"),
+                                    None,
+                                )
+                            })?;
+                        card_context_default_proposal(
+                            &events,
+                            request.rollback_criteria.unwrap_or_default(),
+                        )
+                    }
+                    other => {
+                        return Err(ErrorData::invalid_params(
+                            format!("unsupported phase3 default proposal candidate: {other}"),
+                            None,
+                        ));
+                    }
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                    evaluator_advice: None,
+                    default_proposal: Some(report.into()),
                 }))
             }
             "check_record" => {
@@ -1567,6 +1620,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "record_checked" => {
@@ -1645,6 +1699,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "review" => {
@@ -1700,6 +1755,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "readiness" => {
@@ -1744,6 +1800,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "record" => {
@@ -1793,6 +1850,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "list" => {
@@ -1828,6 +1886,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "stats" => {
@@ -1860,6 +1919,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "gate" => {
@@ -1880,6 +1940,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "research_validate_plan" => {
@@ -1900,6 +1961,7 @@ impl MempalMcpServer {
                     research_plan: Some(validate_research_adapter_plan_value(&report)),
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "research_ingest_plan" => {
@@ -1922,11 +1984,12 @@ impl MempalMcpServer {
                         build_research_ingest_plan_from_value(&report),
                     )),
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, evaluator_advise, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4247,7 +4310,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, capture, evaluator_advise, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4644,6 +4707,56 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_default_proposal_card_context_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            for i in 0..3 {
+                db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                    id: format!("default_proposal_event_{i}"),
+                    track: RuntimeAdoptionTrack::CardContext,
+                    signal: RuntimeAdoptionSignal::Accepted,
+                    feature: "include_cards".to_string(),
+                    query: Some("skill trigger".to_string()),
+                    context_hash: None,
+                    card_id: None,
+                    evaluator_id: None,
+                    research_report_id: None,
+                    note: Some("helped".to_string()),
+                    metadata: None,
+                    created_at: "1777710000".to_string(),
+                })
+                .expect("insert event");
+            }
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "default_proposal",
+                "candidate": "card-context",
+                "rollback_criteria": ["rollback on contradiction or user-visible degradation"]
+            }))
+            .await
+            .expect("default proposal");
+        let report = response.default_proposal.expect("default proposal");
+        assert!(!report.writes);
+        assert!(report.proposal_ready);
+        assert_eq!(report.decision, "eligible_for_default_on_spec");
+        assert!(report.readiness.ready);
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -4655,13 +4768,14 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=default_proposal"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -324,6 +324,7 @@ pub struct Phase3Request {
     pub evidence_refs: Option<Vec<String>>,
     pub counterexample_refs: Option<Vec<String>>,
     pub risk_notes: Option<Vec<String>>,
+    pub rollback_criteria: Option<Vec<String>>,
     pub track: Option<String>,
     pub signal: Option<String>,
     pub feature: Option<String>,
@@ -369,6 +370,8 @@ pub struct Phase3Response {
     pub research_ingest_plan: Option<ResearchIngestPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evaluator_advice: Option<EvaluatorAdviceDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_proposal: Option<CardContextDefaultProposalDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -483,6 +486,31 @@ pub struct EvaluatorAdviceDto {
     pub risk_notes: Vec<String>,
     pub reasons: Vec<String>,
     pub adoption_capture: RuntimeAdoptionRecordPlanDto,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CardContextDefaultProposalDto {
+    pub writes: bool,
+    pub candidate: String,
+    pub proposal_ready: bool,
+    pub decision: String,
+    pub readiness: Phase3ReadinessReportDto,
+    pub rollback_criteria: Vec<String>,
+    pub reasons: Vec<String>,
+}
+
+impl From<crate::core::phase3::CardContextDefaultProposalReport> for CardContextDefaultProposalDto {
+    fn from(report: crate::core::phase3::CardContextDefaultProposalReport) -> Self {
+        Self {
+            writes: report.writes,
+            candidate: report.candidate,
+            proposal_ready: report.proposal_ready,
+            decision: report.decision,
+            readiness: report.readiness.into(),
+            rollback_criteria: report.rollback_criteria,
+            reasons: report.reasons,
+        }
+    }
 }
 
 impl From<crate::core::phase3::EvaluatorAdviceReport> for EvaluatorAdviceDto {

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -1,11 +1,14 @@
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::process::Command;
+use std::thread;
 
 use mempal::core::db::Database;
 use mempal::core::types::{
-    AnchorKind, KnowledgeCard, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
-    Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
-    RuntimeAdoptionTrack,
+    AnchorKind, Drawer, KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+    KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
+    RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
 };
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -28,6 +31,32 @@ fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
         .expect("run mempal")
 }
 
+fn record_card_context_acceptance(home: &TempDir, id: &str) {
+    let output = run_mempal(
+        home,
+        &[
+            "phase3",
+            "adoption",
+            "record",
+            "--id",
+            id,
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--query",
+            "skill trigger context",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn insert_test_card(home: &TempDir, card_id: &str) {
     let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
     db.insert_knowledge_card(&KnowledgeCard {
@@ -47,6 +76,109 @@ fn insert_test_card(home: &TempDir, card_id: &str) {
         updated_at: "1713000000".to_string(),
     })
     .expect("insert test card");
+}
+
+fn evidence_drawer(id: &str, content: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("phase3".to_string()),
+        source_file: Some(format!("tests://phase3/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 2,
+        memory_kind: MemoryKind::Evidence,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        provenance: Some(Provenance::Human),
+        statement: None,
+        tier: None,
+        status: None,
+        supporting_refs: Vec::new(),
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn insert_test_card_with_evidence(home: &TempDir, card_id: &str, evidence_id: &str) {
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let drawer = evidence_drawer(evidence_id, "card context evidence");
+    db.insert_drawer(&drawer).expect("insert evidence drawer");
+    db.insert_vector(evidence_id, &vec![0.25; 384])
+        .expect("insert evidence vector");
+    drop(db);
+    insert_test_card(home, card_id);
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+        id: format!("link_{card_id}_{evidence_id}"),
+        card_id: card_id.to_string(),
+        evidence_drawer_id: evidence_id.to_string(),
+        role: KnowledgeEvidenceRole::Supporting,
+        note: None,
+        created_at: "1710000000".to_string(),
+    })
+    .expect("insert card evidence link");
+}
+
+fn start_openai_embedding_stub(query: &str) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding stub");
+    listener
+        .set_nonblocking(true)
+        .expect("set embedding stub nonblocking");
+    let address = listener.local_addr().expect("local addr");
+    let query = query.to_string();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = (0..50)
+            .find_map(|_| match listener.accept() {
+                Ok(connection) => Some(connection),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(std::time::Duration::from_millis(100));
+                    None
+                }
+                Err(error) => panic!("accept request: {error}"),
+            })
+            .expect("embedding stub timed out waiting for request");
+        let mut request = [0_u8; 4096];
+        let bytes_read = stream.read(&mut request).expect("read embedding request");
+        let request = String::from_utf8_lossy(&request[..bytes_read]);
+        let (_, body) = request
+            .split_once("\r\n\r\n")
+            .expect("request should contain JSON body");
+        let payload: Value = serde_json::from_str(body).expect("parse embedding request");
+        assert_eq!(payload["input"][0], query);
+        let body = serde_json::to_string(&json!({
+            "data": [{ "embedding": vec![0.25; 384] }]
+        }))
+        .expect("serialize embedding response");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write embedding response");
+    });
+    (format!("http://{address}/v1/embeddings"), handle)
+}
+
+fn write_cli_api_config(home: &TempDir, endpoint: &str) {
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        format!(
+            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+        ),
+    )
+    .expect("write config");
 }
 
 #[test]
@@ -242,6 +374,158 @@ fn test_cli_phase3_readiness_card_context_default_blocks_without_evidence() {
         .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
         .expect("list events");
     assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_card_context_ready() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("proposal_accept_{i}"));
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-proposal",
+            "card-context",
+            "--rollback-criterion",
+            "rollback on contradiction or user-visible degradation",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "proposal failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("proposal json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["candidate"], "card-context");
+    assert_eq!(report["proposal_ready"], true);
+    assert_eq!(report["decision"], "eligible_for_default_on_spec");
+    assert_eq!(report["readiness"]["ready"], true);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 3);
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_requires_rollback_criteria() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("proposal_no_rollback_{i}"));
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-proposal",
+            "card-context",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "proposal failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("proposal json");
+    assert_eq!(report["proposal_ready"], false);
+    let reasons = report["reasons"].as_array().expect("reasons");
+    assert!(reasons.iter().any(|reason| {
+        reason
+            .as_str()
+            .is_some_and(|value| value.contains("rollback criteria are required"))
+    }));
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_blocks_without_readiness() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-proposal",
+            "card-context",
+            "--rollback-criterion",
+            "rollback on contradiction or user-visible degradation",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "proposal failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("proposal json");
+    assert_eq!(report["proposal_ready"], false);
+    assert_eq!(report["readiness"]["ready"], false);
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_keeps_context_cards_opt_in() {
+    let home = setup_cli_home();
+    insert_test_card_with_evidence(&home, "card_default_off", "drawer_default_off_evidence");
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("proposal_default_off_{i}"));
+    }
+    let proposal = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-proposal",
+            "card-context",
+            "--rollback-criterion",
+            "rollback on contradiction or user-visible degradation",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        proposal.status.success(),
+        "proposal failed: {}",
+        String::from_utf8_lossy(&proposal.stderr)
+    );
+
+    let query = "card-aware";
+    let (endpoint, handle) = start_openai_embedding_stub(query);
+    write_cli_api_config(&home, &endpoint);
+    let context = run_mempal(&home, &["context", query, "--format", "json"]);
+    assert!(
+        context.status.success(),
+        "context failed: {}",
+        String::from_utf8_lossy(&context.stderr)
+    );
+    handle.join().expect("join embedding stub");
+    let context: Value = serde_json::from_slice(&context.stdout).expect("context json");
+    let has_card = context["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .any(|item| item["card_id"] == "card_default_off");
+    assert!(!has_card, "cards should remain opt-in by default");
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_rejects_unknown_candidate() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "default-proposal", "unknown", "--format", "json"],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 default proposal candidate"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add P74 spec and plan for card-context default-on proposal.
- Add CLI `mempal phase3 default-proposal card-context`.
- Add MCP `mempal_phase3 action=default_proposal`.
- Reuse P66 readiness and require explicit rollback criteria before `proposal_ready=true`.
- Keep `include_cards` opt-in; this PR does not change runtime defaults.

## Verification

- `agent-spec parse specs/p74-card-context-default-proposal.spec.md`
- `agent-spec lint specs/p74-card-context-default-proposal.spec.md --min-score 0.7`
- `cargo test --test phase3_runtime test_cli_phase3_default_proposal -- --nocapture`
- `cargo test mcp::server::tests::test_mcp_phase3_default_proposal_card_context_is_read_only --lib -- --nocapture`
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy -- -D warnings`
- `cargo clippy --features rest -- -D warnings`
- `cargo test`
- `git diff --check`
