### PR TITLE
feat: add rollback control policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
+| `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -216,6 +217,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
+- `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
+| `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -214,6 +215,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
+- `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1570,8 +1570,17 @@ not append runtime adoption events, change schema, or alter search defaults.
 
 Updated recommended next P candidates after completing P78:
 
-- P79 rollback executor contract: turn rollback criteria into a testable policy
-  action that can revert a default/runtime policy change.
+- P79 rollback executor policy implements the first concrete rollback executor
+  for default/runtime policy changes. CLI `mempal phase3 rollback-control
+  card-context` evaluates `card_context/include_cards` rollback evidence and,
+  only with `--execute`, writes local config
+  `context.include_cards_default=false`. MCP `mempal_phase3
+  action=rollback_control` exposes the same rollback evidence check as a
+  read-only agent surface. No runtime adoption events, knowledge lifecycle
+  state, schema, or search defaults are changed by rollback control.
+
+Updated recommended next P candidates after completing P79:
+
 - P80 autonomous promotion boundary audit: decide whether autonomous promotion is
   actually desired, or explicitly declare human-gated governance as the final
   design boundary.

--- a/docs/plans/2026-05-13-p79-rollback-executor-policy.md
+++ b/docs/plans/2026-05-13-p79-rollback-executor-policy.md
@@ -1,0 +1,34 @@
+# P79 Rollback Executor Policy
+
+Spec: `specs/p79-rollback-executor-policy.spec.md`
+
+## Checklist
+
+- [x] Add P79 task contract and plan.
+- [x] Add core rollback-control report logic for `card-context`.
+- [x] Add CLI `mempal phase3 rollback-control card-context`.
+- [x] Add MCP `mempal_phase3 action=rollback_control`.
+- [x] Update protocol, AGENTS/CLAUDE inventory, and MIND-MODEL-DESIGN.
+- [x] Verify spec parse/lint, targeted tests, fmt/check/clippy/test, and diff check.
+
+## Verification
+
+```bash
+agent-spec parse specs/p79-rollback-executor-policy.spec.md
+agent-spec lint specs/p79-rollback-executor-policy.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_check_is_read_only
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_disables_default
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_without_signal_is_noop
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_already_disabled_is_noop
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_rejects_unknown_candidate_without_config_write
+cargo test mcp::server::tests::test_mcp_phase3_rollback_control_check_is_read_only --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+cargo test --features rest
+git diff --check
+```

