### PR TITLE
feat: gate card context default flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
+| `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -214,6 +215,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
+- `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
+| `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -212,6 +213,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
+- `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1556,8 +1556,20 @@ degrades behavior.
 
 Updated recommended next P candidates after completing P77:
 
-- P78 card context default-on runtime flag: implement an explicit, reversible
-  default-on switch only after a P74 proposal is ready.
+P78 card context default runtime flag implements the first actual default
+runtime change path for cards. The default remains `false` unless local config
+sets `context.include_cards_default=true`. `mempal context` and `mempal_context`
+use that config only when the request omits explicit card flags; CLI
+`--include-cards` still opts in, CLI `--no-include-cards` opts out, and MCP
+`include_cards` overrides config when supplied. The only supported write path is
+`mempal phase3 default-control card-context`: enabling requires the P74
+proposal-ready conditions, including sufficient `card_context/include_cards`
+runtime adoption evidence and rollback criteria; disabling is always allowed
+and writes the flag back to false. The command writes local config only and does
+not append runtime adoption events, change schema, or alter search defaults.
+
+Updated recommended next P candidates after completing P78:
+
 - P79 rollback executor contract: turn rollback criteria into a testable policy
   action that can revert a default/runtime policy change.
 - P80 autonomous promotion boundary audit: decide whether autonomous promotion is

