### PR TITLE
docs: codify p-series spec invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,14 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 
 项目使用 agent-spec 管理任务合约。所有实现必须对照 spec 验收。
 
+硬规则：
+
+- 每一个 numbered P 都必须留下 `specs/pNN-*.spec.md`。
+- 每一个 numbered P 都必须留下匹配的 `docs/plans/*pNN*.md`。
+- 该规则同样适用于文档-only、audit-only、policy-only 和代码实现类 P。
+- future spec-less P 不能算完成；missing spec 必须先补齐再实现或合并。
+- 完成后必须同步更新 `AGENTS.md` / `CLAUDE.md` 的 spec 与 plan inventory。
+
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
@@ -122,6 +130,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
+| `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -202,6 +211,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
+- `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 
 项目使用 agent-spec 管理任务合约。所有实现必须对照 spec 验收。
 
+硬规则：
+
+- 每一个 numbered P 都必须留下 `specs/pNN-*.spec.md`。
+- 每一个 numbered P 都必须留下匹配的 `docs/plans/*pNN*.md`。
+- 该规则同样适用于文档-only、audit-only、policy-only 和代码实现类 P。
+- future spec-less P 不能算完成；missing spec 必须先补齐再实现或合并。
+- 完成后必须同步更新 `AGENTS.md` / `CLAUDE.md` 的 spec 与 plan inventory。
+
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
@@ -120,6 +128,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
+| `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -200,6 +209,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
+- `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1534,16 +1534,24 @@ Remaining gaps after P75:
 - no card embedding implementation: P57/P47 keep card-level embeddings behind
   measured miss evidence and future rollback requirements
 
-Recommended next P candidates:
+P76 spec completeness invariant records the process rule that every numbered P
+must leave both a task contract and a matching plan. This includes
+documentation-only, audit-only, policy-only, and code implementation work. The
+rule exists because the P-series is no longer just a task list; it is the
+auditable decision trail for the mind-model implementation. Every P must leave
+a spec before it can be considered complete. A future spec-less P or missing
+spec is explicitly incomplete and must be fixed before implementation or merge.
 
-- P76 live adoption instrumentation boundary: define whether hooks/tool wrappers
+Updated recommended next P candidates after reserving P76 for governance:
+
+- P77 live adoption instrumentation boundary: define whether hooks/tool wrappers
   may semi-automatically create checked adoption captures, with opt-out and
   rollback rules.
-- P77 card context default-on runtime flag: implement an explicit, reversible
+- P78 card context default-on runtime flag: implement an explicit, reversible
   default-on switch only after a P74 proposal is ready.
-- P78 rollback executor contract: turn rollback criteria into a testable policy
+- P79 rollback executor contract: turn rollback criteria into a testable policy
   action that can revert a default/runtime policy change.
-- P79 autonomous promotion boundary audit: decide whether autonomous promotion is
+- P80 autonomous promotion boundary audit: decide whether autonomous promotion is
   actually desired, or explicitly declare human-gated governance as the final
   design boundary.
 