--- a/specs/p79-rollback-executor-policy.spec.md
+++ b/specs/p79-rollback-executor-policy.spec.md
@@ -1,0 +1,151 @@
+spec: task
+name: "P79: rollback executor policy"
+inherits: project
+tags: [phase-3, rollback, context, cards]
+---
+
+## Intent
+
+P78 added an explicit default runtime flag for card-aware context, but rollback
+criteria were still mostly advisory: operators could disable the flag manually,
+yet there was no deterministic executor that converted rollback evidence into a
+policy action. P79 adds the smallest safe rollback executor for the existing
+`card-context` default flag: evaluate runtime adoption evidence, report whether
+rollback is required, and optionally disable the local config flag when
+`--execute` is explicitly supplied.
+
+## Decisions
+
+- P79 must leave its own spec and plan per the P76 invariant.
+- The only supported P79 candidate is `card-context`; it maps to
+  `context.include_cards_default`.
+- Rollback evidence is read from `runtime_adoption_events` with
+  `track=card_context`, `feature=include_cards`, and `signal=rollback`.
+- Rollback executor is safe-by-default: without `--execute`, it is read-only and
+  must not write config or DB state.
+- With `--execute`, rollback may only write local config and set
+  `context.include_cards_default=false`; it must not append runtime adoption
+  events or alter knowledge lifecycle state.
+- If `context.include_cards_default` is already false, rollback execution is a
+  no-op and must still report `applied=false`.
+- The executor should be exposed through CLI `mempal phase3 rollback-control`
+  and MCP `mempal_phase3 action=rollback_control`.
+- Unknown candidates must fail before writing config.
+
+## Boundaries
+
+### Allowed Changes
+
+- specs/p79-rollback-executor-policy.spec.md
+- docs/plans/2026-05-13-p79-rollback-executor-policy.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/core/phase3.rs
+- src/core/protocol.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+
+- Do not change SQLite schema.
+- Do not create a generic rollback engine for unrelated candidates.
+- Do not enable or disable card context automatically in background.
+- Do not make `mempal context` include cards by default without config.
+- Do not write runtime adoption events from rollback execution.
+- Do not alter knowledge card lifecycle promotion or demotion rules.
+
+## Acceptance Criteria
+
+Scenario: CLI rollback check is read-only without execute
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_check_is_read_only
+    Targets: CLI rollback-control read-only behavior.
+  Given `context.include_cards_default=true`
+  And rollback evidence exists for `card_context/include_cards`
+  When running `mempal phase3 rollback-control card-context --format json`
+  Then the command succeeds
+  And JSON reports `writes=false`
+  And JSON reports `rollback_required=true`
+  And JSON reports `applied=false`
+  And the config file still contains `include_cards_default = true`
+
+Scenario: CLI rollback execute disables card context default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_disables_default
+    Targets: CLI rollback-control config side effect.
+  Given `context.include_cards_default=true`
+  And rollback evidence exists for `card_context/include_cards`
+  When running `mempal phase3 rollback-control card-context --execute --format json`
+  Then the command succeeds
+  And JSON reports `writes=true`
+  And JSON reports `rollback_required=true`
+  And JSON reports `applied=true`
+  And the config file contains `include_cards_default = false`
+
+Scenario: CLI rollback execute is no-op without rollback evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_without_signal_is_noop
+    Targets: CLI rollback-control no-signal behavior.
+  Given `context.include_cards_default=true`
+  And no rollback evidence exists for `card_context/include_cards`
+  When running `mempal phase3 rollback-control card-context --execute --format json`
+  Then the command succeeds
+  And JSON reports `writes=false`
+  And JSON reports `rollback_required=false`
+  And JSON reports `applied=false`
+  And the config file still contains `include_cards_default = true`
+
+Scenario: CLI rollback execute is no-op when already disabled
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_already_disabled_is_noop
+    Targets: CLI rollback-control disabled-state behavior.
+  Given `context.include_cards_default=false`
+  And rollback evidence exists for `card_context/include_cards`
+  When running `mempal phase3 rollback-control card-context --execute --format json`
+  Then the command succeeds
+  And JSON reports `writes=false`
+  And JSON reports `rollback_required=true`
+  And JSON reports `applied=false`
+  And the config file still contains `include_cards_default = false`
+
+Scenario: CLI rejects unknown rollback candidate without config write
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_rejects_unknown_candidate_without_config_write
+    Targets: CLI rollback-control error behavior.
+  Given no config file exists
+  When running `mempal phase3 rollback-control unknown --execute --format json`
+  Then the command fails
+  And stderr contains `unsupported phase3 rollback-control candidate`
+  And no config file is created
+
+Scenario: MCP rollback control check is read-only
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_rollback_control_check_is_read_only --lib
+    Targets: MCP rollback-control read-only behavior.
+  Given `mempal_phase3` receives action `rollback_control`
+  And candidate `card-context`
+  And execute is omitted
+  And rollback evidence exists for `card_context/include_cards`
+  When the tool returns a response
+  Then `rollback_control.writes=false`
+  And `rollback_control.rollback_required=true`
+  And `rollback_control.applied=false`
+
+Scenario: MCP tool registry documents rollback control
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+    Targets: MCP tool registry and memory protocol.
+  Given the MCP tool registry is listed
+  When inspecting `mempal_phase3`
+  Then its description contains `rollback_control`
+  And the memory protocol contains `action=rollback_control`
+
+## Out of Scope
+
+- Multi-candidate rollback policy.
+- Background rollback daemon or hook.
+- Automatic rollback based on live agent behavior without explicit `execute`.
+- Runtime adoption event mutation, deletion, or synthesis.

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -131,6 +131,19 @@ pub struct CardContextDefaultProposalReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CardContextRollbackControlReport {
+    pub writes: bool,
+    pub candidate: String,
+    pub execute: bool,
+    pub rollback_required: bool,
+    pub applied: bool,
+    pub include_cards_default_before: bool,
+    pub include_cards_default_after: bool,
+    pub review: RuntimeAdoptionReviewReport,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
     pub feature: Option<String>,
@@ -585,6 +598,52 @@ pub fn card_context_default_proposal(
         .to_string(),
         readiness,
         rollback_criteria,
+        reasons,
+    }
+}
+
+pub fn card_context_rollback_control(
+    events: &[RuntimeAdoptionEvent],
+    include_cards_default: bool,
+    execute: bool,
+) -> CardContextRollbackControlReport {
+    let review = review_runtime_adoption_events(
+        events,
+        RuntimeAdoptionReviewFilters {
+            track: Some("card_context".to_string()),
+            feature: Some("include_cards".to_string()),
+            signal: Some("rollback".to_string()),
+            limit: 10_000,
+        },
+    );
+    let rollback_required = review.stats.rollbacks > 0;
+    let applied = execute && rollback_required && include_cards_default;
+    let include_cards_default_after = include_cards_default && !applied;
+    let mut reasons = Vec::new();
+    if rollback_required {
+        reasons.push("rollback evidence exists for card_context/include_cards".to_string());
+    } else {
+        reasons.push("no rollback evidence exists for card_context/include_cards".to_string());
+    }
+    if !execute {
+        reasons.push("execute=false leaves config unchanged".to_string());
+    } else if applied {
+        reasons.push("card context default disabled by rollback control".to_string());
+    } else if !include_cards_default {
+        reasons.push("card context default already disabled".to_string());
+    } else {
+        reasons.push("rollback not required; config unchanged".to_string());
+    }
+
+    CardContextRollbackControlReport {
+        writes: applied,
+        candidate: "card-context".to_string(),
+        execute,
+        rollback_required,
+        applied,
+        include_cards_default_before: include_cards_default,
+        include_cards_default_after,
+        review,
         reasons,
     }
 }

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=instrumentation_policy before building live tool instrumentation:
@@ -236,6 +236,11 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    disable local card-context defaults: enable requires a proposal-ready P74
    condition and rollback criteria, disable is always allowed, and the command
    writes only local config (`context.include_cards_default`). Use
