### PR TITLE
docs: audit self-evolution after p74

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
+| `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -200,6 +201,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
+- `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
+| `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -198,6 +199,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
+- `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1463,6 +1463,90 @@ Future P candidates:
   `include_cards=false`; any actual default change still requires a future
   explicit spec.
 
+P75 self-evolution completion audit revisits the full objective after P71-P74
+landed on main.
+
+P75 objective restatement:
+
+- The system must preserve raw evidence and runtime outcome evidence with
+  provenance.
+- The system must distill evidence into governed knowledge and cards through
+  deterministic gates.
+- The system must expose retrieval/context surfaces that agents can use without
+  silently changing runtime defaults.
+- The system must accept external research only through evidence-first and
+  evidence-backed candidate insight paths.
+- The system must record, review, and quality-gate runtime adoption feedback.
+- The system must provide evaluator advice without granting lifecycle authority.
+- The system must provide a policy-hardening path where stronger defaults require
+  evidence, readiness checks, rollback criteria, and a new explicit spec.
+
+P75 prompt-to-artifact checklist:
+
+- Evidence substrate: P0-P13 raw drawer storage and citation-bearing search,
+  P54 `runtime_adoption_events`, and schema v9 tests prove durable evidence and
+  runtime outcome storage.
+- Knowledge governance: P12-P28 typed `dao_tian` / `dao_ren` / `shu` / `qi`
+  drawers, policy surfaces, distill, gate, promote/demote, and anchor
+  publication remain covered by `tests/knowledge_lifecycle.rs`.
+- Knowledge cards: P31-P45 card schema, core API, CLI, MCP, retrieval, backfill,
+  and lifecycle surfaces remain covered by `tests/knowledge_card_*` and explicit
+  card-aware context tests.
+- Research bridge: P49/P59/P67/P68 ensure research output enters as evidence or
+  evidence-backed candidate insight suggestions; P71 proves this path in
+  `tests/phase3_self_evolution_replay.rs`.
+- Self-evolution replay: P71 `tests/phase3_self_evolution_replay.rs` walks
+  research -> evidence -> card promotion -> context -> checked adoption record.
+- Adoption capture: P72 `mempal phase3 adoption capture` and
+  `mempal_phase3 action=capture` map concrete `surface/outcome` observations
+  into checked records without background instrumentation.
+- Evaluator advice: P73 `mempal phase3 evaluator advise` and
+  `mempal_phase3 action=evaluator_advise` return replayable advisory output with
+  `lifecycle_authority=false` and `deterministic_gate_required=true`.
+- Default hardening proposal: P74 `mempal phase3 default-proposal card-context`
+  and `mempal_phase3 action=default_proposal` combine P66 readiness with
+  rollback criteria while preserving `include_cards=false`.
+- Protocol and inventory evidence: `src/core/protocol.rs`, `AGENTS.md`, and
+  `CLAUDE.md` list the Phase-3 actions through
+  `capture/evaluator_advise/default_proposal`.
+- Mainline verification evidence: PRs #63, #64, #65, and #66 were merged to
+  main with green `fmt`, `default`, and `rest` CI checks.
+
+P75 conclusion: not complete.
+
+The governed self-evolution substrate is now substantially complete: evidence,
+knowledge governance, cards, research ingestion, runtime adoption feedback,
+replay, capture helpers, evaluator advice, and default-on proposal artifacts are
+implemented and tested. However, the full "complete self-evolving agent system"
+objective still has uncovered requirements if interpreted as autonomous runtime
+self-evolution.
+
+Remaining gaps after P75:
+
+- no automatic live tool instrumentation: adoption capture still requires
+  explicit CLI/MCP calls rather than wrapping actual agent tool execution
+- no actual default-on runtime change: `include_cards` remains opt-in by design,
+  and P74 only creates a proposal artifact
+- no rollback executor: rollback criteria are recorded in proposals but are not
+  executable runtime policy
+- no autonomous promotion authority: lifecycle mutation still requires
+  deterministic gates, evidence refs, and human/reviewer boundaries
+- no card embedding implementation: P57/P47 keep card-level embeddings behind
+  measured miss evidence and future rollback requirements
+
+Recommended next P candidates:
+
+- P76 live adoption instrumentation boundary: define whether hooks/tool wrappers
+  may semi-automatically create checked adoption captures, with opt-out and
+  rollback rules.
+- P77 card context default-on runtime flag: implement an explicit, reversible
+  default-on switch only after a P74 proposal is ready.
+- P78 rollback executor contract: turn rollback criteria into a testable policy
+  action that can revert a default/runtime policy change.
+- P79 autonomous promotion boundary audit: decide whether autonomous promotion is
+  actually desired, or explicitly declare human-gated governance as the final
+  design boundary.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-13-p75-self-evolution-completion-audit.md
+++ b/docs/plans/2026-05-13-p75-self-evolution-completion-audit.md
@@ -1,0 +1,29 @@
+# P75 Self-Evolution Completion Audit
+
+Goal: re-audit the complete self-evolving agent objective after P71-P74 and
+record what is complete versus what still remains.
+
+Spec: `specs/p75-self-evolution-completion-audit.spec.md`
+
+## Steps
+
+- [x] Add P75 task contract and plan.
+- [x] Inspect P71-P74 specs, tests, protocol entries, inventories, and main CI evidence.
+- [x] Add P75 completion audit to `docs/MIND-MODEL-DESIGN.md`.
+- [x] Update AGENTS/CLAUDE spec and plan inventories.
+- [x] Verify spec parse/lint and audit grep selectors.
+- [x] Verify P75 is audit-only with changed-file boundaries.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p75-self-evolution-completion-audit.spec.md
+agent-spec lint specs/p75-self-evolution-completion-audit.spec.md --min-score 0.7
+rg -n "P75 self-evolution completion audit|P75 conclusion" docs/MIND-MODEL-DESIGN.md
+rg -n "P75 prompt-to-artifact checklist|P71.*phase3_self_evolution_replay|P72.*capture|P73.*evaluator_advise|P74.*default_proposal" docs/MIND-MODEL-DESIGN.md
+rg -n "P75 conclusion: not complete|Remaining gaps after P75|no automatic live tool instrumentation|no rollback executor|no actual default-on runtime change" docs/MIND-MODEL-DESIGN.md
+rg -n "p75-self-evolution-completion-audit|P75 self-evolution completion audit" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/specs/p75-self-evolution-completion-audit.spec.md
+++ b/specs/p75-self-evolution-completion-audit.spec.md
@@ -1,0 +1,91 @@
+spec: task
+name: "P75: self-evolution completion audit"
+inherits: project
+tags: [phase-3, self-evolution, audit]
+---
+
+## Intent
+
+P70 audited the self-evolution objective before P71-P74 existed. P75 performs a
+new evidence-based completion audit after the replay, capture helper, evaluator
+advisory API, and card-context default proposal have landed on main. The audit
+must distinguish completed governed self-evolution substrate from any remaining
+requirements for a complete autonomous self-evolving agent system.
+
+## Decisions
+
+- P75 must leave its own `specs/p75-*.spec.md` and plan document.
+- P75 is audit-only and must not change Rust runtime behavior.
+- The audit must restate the objective as concrete deliverables.
+- The audit must include a prompt-to-artifact checklist mapping deliverables to
+  specs, commands, tests, protocol entries, and PR/CI evidence.
+- The audit must explicitly state whether the full objective is complete.
+- If remaining gaps exist, the audit must list next P candidates instead of
+  marking the goal complete.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p75-self-evolution-completion-audit.spec.md
+- docs/plans/2026-05-13-p75-self-evolution-completion-audit.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not modify `tests/**`.
+- Do not add CLI or MCP behavior.
+- Do not mark the overall self-evolution objective complete unless the audit
+  proves no required work remains.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records P75 completion audit
+  Test:
+    Filter: rg -n "P75 self-evolution completion audit|P75 conclusion" docs/MIND-MODEL-DESIGN.md
+    Targets: P75 audit section.
+  Given the MIND-MODEL design document
+  When reading the Phase-3 completion section
+  Then it includes a P75 audit after P71-P74
+  And it states a P75 conclusion
+
+Scenario: Audit maps objective to concrete artifacts
+  Test:
+    Filter: rg -n "P75 prompt-to-artifact checklist|P71.*phase3_self_evolution_replay|P72.*capture|P73.*evaluator_advise|P74.*default_proposal" docs/MIND-MODEL-DESIGN.md
+    Targets: Prompt-to-artifact checklist.
+  Given the P75 audit
+  When reading the checklist
+  Then it maps replay, capture, evaluator advice, and default proposal to concrete artifacts
+
+Scenario: Audit identifies remaining gaps instead of overclaiming completion
+  Test:
+    Filter: rg -n "P75 conclusion: not complete|Remaining gaps after P75|no automatic live tool instrumentation|no rollback executor|no actual default-on runtime change" docs/MIND-MODEL-DESIGN.md
+    Targets: Completion conclusion.
+  Given the P75 audit
+  When reading the conclusion
+  Then it states the full objective is not complete yet
+  And it lists concrete remaining gaps
+
+Scenario: Inventories include P75
+  Test:
+    Filter: rg -n "p75-self-evolution-completion-audit|P75 self-evolution completion audit" AGENTS.md CLAUDE.md
+    Targets: Agent inventories.
+  Given project inventories
+  When searching for P75
+  Then both AGENTS.md and CLAUDE.md include the P75 spec and plan entries
+
+Scenario: P75 remains audit-only
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: P75 audit-only boundary.
+  Given the P75 branch
+  When listing changed files
+  Then changes are limited to the P75 spec, plan, MIND-MODEL design, and agent inventory docs
+
+## Out of Scope
+
+- Implementing automatic live tool instrumentation.
+- Implementing rollback execution.
+- Turning `include_cards` on by default.
+- Adding autonomous promotion authority.


