### PR TITLE
docs: define autonomous promotion boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
+| `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -218,6 +219,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
+- `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
+| `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -216,6 +217,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
+- `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1581,9 +1581,31 @@ Updated recommended next P candidates after completing P78:
 
 Updated recommended next P candidates after completing P79:
 
-- P80 autonomous promotion boundary audit: decide whether autonomous promotion is
-  actually desired, or explicitly declare human-gated governance as the final
-  design boundary.
+P80 autonomous promotion boundary audit resolves the last ambiguous "gap" from
+P70/P75 as a governance boundary rather than a missing implementation.
+Autonomous promotion is out of scope for the current complete self-evolution
+design. mempal can autonomously preserve evidence, prepare candidate knowledge,
+evaluate gates, produce evaluator advice, assemble context, propose default
+changes, and execute explicit rollback controls, but lifecycle authority remains
+human-gated.
+P80 decision: autonomous promotion is out of scope.
+
+human-gated lifecycle authority is the final governance boundary: promotion and
+demotion of Stage-1 knowledge drawers or Phase-2 knowledge cards must remain
+explicit human/operator-triggered lifecycle mutation surfaces. Deterministic
+gates, evidence refs, reviewer rules, evaluator advice, runtime adoption
+evidence, and research findings can support the decision, but none of them can
+silently convert a candidate into promoted knowledge. This boundary keeps the
+system self-evolving in the evidence/proposal/context/adoption loop while
+avoiding an agent that can grant itself durable knowledge authority.
+
+Updated recommended next P candidate after completing P80:
+
+- P81 self-evolution completion audit: re-evaluate the active objective against
+  the actual artifacts after P77-P80. If the governed, human-gated definition is
+  accepted as the intended objective, the audit can close the goal; if the goal
+  still requires fully autonomous lifecycle mutation, that requirement must be
+  reopened as a separate explicit spec rather than inferred.
 
 ## Closing Summary
 

--- a/docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md
+++ b/docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md
@@ -1,0 +1,25 @@
+# P80 Autonomous Promotion Boundary Audit
+
+Spec: `specs/p80-autonomous-promotion-boundary-audit.spec.md`
+
+## Checklist
+
+- [x] Add P80 task contract and plan.
+- [x] Update `docs/MIND-MODEL-DESIGN.md` with the autonomous promotion boundary.
+- [x] Update `src/core/protocol.rs` so agents do not infer autonomous lifecycle authority.
+- [x] Update AGENTS/CLAUDE spec and plan inventory.
+- [x] Verify spec parse/lint, grep-based acceptance checks, fmt/check where relevant, and diff boundary.
+
+## Verification
+
+```bash
+agent-spec parse specs/p80-autonomous-promotion-boundary-audit.spec.md
+agent-spec lint specs/p80-autonomous-promotion-boundary-audit.spec.md --min-score 0.7
+rg -n "P80 autonomous promotion boundary audit|human-gated lifecycle authority|autonomous promotion is out of scope" docs/MIND-MODEL-DESIGN.md
+rg -n "must not autonomously promote|human/operator-triggered lifecycle mutation|evaluator advice remains advisory" src/core/protocol.rs
+rg -n "p80-autonomous-promotion-boundary-audit|P80 autonomous promotion boundary audit" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+cargo fmt -- --check
+cargo check
+git diff --check
+```