+   action=rollback_control or CLI `mempal phase3 rollback-control card-context`
+   to evaluate rollback evidence for the card-context default. The CLI executor
+   is read-only unless `--execute` is supplied; when executed, it only sets local
+   config `context.include_cards_default=false` and does not append runtime
+   adoption events or alter knowledge lifecycle state. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,
@@ -265,7 +270,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,15 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        CardContextDefaultProposalReport, EvaluatorAdviceInput, EvaluatorAdviceReport,
-        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCaptureInput,
-        RuntimeAdoptionCaptureReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
-        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
-        RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
-        capture_runtime_adoption_record_input, card_context_default_proposal,
-        card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
+        CardContextDefaultProposalReport, CardContextRollbackControlReport, EvaluatorAdviceInput,
+        EvaluatorAdviceReport, Phase3ReadinessReport, ResearchIngestPlanReport,
+        RuntimeAdoptionCaptureInput, RuntimeAdoptionCaptureReport,
+        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
+        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
+        build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
+        card_context_default_proposal, card_context_default_readiness,
+        card_context_rollback_control, check_runtime_adoption_record, evaluator_advice,
         prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
         review_runtime_adoption_events, runtime_adoption_guidance,
         runtime_adoption_instrumentation_policy, should_write_checked_record,