### PR DESCRIPTION
## Summary

- Add P75 spec and plan for post-P74 self-evolution completion audit.
- Update MIND-MODEL with prompt-to-artifact checklist after P71-P74.
- Record that the governed self-evolution substrate is substantially complete.
- Record that the full autonomous self-evolving agent objective is still not complete.
- List remaining gaps: live tool instrumentation, actual default-on runtime change, rollback executor, autonomous promotion authority, card embeddings.

## Verification

- `agent-spec parse specs/p75-self-evolution-completion-audit.spec.md`
- `agent-spec lint specs/p75-self-evolution-completion-audit.spec.md --min-score 0.7`
- `rg -n "P75 self-evolution completion audit|P75 conclusion" docs/MIND-MODEL-DESIGN.md`
- `rg -n "P75 prompt-to-artifact checklist|P71.*phase3_self_evolution_replay|P72.*capture|P73.*evaluator_advise|P74.*default_proposal" docs/MIND-MODEL-DESIGN.md`
- `rg -n "P75 conclusion: not complete|Remaining gaps after P75|no automatic live tool instrumentation|no rollback executor|no actual default-on runtime change" docs/MIND-MODEL-DESIGN.md`
- `rg -n "p75-self-evolution-completion-audit|P75 self-evolution completion audit" AGENTS.md CLAUDE.md`
- `git diff --name-only main...HEAD`
- `git diff --check`