--- a/docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md
+++ b/docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md
@@ -1,0 +1,40 @@
+# P78 Card Context Default Runtime Flag
+
+Goal: add an explicit, reversible runtime config flag for card-aware context
+defaults, gated by P74 proposal readiness when enabling.
+
+Spec: `specs/p78-card-context-default-runtime-flag.spec.md`
+
+## Steps
+
+- [x] Add P78 task contract and plan.
+- [x] Add failing context tests for config default false/true and explicit disable override.
+- [x] Add failing MCP context test for omitted `include_cards` using config default.
+- [x] Add failing Phase-3 default-control enable/disable tests.
+- [x] Add `context.include_cards_default` config load/save support.
+- [x] Wire CLI and MCP context default resolution.
+- [x] Implement `mempal phase3 default-control card-context` enable/disable.
+- [x] Update protocol text, AGENTS/CLAUDE inventories, and MIND-MODEL summary.
+- [x] Verify spec parse/lint, targeted tests, fmt/check/clippy/test, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p78-card-context-default-runtime-flag.spec.md
+agent-spec lint specs/p78-card-context-default-runtime-flag.spec.md --min-score 0.7
+cargo test --test context_assembler test_cli_context_config_default_false_omits_cards
+cargo test --test context_assembler test_cli_context_config_default_true_includes_cards
+cargo test --test context_assembler test_cli_context_no_include_cards_overrides_config_default_true
+cargo test mcp::server::tests::test_mcp_context_include_cards_omitted_uses_config_default --lib
+cargo test --test phase3_runtime test_cli_phase3_default_control_enable_requires_ready_proposal
+cargo test --test phase3_runtime test_cli_phase3_default_control_disable_is_reversible
+rg -n "p78-card-context-default-runtime-flag|P78 card context default runtime flag" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/specs/p78-card-context-default-runtime-flag.spec.md
+++ b/specs/p78-card-context-default-runtime-flag.spec.md
@@ -1,0 +1,142 @@
+spec: task
+name: "P78: card context default runtime flag"
+inherits: project
+tags: [phase-3, context, cards, default-policy]
+---
+
+## Intent
+
+P74 introduced a read-only default-on proposal for card-aware context, and P75
+left the actual default-on runtime change as an open gap. P78 adds an explicit,
+reversible runtime flag for card context defaults. The flag must remain disabled
+by default, must only be enabled through a proposal-ready Phase-3 control path,
+and must be overrideable per request.
+
+## Decisions
+
+- Add config field `context.include_cards_default`, defaulting to `false`.
+- `mempal context` uses `context.include_cards_default` when neither
+  `--include-cards` nor `--no-include-cards` is provided.
+- `mempal_context` uses `context.include_cards_default` when MCP
+  `include_cards` is omitted.
+- Add CLI `mempal phase3 default-control card-context`.
+- `default-control --enable` must require a P74-ready proposal: sufficient
+  card-context readiness plus at least one rollback criterion.
+- `default-control --disable` is always allowed and writes the flag back to
+  `false`.
+- The control command writes only the local mempal config file, not drawers,
+  runtime adoption events, cards, or schema.
+- P78 must leave its own spec and plan per the P76 invariant.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p78-card-context-default-runtime-flag.spec.md
+- docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md
+- src/core/config.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/core/protocol.rs
+- tests/context_assembler.rs
+- tests/phase3_runtime.rs
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+
+### Forbidden
+- Do not change search defaults.
+- Do not make card context default-on without config.
+- Do not enable the flag when P74 proposal readiness fails.
+- Do not add new database schema.
+- Do not append runtime adoption events from `default-control`.
+- Do not remove explicit `--include-cards` or MCP `include_cards=true`.
+
+## Acceptance Criteria
+
+Scenario: Config default keeps card context opt-in
+  Test:
+    Filter: cargo test --test context_assembler test_cli_context_config_default_false_omits_cards
+    Targets: CLI context default behavior.
+  Given no config file or a config with `context.include_cards_default=false`
+  And query text `card-aware`
+  When running `mempal context "card-aware" --format json` without card flags
+  Then the context response omits card sections
+
+Scenario: Config flag enables card context by default
+  Test:
+    Filter: cargo test --test context_assembler test_cli_context_config_default_true_includes_cards
+    Targets: CLI context config default.
+  Given a config with `context.include_cards_default=true`
+  And an active knowledge card with linked evidence exists
+  And query text `card-aware`
+  When running `mempal context "card-aware" --format json` without card flags
+  Then the context response includes card sections
+
+Scenario: CLI per-request no flag overrides config default
+  Test:
+    Filter: cargo test --test context_assembler test_cli_context_no_include_cards_overrides_config_default_true
+    Targets: CLI override behavior.
+  Given a config with `context.include_cards_default=true`
+  And query text `card-aware`
+  When running `mempal context "card-aware" --no-include-cards --format json`
+  Then the context response omits card sections
+
+Scenario: MCP omitted include_cards follows config default
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_context_include_cards_omitted_uses_config_default --lib
+    Targets: MCP context behavior.
+  Given an MCP server configured with `context.include_cards_default=true`
+  And a request omits `include_cards`
+  When calling `mempal_context`
+  Then the response includes card sections
+
+Scenario: Default control enables only after proposal is ready
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_control_enable_requires_ready_proposal
+    Targets: CLI default-control gate and config file side effect.
+  Given no accepted `card_context/include_cards` evidence
+  And rollback criterion text `disable if rollbacks appear`
+  When running `mempal phase3 default-control card-context --enable --rollback-criterion "disable if rollbacks appear" --format json`
+  Then the command reports `applied=false`
+  And `context.include_cards_default` remains false
+  Given three accepted `card_context/include_cards` events
+  When running the same enable command
+  Then it reports `applied=true`
+  And config `context.include_cards_default` becomes true
+
+Scenario: Default control writes config file on successful enable
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_control_enable_writes_config_file_output
+    Targets: Config file side effect.
+  Given three accepted `card_context/include_cards` events
+  And a rollback criterion value is provided
+  When running `mempal phase3 default-control card-context --enable --rollback-criterion "disable if rollbacks appear" --format json`
+  Then the local config file exists
+  And the file contains `include_cards_default = true`
+
+Scenario: Default control rejects unknown candidate without config write
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_control_rejects_unknown_candidate_without_config_write
+    Targets: CLI error path and config file side effect.
+  Given no config file exists
+  When running `mempal phase3 default-control unknown --enable --rollback-criterion "disable if rollbacks appear" --format json`
+  Then the command fails
+  And stderr includes `unsupported phase3 default-control candidate`
+  And no config file is created
+
+Scenario: Default control disable is reversible and read-model safe
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_control_disable_is_reversible
+    Targets: CLI default-control disable path.
+  Given config `context.include_cards_default=true`
+  When running `mempal phase3 default-control card-context --disable --format json`
+  Then it reports `applied=true`
+  And config `context.include_cards_default` becomes false
+  And no runtime adoption event is appended
+
+## Out of Scope
+
+- Implementing rollback executor policy.
+- Installing live instrumentation hooks.
+- Making search card-aware by default.
+- Adding new persistence schema.

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -2,17 +2,18 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 const DEFAULT_DB_PATH: &str = "~/.mempal/palace.db";
 const DEFAULT_EMBED_BACKEND: &str = "model2vec";
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     pub db_path: String,
     pub embed: EmbedConfig,