@@ -598,6 +599,13 @@ enum Phase3Commands {
         disable: bool,
         #[arg(long = "rollback-criterion")]
         rollback_criteria: Vec<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    RollbackControl {
+        candidate: String,
+        #[arg(long)]
+        execute: bool,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2399,6 +2407,14 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
                 phase3_default_control(db, &candidate, enable, disable, rollback_criteria)?;
             print_phase3_default_control(&report, &format)
         }
+        Phase3Commands::RollbackControl {
+            candidate,
+            execute,
+            format,
+        } => {
+            let report = phase3_rollback_control(db, &candidate, execute)?;
+            print_phase3_rollback_control(&report, &format)
+        }
         Phase3Commands::Gate { candidate, format } => {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
@@ -2505,6 +2521,38 @@ fn phase3_default_control(
             })
         }
         other => bail!("unsupported phase3 default-control candidate: {other}"),
+    }
+}
+
+fn phase3_rollback_control(
+    db: &Database,
+    candidate: &str,
+    execute: bool,
+) -> Result<CardContextRollbackControlReport> {
+    match candidate {
+        "card-context" => {
+            let mut config = Config::load().context("failed to load config")?;
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: Some(RuntimeAdoptionTrack::CardContext),
+                        feature: Some("include_cards".to_string()),
+                    },
+                    10_000,
+                )
+                .context("failed to list runtime adoption events")?;
+            let report = card_context_rollback_control(
+                &events,
+                config.context.include_cards_default,
+                execute,
+            );
+            if report.applied {
+                config.context.include_cards_default = false;
+                config.save_default().context("failed to save config")?;
+            }
+            Ok(report)
+        }
+        other => bail!("unsupported phase3 rollback-control candidate: {other}"),
     }
 }
 
@@ -3639,6 +3687,43 @@ fn print_phase3_default_control(report: &Phase3DefaultControlReport, format: &st
             Ok(())
         }
         other => bail!("unsupported phase3 default control format: {other}"),