--- a/docs/plans/2026-05-13-p76-spec-completeness-invariant.md
+++ b/docs/plans/2026-05-13-p76-spec-completeness-invariant.md
@@ -1,0 +1,31 @@
+# P76 Spec Completeness Invariant
+
+Goal: codify the project governance rule that every numbered P must leave both
+a task spec and a matching plan before it can be considered complete.
+
+Spec: `specs/p76-spec-completeness-invariant.spec.md`
+
+## Steps
+
+- [x] Add P76 task contract and plan.
+- [x] Update AGENTS/CLAUDE Spec system rules with the hard invariant.
+- [x] Add P76 to completed spec and plan inventories.
+- [x] Add a MIND-MODEL governance note and renumber the next recommended P
+      candidates after reserving P76.
+- [x] Verify spec parse/lint and grep selectors.
+- [x] Verify P76 is governance-only with changed-file boundaries.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p76-spec-completeness-invariant.spec.md
+agent-spec lint specs/p76-spec-completeness-invariant.spec.md --min-score 0.7
+rg -n "Every future numbered P must include|docs/plans/.*pNN|documentation-only, audit-only, policy-only" specs/p76-spec-completeness-invariant.spec.md
+rg -n "每一个 numbered P|specs/pNN-\\*\\.spec\\.md|docs/plans/.*pNN|文档-only|audit-only|policy-only" AGENTS.md CLAUDE.md
+rg -n "p76-spec-completeness-invariant|P76 spec completeness invariant" AGENTS.md CLAUDE.md
+rg -n "P76 spec completeness invariant|Every P must leave a spec|future P numbering" docs/MIND-MODEL-DESIGN.md
+rg -n "不能算完成|spec-less P|missing spec|必须留下.*spec" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/specs/p76-spec-completeness-invariant.spec.md
+++ b/specs/p76-spec-completeness-invariant.spec.md
@@ -1,0 +1,97 @@
+spec: task
+name: "P76: spec completeness invariant"
+inherits: project
+tags: [governance, specs, process]
+---
+
+## Intent
+
+P76 codifies the project rule that every numbered P must leave an explicit task
+contract before it is implemented or merged. This prevents future work from
+landing as undocumented implementation drift and makes the P-series auditable as
+a complete decision and verification trail.
+
+## Decisions
+
+- Every future numbered P must include a `specs/pNN-*.spec.md` task contract.
+- Every future numbered P must include a matching `docs/plans/*pNN*.md` plan.
+- Agent inventories must list completed P specs and plans after the work lands.
+- This rule applies to documentation-only, audit-only, policy-only, and code
+  implementation P tasks.
+- P76 itself must obey the same rule by adding its own spec and plan.
+- P76 is governance-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p76-spec-completeness-invariant.spec.md
+- docs/plans/2026-05-13-p76-spec-completeness-invariant.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not modify `tests/**`.
+- Do not add or change CLI, MCP, REST, or database behavior.
+- Do not retroactively rewrite older completed spec contents.
+
+## Acceptance Criteria
+
+Scenario: P76 spec exists and states the invariant
+  Test:
+    Filter: rg -n "Every future numbered P must include|docs/plans/.*pNN|documentation-only, audit-only, policy-only" specs/p76-spec-completeness-invariant.spec.md
+    Targets: P76 task contract.
+  Given the P76 task contract
+  When reading its decisions
+  Then it requires every future numbered P to include both a spec and a plan
+  And it applies the rule to non-code P tasks too
+
+Scenario: Project agent instructions expose the hard rule
+  Test:
+    Filter: rg -n "每一个 numbered P|specs/pNN-\\*\\.spec\\.md|docs/plans/.*pNN|文档-only|audit-only|policy-only" AGENTS.md CLAUDE.md
+    Targets: Agent instructions.
+  Given project agent instructions
+  When searching the Spec system section
+  Then both AGENTS.md and CLAUDE.md contain the P completeness hard rule
+
+Scenario: Inventories include P76
+  Test:
+    Filter: rg -n "p76-spec-completeness-invariant|P76 spec completeness invariant" AGENTS.md CLAUDE.md
+    Targets: Agent inventories.
+  Given project inventories
+  When searching for P76
+  Then both AGENTS.md and CLAUDE.md include the P76 spec and plan entries
+
+Scenario: MIND-MODEL records the governance decision
+  Test:
+    Filter: rg -n "P76 spec completeness invariant|Every P must leave a spec|future P numbering" docs/MIND-MODEL-DESIGN.md
+    Targets: MIND-MODEL governance note.
+  Given the MIND-MODEL design document
+  When reading the Phase-3 completion tail
+  Then it records the P76 governance decision
+  And it updates future P numbering after reserving P76 for the invariant
+
+Scenario: P76 remains governance-only
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: P76 governance-only boundary.
+  Given the P76 branch
+  When listing changed files
+  Then changes are limited to the P76 spec, plan, MIND-MODEL design, and agent inventory docs
+
+Scenario: Specless future P is rejected as incomplete
+  Test:
+    Filter: rg -n "不能算完成|spec-less P|missing spec|必须留下.*spec" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Future P failure rule.
+  Given a future numbered P without a matching task spec
+  When applying the project governance rule
+  Then that spec-less P is rejected as incomplete
+  And the agent must create the missing spec before implementation or merge
+
+## Out of Scope
+
+- Implementing live adoption instrumentation.
+- Implementing card-context default-on runtime behavior.
+- Implementing rollback execution.
+- Changing the agent-spec CLI itself.


### PR DESCRIPTION
## Summary

- Add P76 task spec and matching plan for the P-series spec completeness invariant.
- Codify the hard rule in AGENTS/CLAUDE: every numbered P needs `specs/pNN-*.spec.md` and `docs/plans/*pNN*.md`, including docs/audit/policy-only work.
- Record the governance decision in MIND-MODEL and renumber the next recommended P candidates.

## Verification

- `agent-spec parse specs/p76-spec-completeness-invariant.spec.md`
- `agent-spec lint specs/p76-spec-completeness-invariant.spec.md --min-score 0.7`
- grep acceptance selectors from the P76 plan
- `git diff --check`