--- a/specs/p80-autonomous-promotion-boundary-audit.spec.md
+++ b/specs/p80-autonomous-promotion-boundary-audit.spec.md
@@ -1,0 +1,112 @@
+spec: task
+name: "P80: autonomous promotion boundary audit"
+inherits: project
+tags: [phase-3, governance, autonomy, audit]
+---
+
+## Intent
+
+P70 and P75 treated missing autonomous promotion authority as a possible gap in
+the "complete self-evolving agent system" objective. P80 resolves that ambiguity
+as a design boundary instead of adding unsafe authority: mempal may autonomously
+collect evidence, propose candidates, evaluate gates, recommend actions, enable
+explicit default controls, and execute explicit rollback controls, but it must
+not autonomously mutate knowledge lifecycle status. Human-gated or explicit
+operator-triggered lifecycle mutation is the final governance boundary for this
+design stage.
+
+## Decisions
+
+- P80 must leave its own spec and plan per the P76 invariant.
+- Autonomous promotion is explicitly out of scope for the current complete
+  self-evolution design.
+- `mempal_knowledge_promote`, `mempal_knowledge_demote`, knowledge-card
+  promote/demote, and equivalent CLI commands remain explicit lifecycle
+  mutation surfaces.
+- Evaluators remain advisory-only and cannot satisfy reviewer or lifecycle
+  authority requirements.
+- Runtime adoption, research ingestion, card context default control, and
+  rollback control may affect evidence/config, but must not bypass lifecycle
+  gates or human/operator intent.
+- P80 is a docs/protocol/spec audit only; it must not add schema, background
+  workers, hooks, daemons, or automatic promotion execution.
+- After P80, the active completion question should be reframed as: whether the
+  governed self-evolution system, with human-gated lifecycle authority, satisfies
+  the user's objective.
+
+## Boundaries
+
+### Allowed Changes
+
+- specs/p80-autonomous-promotion-boundary-audit.spec.md
+- docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/core/protocol.rs
+
+### Forbidden
+
+- Do not implement autonomous promotion or demotion.
+- Do not add new CLI or MCP lifecycle mutation commands.
+- Do not change SQLite schema.
+- Do not change promotion/demotion gate behavior.
+- Do not add background workers, hooks, or daemons.
+- Do not mark the whole active goal complete without a separate completion
+  audit against current artifacts.
+
+## Acceptance Criteria
+
+Scenario: P80 spec and plan are present
+  Test:
+    Filter: agent-spec parse specs/p80-autonomous-promotion-boundary-audit.spec.md && agent-spec lint specs/p80-autonomous-promotion-boundary-audit.spec.md --min-score 0.7
+    Targets: P76 spec completeness invariant.
+  Given P80 is a numbered P
+  When checking repository artifacts
+  Then `specs/p80-autonomous-promotion-boundary-audit.spec.md` exists
+  And `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` exists
+
+Scenario: MIND-MODEL records human-gated lifecycle as final boundary
+  Test:
+    Filter: rg -n "P80 autonomous promotion boundary audit|human-gated lifecycle authority|autonomous promotion is out of scope" docs/MIND-MODEL-DESIGN.md
+    Targets: Design narrative.
+  Given P80 resolves the autonomous promotion ambiguity
+  When reading `docs/MIND-MODEL-DESIGN.md`
+  Then it states autonomous promotion is out of scope
+  And it states human-gated lifecycle authority is the final governance boundary
+  And it identifies the next step as a completion audit, not more implementation
+
+Scenario: Protocol tells agents not to autonomously mutate lifecycle state
+  Test:
+    Filter: rg -n "must not autonomously promote|human/operator-triggered lifecycle mutation|evaluator advice remains advisory" src/core/protocol.rs
+    Targets: MCP protocol instructions.
+  Given agents consume `MEMORY_PROTOCOL`
+  When reading `src/core/protocol.rs`
+  Then the protocol forbids autonomous promotion
+  And it keeps evaluator advice advisory-only
+  And it requires explicit human/operator-triggered lifecycle mutation
+
+Scenario: AGENTS and CLAUDE inventories include P80
+  Test:
+    Filter: rg -n "p80-autonomous-promotion-boundary-audit|P80 autonomous promotion boundary audit" AGENTS.md CLAUDE.md
+    Targets: Repository agent inventories.
+  Given repository-level agent instructions list completed specs and plans
+  When checking `AGENTS.md` and `CLAUDE.md`
+  Then both files list the P80 spec
+  And both files list the P80 plan
+
+Scenario: No autonomous lifecycle implementation is added
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: Implementation boundary.
+  Given P80 is a docs/protocol audit
+  When inspecting changed paths
+  Then changed files are limited to P80 spec, P80 plan, AGENTS, CLAUDE, MIND-MODEL, and protocol docs
+  And no Rust command, MCP handler, schema, or lifecycle implementation file is changed except `src/core/protocol.rs`
+
+## Out of Scope
+
+- Autonomous promotion implementation.
+- Autonomous demotion implementation.
+- Agent runtime wrappers that call lifecycle mutation commands.
+- New completion claim without an explicit audit spec or audit artifact.

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -240,7 +240,14 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    to evaluate rollback evidence for the card-context default. The CLI executor
    is read-only unless `--execute` is supplied; when executed, it only sets local
    config `context.include_cards_default=false` and does not append runtime
-   adoption events or alter knowledge lifecycle state. Use
+   adoption events or alter knowledge lifecycle state. Agents must not
+   autonomously promote, demote, or otherwise mutate durable knowledge lifecycle
+   state. Agents must not autonomously promote knowledge.
+   human/operator-triggered lifecycle mutation remains required through
+   explicit promote/demote commands with deterministic gates
+   and evidence refs. Evaluator advice remains advisory: it can support review
+   but cannot satisfy reviewer authority, bypass gates, or create autonomous
+   lifecycle authority. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,


### PR DESCRIPTION
## Summary

- add P80 spec and plan for the autonomous promotion boundary audit
- define autonomous promotion as out of scope for the current self-evolution design
- update protocol so agents do not infer autonomous lifecycle authority

## Boundary

The system can autonomously gather evidence, propose, evaluate, advise, assemble context, control defaults explicitly, and execute explicit rollbacks. Durable knowledge lifecycle mutation remains human/operator-triggered through explicit promote/demote surfaces with deterministic gates and evidence refs.

## Validation

- `agent-spec parse specs/p80-autonomous-promotion-boundary-audit.spec.md`
- `agent-spec lint specs/p80-autonomous-promotion-boundary-audit.spec.md --min-score 0.7`
- grep acceptance checks for MIND-MODEL, protocol, AGENTS/CLAUDE inventory
- changed paths limited to spec/plan/AGENTS/CLAUDE/MIND-MODEL/protocol
- `cargo fmt -- --check`
- `cargo check`
- `git diff --check`