+    }
+}
+
+fn print_phase3_rollback_control(
+    report: &CardContextRollbackControlReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("candidate={}", report.candidate);
+            println!("execute={}", report.execute);
+            println!("rollback_required={}", report.rollback_required);
+            println!("applied={}", report.applied);
+            println!(
+                "include_cards_default_before={}",
+                report.include_cards_default_before
+            );
+            println!(
+                "include_cards_default_after={}",
+                report.include_cards_default_after
+            );
+            println!("rollback_events={}", report.review.stats.rollbacks);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize phase3 rollback control report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 rollback-control format: {other}"),
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10,8 +10,9 @@ use crate::core::{
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
         build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
         card_context_default_proposal, card_context_default_readiness,
-        check_runtime_adoption_record, evaluator_advice, prepare_runtime_adoption_capture,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        card_context_rollback_control, check_runtime_adoption_record, evaluator_advice,
+        prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
         runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     types::{
@@ -1371,7 +1372,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; instrumentation_policy defines opt-in live instrumentation boundaries without writing; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; instrumentation_policy defines opt-in live instrumentation boundaries without writing; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; rollback_control evaluates card-context rollback evidence without writing; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1397,6 +1398,7 @@ impl MempalMcpServer {
                 research_ingest_plan: None,
                 evaluator_advice: None,
                 default_proposal: None,
+                rollback_control: None,
             })),
             "instrumentation_policy" => Ok(Json(Phase3Response {
                 guidance: None,
@@ -1414,6 +1416,7 @@ impl MempalMcpServer {
                 research_ingest_plan: None,
                 evaluator_advice: None,
                 default_proposal: None,
+                rollback_control: None,
             })),
             "prepare_record" => {
                 let track = parse_runtime_adoption_track(required_string(
@@ -1454,6 +1457,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "capture" => {
@@ -1538,6 +1542,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "evaluator_advise" => {
@@ -1575,6 +1580,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: Some(report.into()),
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "default_proposal" => {
@@ -1624,6 +1630,64 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: Some(report.into()),
+                    rollback_control: None,
+                }))
+            }
+            "rollback_control" => {
+                let candidate = required_string(request.candidate.as_deref(), "candidate")?;
+                let report = match candidate {
+                    "card-context" => {
+                        if request.execute.unwrap_or(false) {
+                            return Err(ErrorData::invalid_params(
+                                "rollback_control execute is only supported by CLI in P79",
+                                None,
+                            ));
+                        }
+                        let db = self.open_db()?;
+                        let events = db
+                            .list_runtime_adoption_events(
+                                &RuntimeAdoptionFilter {
+                                    track: Some(RuntimeAdoptionTrack::CardContext),
+                                    feature: Some("include_cards".to_string()),
+                                },
+                                10_000,
+                            )
+                            .map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("failed to list runtime adoption events: {error}"),
+                                    None,
+                                )
+                            })?;
+                        card_context_rollback_control(
+                            &events,
+                            self.config.context.include_cards_default,
+                            false,
+                        )
+                    }
+                    other => {
+                        return Err(ErrorData::invalid_params(
+                            format!("unsupported phase3 rollback-control candidate: {other}"),
+                            None,
+                        ));
+                    }
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    instrumentation_policy: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                    evaluator_advice: None,
+                    default_proposal: None,
+                    rollback_control: Some(report.into()),
                 }))
             }
             "check_record" => {
@@ -1665,6 +1729,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "record_checked" => {
@@ -1745,6 +1810,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "review" => {
@@ -1802,6 +1868,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "readiness" => {
@@ -1848,6 +1915,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "record" => {
@@ -1899,6 +1967,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "list" => {
@@ -1936,6 +2005,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "stats" => {
@@ -1970,6 +2040,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "gate" => {
@@ -1992,6 +2063,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "research_validate_plan" => {
@@ -2014,6 +2086,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "research_ingest_plan" => {
@@ -2038,11 +2111,12 @@ impl MempalMcpServer {
                     )),
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, rollback_control, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4423,7 +4497,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, rollback_control, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4913,6 +4987,57 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_rollback_control_check_is_read_only() {
+        let mut config = crate::core::config::Config::default();
+        config.context.include_cards_default = true;
+        let (_tempdir, db_path, server) = setup_server_with_config(config);
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                id: "rollback_control_event".to_string(),
+                track: RuntimeAdoptionTrack::CardContext,
+                signal: RuntimeAdoptionSignal::Rollback,
+                feature: "include_cards".to_string(),
+                query: None,
+                context_hash: None,
+                card_id: None,
+                evaluator_id: None,
+                research_report_id: None,
+                note: Some("reverted default".to_string()),
+                metadata: None,
+                created_at: "1777710000".to_string(),
+            })
+            .expect("insert event");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "rollback_control",
+                "candidate": "card-context"
+            }))
+            .await
+            .expect("rollback control");
+        let report = response.rollback_control.expect("rollback control");
+        assert!(!report.writes);
+        assert!(report.rollback_required);
+        assert!(!report.applied);
+        assert!(report.include_cards_default_before);
+        assert!(report.include_cards_default_after);
+        assert_eq!(report.review.stats.rollbacks, 1);
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -4924,7 +5049,7 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
@@ -4933,6 +5058,7 @@ mod tests {
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=default_proposal"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=rollback_control"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("live instrumentation is opt-in"));

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -375,6 +375,8 @@ pub struct Phase3Response {
     pub evaluator_advice: Option<EvaluatorAdviceDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_proposal: Option<CardContextDefaultProposalDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rollback_control: Option<CardContextRollbackControlDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -521,6 +523,19 @@ pub struct CardContextDefaultProposalDto {
     pub reasons: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CardContextRollbackControlDto {
+    pub writes: bool,
+    pub candidate: String,
+    pub execute: bool,
+    pub rollback_required: bool,
+    pub applied: bool,
+    pub include_cards_default_before: bool,
+    pub include_cards_default_after: bool,
+    pub review: RuntimeAdoptionReviewReportDto,
+    pub reasons: Vec<String>,
+}
+
 impl From<crate::core::phase3::CardContextDefaultProposalReport> for CardContextDefaultProposalDto {
     fn from(report: crate::core::phase3::CardContextDefaultProposalReport) -> Self {
         Self {
@@ -530,6 +545,22 @@ impl From<crate::core::phase3::CardContextDefaultProposalReport> for CardContext
             decision: report.decision,
             readiness: report.readiness.into(),
             rollback_criteria: report.rollback_criteria,
+            reasons: report.reasons,
+        }
+    }
+}
+
+impl From<crate::core::phase3::CardContextRollbackControlReport> for CardContextRollbackControlDto {
+    fn from(report: crate::core::phase3::CardContextRollbackControlReport) -> Self {
+        Self {
+            writes: report.writes,
+            candidate: report.candidate,
+            execute: report.execute,
+            rollback_required: report.rollback_required,
+            applied: report.applied,
+            include_cards_default_before: report.include_cards_default_before,
+            include_cards_default_after: report.include_cards_default_after,
+            review: report.review.into(),
             reasons: report.reasons,
         }
     }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -57,6 +57,32 @@ fn record_card_context_acceptance(home: &TempDir, id: &str) {
     );
 }
 
+fn record_card_context_rollback(home: &TempDir, id: &str) {
+    let output = run_mempal(
+        home,
+        &[
+            "phase3",
+            "adoption",
+            "record",
+            "--id",
+            id,
+            "--track",
+            "card_context",
+            "--signal",
+            "rollback",
+            "--feature",
+            "include_cards",
+            "--note",
+            "reverted card context default",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn insert_test_card(home: &TempDir, card_id: &str) {
     let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
     db.insert_knowledge_card(&KnowledgeCard {
@@ -671,6 +697,161 @@ fn test_cli_phase3_default_control_disable_is_reversible() {
         .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
         .expect("list events");
     assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_check_is_read_only() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = true\n",
+    )
+    .expect("write config");
+    record_card_context_rollback(&home, "rollback_check_1");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "card-context",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "rollback control failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("rollback json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["rollback_required"], true);
+    assert_eq!(report["applied"], false);
+    assert!(read_include_cards_default(&home));
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_execute_disables_default() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = true\n",
+    )
+    .expect("write config");
+    record_card_context_rollback(&home, "rollback_execute_1");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "card-context",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "rollback control execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("rollback json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["rollback_required"], true);
+    assert_eq!(report["applied"], true);
+    assert!(!read_include_cards_default(&home));
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_execute_without_signal_is_noop() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = true\n",
+    )
+    .expect("write config");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "card-context",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "rollback control execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("rollback json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["rollback_required"], false);
+    assert_eq!(report["applied"], false);
+    assert!(read_include_cards_default(&home));
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_execute_already_disabled_is_noop() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = false\n",
+    )
+    .expect("write config");
+    record_card_context_rollback(&home, "rollback_disabled_1");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "card-context",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "rollback control execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("rollback json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["rollback_required"], true);
+    assert_eq!(report["applied"], false);
+    assert!(!read_include_cards_default(&home));
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_rejects_unknown_candidate_without_config_write() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "unknown",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 rollback-control candidate"));
+    assert!(!home.path().join(".mempal/config.toml").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add P79 spec and plan for rollback executor policy
- add CLI `mempal phase3 rollback-control card-context` with read-only default and explicit `--execute` config rollback
- add MCP `mempal_phase3 action=rollback_control` as a read-only rollback evidence check

## Boundaries

- no schema changes
- no background rollback
- no runtime adoption event writes from rollback execution
- no knowledge lifecycle mutation

## Validation

- `agent-spec parse specs/p79-rollback-executor-policy.spec.md`
- `agent-spec lint specs/p79-rollback-executor-policy.spec.md --min-score 0.7`
- P79 targeted CLI/MCP tests
- `cargo fmt -- --check`
- `cargo check`
- `cargo check --features rest`
- `cargo clippy -- -D warnings`
- `cargo clippy --features rest -- -D warnings`
- `cargo test`
- `cargo test --features rest`
- `git diff --check`
