### PR TITLE
feat: add phase3 instrumentation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
+| `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -212,6 +213,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
+- `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 
 ### Spec 使用方式
 
@@ -247,7 +249,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74/P77） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
+| `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -210,6 +211,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
+- `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 
 ### Spec 使用方式
 
@@ -245,7 +247,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74/P77） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1544,9 +1544,18 @@ spec is explicitly incomplete and must be fixed before implementation or merge.
 
 Updated recommended next P candidates after reserving P76 for governance:
 
-- P77 live adoption instrumentation boundary: define whether hooks/tool wrappers
-  may semi-automatically create checked adoption captures, with opt-out and
-  rollback rules.
+P77 live adoption instrumentation boundary adds a read-only policy surface for
+the live instrumentation gap. `mempal phase3 adoption instrumentation-policy`
+and `mempal_phase3 action=instrumentation_policy` return `writes=false`,
+`default_mode=manual_only`, allow only `opt_in_wrapper` as the semi-automatic
+mode, and explicitly forbid `implicit_background_capture`, silent event append,
+and quality gate bypass. This does not install hooks or wrappers; it defines the
+safe boundary future instrumentation must obey: opt-in, user opt-out, checked
+capture/record_checked writes, and rollback evidence when instrumentation
+degrades behavior.
+
+Updated recommended next P candidates after completing P77:
+
 - P78 card context default-on runtime flag: implement an explicit, reversible
   default-on switch only after a P74 proposal is ready.
 - P79 rollback executor contract: turn rollback criteria into a testable policy