+    pub context: ContextConfig,
 }
 
 impl Default for Config {
@@ -20,6 +21,7 @@ impl Default for Config {
         Self {
             db_path: DEFAULT_DB_PATH.to_string(),
             embed: EmbedConfig::default(),
+            context: ContextConfig::default(),
         }
     }
 }
@@ -39,9 +41,27 @@ impl Config {
             }),
         }
     }
+
+    pub fn save_to(&self, path: &Path) -> Result<(), ConfigError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        let contents = toml::to_string_pretty(self)?;
+        fs::write(path, contents).map_err(|source| ConfigError::Write {
+            path: path.to_path_buf(),
+            source,
+        })
+    }
+
+    pub fn save_default(&self) -> Result<(), ConfigError> {
+        self.save_to(&default_config_path())
+    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct EmbedConfig {
     pub backend: String,
@@ -62,6 +82,12 @@ impl Default for EmbedConfig {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct ContextConfig {
+    pub include_cards_default: bool,
+}
+
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("failed to read config from {path}")]
@@ -70,8 +96,16 @@ pub enum ConfigError {
         #[source]
         source: std::io::Error,
     },
+    #[error("failed to write config to {path}")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("failed to parse config TOML")]
     Parse(#[from] toml::de::Error),
+    #[error("failed to serialize config TOML")]
+    Serialize(#[from] toml::ser::Error),
 }
 
 fn default_config_path() -> PathBuf {

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -232,6 +232,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    candidate=card-context to combine card-context readiness with explicit
    rollback criteria before writing a future default-on spec; it is read-only
    and does not change include_cards defaults. Use
+   CLI `mempal phase3 default-control card-context` to explicitly enable or
+   disable local card-context defaults: enable requires a proposal-ready P74
+   condition and rollback criteria, disable is always allowed, and the command
+   writes only local config (`context.include_cards_default`). Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,8 @@ enum Commands {
         include_evidence: bool,
         #[arg(long)]
         include_cards: bool,
+        #[arg(long, conflicts_with = "include_cards")]
+        no_include_cards: bool,
         #[arg(long, default_value_t = 12)]
         max_items: usize,
         #[arg(long = "dao-tian-limit", default_value_t = 1)]
@@ -588,6 +590,17 @@ enum Phase3Commands {
         #[arg(long, default_value = "plain")]
         format: String,
     },
+    DefaultControl {
+        candidate: String,
+        #[arg(long, conflicts_with = "disable")]
+        enable: bool,
+        #[arg(long, conflicts_with = "enable")]
+        disable: bool,
+        #[arg(long = "rollback-criterion")]
+        rollback_criteria: Vec<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     Gate {
         candidate: String,
         #[arg(long, default_value = "plain")]
@@ -969,6 +982,7 @@ async fn run() -> Result<()> {
             format,
             include_evidence,
             include_cards,
+            no_include_cards,
             max_items,
             dao_tian_limit,
         } => {
@@ -983,6 +997,7 @@ async fn run() -> Result<()> {
                     format,
                     include_evidence,
                     include_cards,
+                    no_include_cards,
                     max_items,
                     dao_tian_limit,
                 },
@@ -1039,6 +1054,7 @@ struct ContextCommandArgs {
     format: String,
     include_evidence: bool,
     include_cards: bool,
+    no_include_cards: bool,
     max_items: usize,
     dao_tian_limit: usize,
 }
@@ -1248,6 +1264,11 @@ async fn context_command(db: &Database, config: &Config, args: ContextCommandArg
     };
 
     let embedder = build_embedder(config).await?;
+    let include_cards = if args.no_include_cards {
+        false
+    } else {
+        args.include_cards || config.context.include_cards_default
+    };
     let pack = assemble_context(
         db,
         &*embedder,
@@ -1257,7 +1278,7 @@ async fn context_command(db: &Database, config: &Config, args: ContextCommandArg
             field: args.field,
             cwd,
             include_evidence: args.include_evidence,
-            include_cards: args.include_cards,
+            include_cards,
             max_items: args.max_items,
             dao_tian_limit: args.dao_tian_limit,
         },
@@ -2367,6 +2388,17 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
             let report = phase3_default_proposal(db, &candidate, rollback_criteria)?;
             print_card_context_default_proposal(&report, &format)
         }
+        Phase3Commands::DefaultControl {
+            candidate,
+            enable,
+            disable,
+            rollback_criteria,
+            format,
+        } => {
+            let report =
+                phase3_default_control(db, &candidate, enable, disable, rollback_criteria)?;
+            print_phase3_default_control(&report, &format)
+        }
         Phase3Commands::Gate { candidate, format } => {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
@@ -2406,6 +2438,73 @@ fn phase3_default_proposal(
             Ok(card_context_default_proposal(&events, rollback_criteria))
         }
         other => bail!("unsupported phase3 default proposal candidate: {other}"),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Phase3DefaultControlReport {
+    writes: bool,
+    candidate: String,
+    requested: String,
+    applied: bool,
+    include_cards_default: bool,
+    proposal: Option<CardContextDefaultProposalReport>,
+    reasons: Vec<String>,
+}
+
+fn phase3_default_control(
+    db: &Database,
+    candidate: &str,
+    enable: bool,
+    disable: bool,
+    rollback_criteria: Vec<String>,
+) -> Result<Phase3DefaultControlReport> {
+    if enable == disable {
+        bail!("exactly one of --enable or --disable is required");
+    }
+    match candidate {
+        "card-context" => {
+            let mut config = Config::load().context("failed to load config")?;
+            if disable {
+                config.context.include_cards_default = false;
+                config.save_default().context("failed to save config")?;
+                return Ok(Phase3DefaultControlReport {
+                    writes: true,
+                    candidate: candidate.to_string(),
+                    requested: "disable".to_string(),
+                    applied: true,
+                    include_cards_default: false,
+                    proposal: None,
+                    reasons: vec!["card context default disabled".to_string()],
+                });
+            }
+
+            let proposal = phase3_default_proposal(db, candidate, rollback_criteria)?;
+            if !proposal.proposal_ready {
+                return Ok(Phase3DefaultControlReport {
+                    writes: false,
+                    candidate: candidate.to_string(),
+                    requested: "enable".to_string(),
+                    applied: false,
+                    include_cards_default: config.context.include_cards_default,
+                    proposal: Some(proposal),
+                    reasons: vec!["default-on proposal is not ready".to_string()],
+                });
+            }
+
+            config.context.include_cards_default = true;
+            config.save_default().context("failed to save config")?;
+            Ok(Phase3DefaultControlReport {
+                writes: true,
+                candidate: candidate.to_string(),
+                requested: "enable".to_string(),
+                applied: true,
+                include_cards_default: true,
+                proposal: Some(proposal),
+                reasons: vec!["card context default enabled".to_string()],
+            })
+        }
+        other => bail!("unsupported phase3 default-control candidate: {other}"),
     }
 }
 
@@ -3515,6 +3614,31 @@ fn print_card_context_default_proposal(
             Ok(())
         }
         other => bail!("unsupported phase3 default proposal format: {other}"),
+    }
+}
+
+fn print_phase3_default_control(report: &Phase3DefaultControlReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("candidate={}", report.candidate);
+            println!("requested={}", report.requested);
+            println!("applied={}", report.applied);
+            println!("include_cards_default={}", report.include_cards_default);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize phase3 default control report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 default control format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -81,6 +81,7 @@ use super::tools::{
 #[derive(Clone)]
 pub struct MempalMcpServer {
     db_path: PathBuf,
+    config: crate::core::config::Config,
     embedder_factory: Arc<dyn EmbedderFactory>,
     tool_router: ToolRouter<Self>,
     /// Captured via `initialize` override so `auto` peek mode can infer the
@@ -90,15 +91,33 @@ pub struct MempalMcpServer {
 
 impl MempalMcpServer {
     pub fn new(db_path: PathBuf, config: crate::core::config::Config) -> Self {
-        Self::new_with_factory(
+        let embedder_factory =
+            Arc::new(crate::embed::ConfiguredEmbedderFactory::new(config.clone()));
+        Self {
             db_path,
-            Arc::new(crate::embed::ConfiguredEmbedderFactory::new(config)),
-        )
+            config,
+            embedder_factory,
+            tool_router: Self::tool_router(),
+            client_name: Arc::new(Mutex::new(None)),
+        }
     }
 
     pub fn new_with_factory(db_path: PathBuf, embedder_factory: Arc<dyn EmbedderFactory>) -> Self {
+        Self::new_with_config_and_factory(
+            db_path,
+            crate::core::config::Config::default(),
+            embedder_factory,
+        )
+    }
+
+    pub fn new_with_config_and_factory(
+        db_path: PathBuf,
+        config: crate::core::config::Config,
+        embedder_factory: Arc<dyn EmbedderFactory>,
+    ) -> Self {
         Self {
             db_path,
+            config,
             embedder_factory,
             tool_router: Self::tool_router(),
             client_name: Arc::new(Mutex::new(None)),
@@ -1020,7 +1039,9 @@ impl MempalMcpServer {
                     .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
                 cwd,
                 include_evidence: request.include_evidence.unwrap_or(false),
-                include_cards: request.include_cards.unwrap_or(false),
+                include_cards: request
+                    .include_cards
+                    .unwrap_or(self.config.context.include_cards_default),
                 max_items,
                 dao_tian_limit,
             },
@@ -3058,6 +3079,21 @@ mod tests {
         (tempdir, db_path, server)
     }
 
+    fn setup_server_with_config(
+        config: crate::core::config::Config,
+    ) -> (TempDir, PathBuf, MempalMcpServer) {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let server = MempalMcpServer::new_with_config_and_factory(
+            db_path.clone(),
+            config,
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        );
+        (tempdir, db_path, server)
+    }
+
     fn knowledge_card(
         id: &str,
         tier: KnowledgeTier,
@@ -3621,6 +3657,51 @@ mod tests {
         assert_eq!(
             card.evidence_citations[0].source_file,
             "/tmp/card-evidence.md"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_include_cards_omitted_uses_config_default() {
+        let mut config = crate::core::config::Config::default();
+        config.context.include_cards_default = true;
+        let (_tempdir, db_path, server) = setup_server_with_config(config);
+        insert_drawer(
+            &db_path,
+            "drawer_card_default_evidence",
+            "card evidence",
+            "mempal",
+            Some("context"),
+            "/tmp/card-default-evidence.md",
+            2,
+        );
+        let mut card = knowledge_card(
+            "card_context_default",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "general",
+        );
+        card.anchor_id = anchor::LEGACY_REPO_ANCHOR_ID.to_string();
+        insert_knowledge_card(&db_path, card);
+        insert_knowledge_card_link(
+            &db_path,
+            "link_card_context_default_supporting",
+            "card_context_default",
+            "drawer_card_default_evidence",
+            KnowledgeEvidenceRole::Supporting,
+        );
+
+        let response = server
+            .context_json_for_test(serde_json::json!({
+                "query": "card context"
+            }))
+            .await
+            .expect("context should succeed");
+        assert!(
+            response
+                .sections
+                .iter()
+                .flat_map(|section| section.items.iter())
+                .any(|item| item.card_id.as_deref() == Some("card_context_default"))
         );
     }
 

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -254,13 +254,27 @@ fn start_openai_embedding_stub(
 
 fn write_cli_api_config(home: &Path, endpoint: &str) {
     let config_path = home.join(".mempal").join("config.toml");
+    let existing = fs::read_to_string(&config_path).unwrap_or_default();
+    let prefix = if existing.trim().is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", existing.trim_end())
+    };
     fs::write(
         config_path,
         format!(
-            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+            "{prefix}[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
         ),
     )
     .expect("write cli config");
+}
+
+fn write_context_default_config(home: &Path, include_cards_default: bool) {
+    fs::write(
+        home.join(".mempal").join("config.toml"),
+        format!("[context]\ninclude_cards_default = {include_cards_default}\n"),
+    )
+    .expect("write context config");
 }
 
 fn run_context_json(home: &Path, query: &str, extra_args: &[&str]) -> Value {
@@ -759,6 +773,115 @@ fn test_cli_context_include_cards_json() {
         card["evidence_citations"][0]["source_file"],
         "tests://context/drawer_card_evidence"
     );
+}
+
+#[test]
+fn test_cli_context_config_default_false_omits_cards() {
+    let (tmp, db) = setup_cli_home();
+    write_context_default_config(tmp.path(), false);
+    insert_fixture(
+        &db,
+        &evidence_drawer("drawer_card_default_false", "card evidence source"),
+    );
+    insert_card(
+        &db,
+        &knowledge_card(
+            "card_default_false",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Config false keeps card context opt-in.",
+        ),
+    );
+    insert_card_link(
+        &db,
+        "link_card_default_false",
+        "card_default_false",
+        "drawer_card_default_false",
+        KnowledgeEvidenceRole::Supporting,
+    );
+
+    let value = run_context_json(tmp.path(), "card-aware", &[]);
+    let items = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .collect::<Vec<_>>();
+    assert!(items.iter().all(|item| item["card_id"].is_null()));
+}
+
+#[test]
+fn test_cli_context_config_default_true_includes_cards() {
+    let (tmp, db) = setup_cli_home();
+    write_context_default_config(tmp.path(), true);
+    insert_fixture(
+        &db,
+        &evidence_drawer("drawer_card_default_true", "card evidence source"),
+    );
+    insert_card(
+        &db,
+        &knowledge_card(
+            "card_default_true",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Config true includes card context by default.",
+        ),
+    );
+    insert_card_link(
+        &db,
+        "link_card_default_true",
+        "card_default_true",
+        "drawer_card_default_true",
+        KnowledgeEvidenceRole::Supporting,
+    );
+
+    let value = run_context_json(tmp.path(), "card-aware", &[]);
+    let items = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .collect::<Vec<_>>();
+    assert!(
+        items
+            .iter()
+            .any(|item| item["card_id"] == "card_default_true")
+    );
+}
+
+#[test]
+fn test_cli_context_no_include_cards_overrides_config_default_true() {
+    let (tmp, db) = setup_cli_home();
+    write_context_default_config(tmp.path(), true);
+    insert_fixture(
+        &db,
+        &evidence_drawer("drawer_card_no_override", "card evidence source"),
+    );
+    insert_card(
+        &db,
+        &knowledge_card(
+            "card_no_override",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "No include cards flag overrides config true.",
+        ),
+    );
+    insert_card_link(
+        &db,
+        "link_card_no_override",
+        "card_no_override",
+        "drawer_card_no_override",
+        KnowledgeEvidenceRole::Supporting,
+    );
+
+    let value = run_context_json(tmp.path(), "card-aware", &["--no-include-cards"]);
+    let items = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .collect::<Vec<_>>();
+    assert!(items.iter().all(|item| item["card_id"].is_null()));
 }
 
 #[test]

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -181,6 +181,12 @@ fn write_cli_api_config(home: &TempDir, endpoint: &str) {
     .expect("write config");
 }
 
+fn read_include_cards_default(home: &TempDir) -> bool {
+    let config = mempal::core::config::Config::load_from(&home.path().join(".mempal/config.toml"))
+        .expect("load config");
+    config.context.include_cards_default
+}
+
 #[test]
 fn test_runtime_adoption_event_roundtrip_db() {
     let tmp = TempDir::new().expect("tempdir");
@@ -526,6 +532,145 @@ fn test_cli_phase3_default_proposal_rejects_unknown_candidate() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unsupported phase3 default proposal candidate"));
+}
+
+#[test]
+fn test_cli_phase3_default_control_enable_requires_ready_proposal() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "card-context",
+            "--enable",
+            "--rollback-criterion",
+            "disable if rollbacks appear",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "default control failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("control json");
+    assert_eq!(report["applied"], false);
+    assert_eq!(report["include_cards_default"], false);
+    assert!(!read_include_cards_default(&home));
+
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("control_accept_{i}"));
+    }
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "card-context",
+            "--enable",
+            "--rollback-criterion",
+            "disable if rollbacks appear",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "default control enable failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("control json");
+    assert_eq!(report["applied"], true);
+    assert_eq!(report["include_cards_default"], true);
+    assert!(read_include_cards_default(&home));
+}
+
+#[test]
+fn test_cli_phase3_default_control_enable_writes_config_file_output() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("control_file_accept_{i}"));
+    }
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "card-context",
+            "--enable",
+            "--rollback-criterion",
+            "disable if rollbacks appear",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "default control enable failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let contents =
+        fs::read_to_string(home.path().join(".mempal/config.toml")).expect("read config");
+    assert!(contents.contains("include_cards_default = true"));
+}
+
+#[test]
+fn test_cli_phase3_default_control_rejects_unknown_candidate_without_config_write() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "unknown",
+            "--enable",
+            "--rollback-criterion",
+            "disable if rollbacks appear",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 default-control candidate"));
+    assert!(!home.path().join(".mempal/config.toml").exists());
+}
+
+#[test]
+fn test_cli_phase3_default_control_disable_is_reversible() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = true\n",
+    )
+    .expect("write config");
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "card-context",
+            "--disable",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "default control disable failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("control json");
+    assert_eq!(report["applied"], true);
+    assert_eq!(report["include_cards_default"], false);
+    assert!(!read_include_cards_default(&home));
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add P78 spec and plan for the card context default runtime flag
- add explicit reversible `mempal phase3 default-control card-context --enable|--disable`
- make CLI/MCP context use `context.include_cards_default` only when request flags omit an explicit choice

## Validation

- `agent-spec parse specs/p78-card-context-default-runtime-flag.spec.md`
- `agent-spec lint specs/p78-card-context-default-runtime-flag.spec.md --min-score 0.7`
- targeted P78 context/default-control/MCP tests
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy -- -D warnings`
- `cargo clippy --features rest -- -D warnings`
- `cargo test`
- `cargo test --features rest`
- `git diff --check`