--- a/docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md
+++ b/docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md
@@ -1,0 +1,37 @@
+# P77 Live Adoption Instrumentation Boundary
+
+Goal: expose a deterministic read-only Phase-3 policy surface that defines which
+live adoption instrumentation modes are allowed before any hooks or tool wrappers
+are implemented.
+
+Spec: `specs/p77-live-adoption-instrumentation-boundary.spec.md`
+
+## Steps
+
+- [x] Add P77 task contract and plan.
+- [x] Add failing CLI tests for `mempal phase3 adoption instrumentation-policy`.
+- [x] Add failing MCP test for `mempal_phase3 action=instrumentation_policy`.
+- [x] Implement pure instrumentation policy DTOs in `src/core/phase3.rs`.
+- [x] Wire CLI and MCP read-only surfaces.
+- [x] Update protocol text, AGENTS/CLAUDE inventories, and MIND-MODEL summary.
+- [x] Verify spec parse/lint, targeted tests, fmt/check/clippy/test, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p77-live-adoption-instrumentation-boundary.spec.md
+agent-spec lint specs/p77-live-adoption-instrumentation-boundary.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_json_is_read_only
+cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_rejects_invalid_format
+cargo test mcp::server::tests::test_mcp_phase3_instrumentation_policy_action_is_read_only --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+rg -n "p77-live-adoption-instrumentation-boundary|P77 live adoption instrumentation boundary" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p77-live-adoption-instrumentation-boundary.spec.md
+++ b/specs/p77-live-adoption-instrumentation-boundary.spec.md
@@ -1,0 +1,108 @@
+spec: task
+name: "P77: live adoption instrumentation boundary"
+inherits: project
+tags: [phase-3, runtime-adoption, instrumentation, policy]
+---
+
+## Intent
+
+P75 identified missing automatic live tool instrumentation as a remaining gap in
+the self-evolution objective. P77 defines the safe boundary before any hooks or
+tool wrappers are allowed: instrumentation may help prepare or trigger checked
+adoption capture, but it must not silently append evidence or bypass existing
+quality gates. The boundary must be exposed to both CLI users and MCP agents so
+future runtime wrappers can follow the same contract.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption instrumentation-policy`.
+- Add MCP `mempal_phase3 action=instrumentation_policy`.
+- The policy surface is read-only and must not append `runtime_adoption_events`.
+- The default instrumentation mode remains `manual_only`.
+- `opt_in_wrapper` is the only semi-automatic mode allowed by P77.
+- `implicit_background_capture` is explicitly forbidden.
+- Any wrapper-created capture must go through existing `capture` /
+  `record_checked` quality gates and must preserve opt-out and rollback
+  requirements.
+- P77 must leave its own spec and plan per the P76 invariant.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p77-live-adoption-instrumentation-boundary.spec.md
+- docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- src/core/protocol.rs
+- tests/phase3_runtime.rs
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+
+### Forbidden
+- Do not add actual shell hooks, background workers, daemon processes, or tool
+  wrappers.
+- Do not change `capture` default dry-run behavior.
+- Do not write runtime adoption events from `instrumentation-policy`.
+- Do not make `include_cards` default-on.
+- Do not add new database schema or external dependencies.
+
+## Acceptance Criteria
+
+Scenario: CLI exposes read-only instrumentation policy
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_json_is_read_only
+    Targets: CLI policy output and event count.
+  Given an empty runtime adoption event table
+  When running `mempal phase3 adoption instrumentation-policy --format json`
+  Then the JSON report has `writes=false`
+  And `default_mode` is `manual_only`
+  And allowed modes include `opt_in_wrapper`
+  And forbidden modes include `implicit_background_capture`
+  And the runtime adoption event count remains zero
+
+Scenario: CLI rejects unsupported instrumentation policy output format
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_rejects_invalid_format
+    Targets: CLI error handling.
+  Given the CLI policy command
+  When running it with `--format yaml`
+  Then the command fails
+  And stderr includes `unsupported phase3 adoption format`
+
+Scenario: MCP exposes read-only instrumentation policy
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_instrumentation_policy_action_is_read_only --lib
+    Targets: MCP policy action in `src/mcp/server.rs`.
+  Given an empty test database
+  When `mempal_phase3` is called with `action=instrumentation_policy`
+  Then the response includes an instrumentation policy with `writes=false`
+  And one allowed mode is `opt_in_wrapper`
+  And no runtime adoption event is appended
+  And the behavior is exercised through `src/mcp/server.rs`
+
+Scenario: Protocol advertises instrumentation boundary
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+    Targets: MCP tool description and MEMORY_PROTOCOL.
+  Given the MCP tool registry and protocol instructions
+  When inspecting the Phase-3 surface
+  Then `instrumentation_policy` is listed as a supported action
+  And the protocol states that live instrumentation is opt-in and must use checked capture
+
+Scenario: Inventories include P77
+  Test:
+    Filter: rg -n "p77-live-adoption-instrumentation-boundary|P77 live adoption instrumentation boundary" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Project inventories and design document.
+  Given project inventories and MIND-MODEL design
+  When searching for P77
+  Then the P77 spec, plan, and design summary are recorded
+
+## Out of Scope
+
+- Installing runtime hooks.
+- Wrapping agent tool calls.
+- Executing rollback policies.
+- Automatically changing context defaults.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -35,6 +35,25 @@ pub struct RuntimeAdoptionTrackGuidance {
     pub feature_examples: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionInstrumentationPolicy {
+    pub version: u32,
+    pub writes: bool,
+    pub default_mode: String,
+    pub allowed_modes: Vec<RuntimeAdoptionInstrumentationMode>,
+    pub forbidden_modes: Vec<String>,
+    pub requirements: Vec<String>,
+    pub rollback_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionInstrumentationMode {
+    pub mode: String,
+    pub description: String,
+    pub requires_execute: bool,
+    pub requires_checked_capture: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct RuntimeAdoptionRecordPlan {
     pub writes: bool,
@@ -307,6 +326,42 @@ pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
                     "research_ingest_plan".to_string(),
                 ],
             },
+        ],
+    }
+}
+
+pub fn runtime_adoption_instrumentation_policy() -> RuntimeAdoptionInstrumentationPolicy {
+    RuntimeAdoptionInstrumentationPolicy {
+        version: 1,
+        writes: false,
+        default_mode: "manual_only".to_string(),
+        allowed_modes: vec![
+            RuntimeAdoptionInstrumentationMode {
+                mode: "manual_only".to_string(),
+                description: "agents explicitly call guidance, capture, or record_checked after observing a concrete runtime outcome".to_string(),
+                requires_execute: false,
+                requires_checked_capture: true,
+            },
+            RuntimeAdoptionInstrumentationMode {
+                mode: "opt_in_wrapper".to_string(),
+                description: "a user-enabled wrapper may prepare capture inputs around a tool call, but writes still require execute=true and checked capture quality gates".to_string(),
+                requires_execute: true,
+                requires_checked_capture: true,
+            },
+        ],
+        forbidden_modes: vec![
+            "implicit_background_capture".to_string(),
+            "silent_event_append".to_string(),
+            "quality_gate_bypass".to_string(),
+        ],
+        requirements: vec![
+            "live instrumentation is opt-in; users must have an opt-out before any capture is written".to_string(),
+            "wrappers must preserve source surface, outcome, query/context identifiers, and relevant metadata".to_string(),
+            "writes must go through existing capture or record_checked quality gates".to_string(),
+        ],
+        rollback_requirements: vec![
+            "rollback criteria must be recorded before any future default-on instrumentation proposal".to_string(),
+            "rollback signals must be captured when instrumentation degrades task behavior or creates noisy evidence".to_string(),
         ],
     }
 }

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,9 +213,13 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
+   action=instrumentation_policy before building live tool instrumentation:
+   live instrumentation is opt-in, must preserve user opt-out, and must route
+   writes through checked capture or record_checked instead of silently
+   appending events. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
    action=capture when you have a concrete runtime outcome but do not want to
@@ -257,7 +261,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,8 @@ use mempal::core::{
         capture_runtime_adoption_record_input, card_context_default_proposal,
         card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
         prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
+        runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -639,6 +640,10 @@ enum Phase3EvaluatorCommands {
 #[allow(clippy::large_enum_variant)] // `record` intentionally carries the full event payload.
 enum Phase3AdoptionCommands {
     Guidance {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    InstrumentationPolicy {
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2438,6 +2443,12 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
         Phase3AdoptionCommands::Guidance { format } => {
             print_runtime_adoption_guidance(&runtime_adoption_guidance(), &format)
         }
+        Phase3AdoptionCommands::InstrumentationPolicy { format } => {
+            print_runtime_adoption_instrumentation_policy(
+                &runtime_adoption_instrumentation_policy(),
+                &format,
+            )
+        }
         Phase3AdoptionCommands::PrepareRecord {
             track,
             signal,
@@ -2983,6 +2994,44 @@ fn print_runtime_adoption_guidance(guidance: &RuntimeAdoptionGuidance, format: &
                 "{}",
                 serde_json::to_string_pretty(guidance)
                     .context("failed to serialize runtime adoption guidance")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
+    }
+}
+
+fn print_runtime_adoption_instrumentation_policy(
+    policy: &mempal::core::phase3::RuntimeAdoptionInstrumentationPolicy,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("version={}", policy.version);
+            println!("writes={}", policy.writes);
+            println!("default_mode={}", policy.default_mode);
+            for mode in &policy.allowed_modes {
+                println!(
+                    "allowed_mode={} requires_execute={} requires_checked_capture={}",
+                    mode.mode, mode.requires_execute, mode.requires_checked_capture
+                );
+            }
+            for mode in &policy.forbidden_modes {
+                println!("forbidden_mode={mode}");
+            }
+            for requirement in &policy.requirements {
+                println!("requirement={requirement}");
+            }
+            for requirement in &policy.rollback_requirements {
+                println!("rollback_requirement={requirement}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(policy)
+                    .context("failed to serialize runtime adoption instrumentation policy")?
             );
             Ok(())
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -12,7 +12,7 @@ use crate::core::{
         card_context_default_proposal, card_context_default_readiness,
         check_runtime_adoption_record, evaluator_advice, prepare_runtime_adoption_capture,
         prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
-        should_write_checked_record,
+        runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1350,7 +1350,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; instrumentation_policy defines opt-in live instrumentation boundaries without writing; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1362,6 +1362,24 @@ impl MempalMcpServer {
         match action {
             "guidance" => Ok(Json(Phase3Response {
                 guidance: Some(runtime_adoption_guidance().into()),
+                instrumentation_policy: None,
+                record_plan: None,
+                record_quality: None,
+                record_checked: None,
+                review_report: None,
+                readiness_report: None,
+                event: None,
+                events: Vec::new(),
+                stats: None,
+                gate: None,
+                research_plan: None,
+                research_ingest_plan: None,
+                evaluator_advice: None,
+                default_proposal: None,
+            })),
+            "instrumentation_policy" => Ok(Json(Phase3Response {
+                guidance: None,
+                instrumentation_policy: Some(runtime_adoption_instrumentation_policy().into()),
                 record_plan: None,
                 record_quality: None,
                 record_checked: None,
@@ -1401,6 +1419,7 @@ impl MempalMcpServer {
                 });
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: Some(plan.into()),
                     record_quality: None,
                     record_checked: None,
@@ -1484,6 +1503,7 @@ impl MempalMcpServer {
                 }
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: Some(capture.record_plan.into()),
                     record_quality: Some(capture.record_quality.into()),
                     record_checked: capture.record_checked.map(Into::into),
@@ -1520,6 +1540,7 @@ impl MempalMcpServer {
                 .map_err(|error| ErrorData::invalid_params(error, None))?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1568,6 +1589,7 @@ impl MempalMcpServer {
                 };
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1608,6 +1630,7 @@ impl MempalMcpServer {
                 };
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: Some(check_runtime_adoption_record(&input).into()),
                     record_checked: None,
@@ -1679,6 +1702,7 @@ impl MempalMcpServer {
                 };
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: Some(
@@ -1743,6 +1767,7 @@ impl MempalMcpServer {
                 );
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1788,6 +1813,7 @@ impl MempalMcpServer {
                 };
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1838,6 +1864,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1871,6 +1898,7 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1907,6 +1935,7 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1928,6 +1957,7 @@ impl MempalMcpServer {
                 let gate = phase3_gate_report(&db, candidate)?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1949,6 +1979,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1970,6 +2001,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1989,7 +2021,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4310,7 +4342,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4369,6 +4401,49 @@ mod tests {
                     .feature_examples
                     .contains(&"include_cards".to_string())
         }));
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_instrumentation_policy_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "instrumentation_policy"
+            }))
+            .await
+            .expect("instrumentation policy");
+        let policy = response
+            .instrumentation_policy
+            .expect("instrumentation policy");
+        assert!(!policy.writes);
+        assert_eq!(policy.default_mode, "manual_only");
+        assert!(policy.allowed_modes.iter().any(|mode| {
+            mode.mode == "opt_in_wrapper" && mode.requires_execute && mode.requires_checked_capture
+        }));
+        assert!(
+            policy
+                .forbidden_modes
+                .contains(&"implicit_background_capture".to_string())
+        );
 
         let db = Database::open(&db_path).expect("reopen db");
         assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
@@ -4768,16 +4843,19 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=instrumentation_policy"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=default_proposal"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("live instrumentation is opt-in"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("checked capture"));
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL
                 .contains("used when guidance was actually consumed")

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2,6 +2,7 @@ use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
     Phase3ReadinessReport, ResearchCandidateInsightPlan, ResearchEvidenceDrawerPlan,
     ResearchIngestPlanReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
+    RuntimeAdoptionInstrumentationMode, RuntimeAdoptionInstrumentationPolicy,
     RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
     RuntimeAdoptionReviewReport, RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance,
     RuntimeAdoptionTrackGuidance,
@@ -347,6 +348,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guidance: Option<RuntimeAdoptionGuidanceDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub instrumentation_policy: Option<RuntimeAdoptionInstrumentationPolicyDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub record_plan: Option<RuntimeAdoptionRecordPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_quality: Option<RuntimeAdoptionRecordQualityDto>,
@@ -395,6 +398,25 @@ pub struct RuntimeAdoptionTrackGuidanceDto {
     pub track: String,
     pub when: String,
     pub feature_examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionInstrumentationPolicyDto {
+    pub version: u32,
+    pub writes: bool,
+    pub default_mode: String,
+    pub allowed_modes: Vec<RuntimeAdoptionInstrumentationModeDto>,
+    pub forbidden_modes: Vec<String>,
+    pub requirements: Vec<String>,
+    pub rollback_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionInstrumentationModeDto {
+    pub mode: String,
+    pub description: String,
+    pub requires_execute: bool,
+    pub requires_checked_capture: bool,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -657,6 +679,31 @@ impl From<RuntimeAdoptionTrackGuidance> for RuntimeAdoptionTrackGuidanceDto {
             track: guidance.track,
             when: guidance.when,
             feature_examples: guidance.feature_examples,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionInstrumentationPolicy> for RuntimeAdoptionInstrumentationPolicyDto {
+    fn from(policy: RuntimeAdoptionInstrumentationPolicy) -> Self {
+        Self {
+            version: policy.version,
+            writes: policy.writes,
+            default_mode: policy.default_mode,
+            allowed_modes: policy.allowed_modes.into_iter().map(Into::into).collect(),
+            forbidden_modes: policy.forbidden_modes,
+            requirements: policy.requirements,
+            rollback_requirements: policy.rollback_requirements,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionInstrumentationMode> for RuntimeAdoptionInstrumentationModeDto {
+    fn from(mode: RuntimeAdoptionInstrumentationMode) -> Self {
+        Self {
+            mode: mode.mode,
+            description: mode.description,
+            requires_execute: mode.requires_execute,
+            requires_checked_capture: mode.requires_checked_capture,
         }
     }
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -693,6 +693,90 @@ fn test_cli_phase3_adoption_guidance_rejects_invalid_format() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_instrumentation_policy_json_is_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "instrumentation-policy",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "instrumentation policy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let policy: Value = serde_json::from_slice(&output.stdout).expect("policy json");
+    assert_eq!(policy["writes"], false);
+    assert_eq!(policy["version"], 1);
+    assert_eq!(policy["default_mode"], "manual_only");
+    assert!(
+        policy["allowed_modes"]
+            .as_array()
+            .expect("allowed modes")
+            .iter()
+            .any(|mode| mode["mode"] == "opt_in_wrapper"
+                && mode["requires_execute"] == true
+                && mode["requires_checked_capture"] == true)
+    );
+    assert!(
+        policy["forbidden_modes"]
+            .as_array()
+            .expect("forbidden modes")
+            .iter()
+            .any(|mode| mode == "implicit_background_capture")
+    );
+    assert!(
+        policy["requirements"]
+            .as_array()
+            .expect("requirements")
+            .iter()
+            .any(|requirement| requirement
+                .as_str()
+                .expect("requirement")
+                .contains("opt-out"))
+    );
+    assert!(
+        policy["rollback_requirements"]
+            .as_array()
+            .expect("rollback requirements")
+            .iter()
+            .any(|requirement| requirement
+                .as_str()
+                .expect("rollback requirement")
+                .contains("rollback"))
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_instrumentation_policy_rejects_invalid_format() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "instrumentation-policy",
+            "--format",
+            "yaml",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 adoption format"));
+}
+
+#[test]
 fn test_cli_phase3_adoption_prepare_record_json_is_read_only() {
     let home = setup_cli_home();
     let output = run_mempal(


### PR DESCRIPTION
## Summary

- Add P77 spec and plan for the live adoption instrumentation boundary.
- Add read-only CLI `mempal phase3 adoption instrumentation-policy` and MCP `mempal_phase3 action=instrumentation_policy`.
- Define instrumentation policy: default `manual_only`, allow only `opt_in_wrapper`, forbid implicit/background capture, silent event append, and quality-gate bypass.
- Update Phase-3 protocol, inventories, and MIND-MODEL summary.

## Verification

- `agent-spec parse specs/p77-live-adoption-instrumentation-boundary.spec.md`
- `agent-spec lint specs/p77-live-adoption-instrumentation-boundary.spec.md --min-score 0.7`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_json_is_read_only`
- `cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_rejects_invalid_format`
- `cargo test mcp::server::tests::test_mcp_phase3_instrumentation_policy_action_is_read_only --lib`
- `cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib`
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy -- -D warnings`
- `cargo clippy --features rest -- -D warnings`
- `cargo test`
- `cargo test --features rest`
- `git diff --check`
