### PR TITLE
docs: complete self-evolution audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 | `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
+| `specs/p81-self-evolution-completion-audit.spec.md` | 完成 | P81 self-evolution completion audit：按 P80 human-gated 边界审计完整自进化 agent 系统目标并确认完成 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -220,6 +221,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 - `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
+- `docs/plans/2026-05-13-p81-self-evolution-completion-audit.md` — P81 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 | `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
+| `specs/p81-self-evolution-completion-audit.spec.md` | 完成 | P81 self-evolution completion audit：按 P80 human-gated 边界审计完整自进化 agent 系统目标并确认完成 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -218,6 +219,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 - `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
+- `docs/plans/2026-05-13-p81-self-evolution-completion-audit.md` — P81 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1607,6 +1607,75 @@ Updated recommended next P candidate after completing P80:
   still requires fully autonomous lifecycle mutation, that requirement must be
   reopened as a separate explicit spec rather than inferred.
 
+P81 self-evolution completion audit is the final audit for the active objective
+`完整自进化 agent 系统`.
+
+Objective restatement: the target is a governed human-gated complete
+self-evolving agent system. "Complete" means the agent can gather external and
+runtime evidence, preserve provenance, distill and structure knowledge, retrieve
+the right knowledge/skills/tools at runtime, record feedback, evaluate stronger
+defaults, apply explicit default/rollback controls, and keep durable knowledge
+lifecycle mutation under deterministic gates plus human/operator intent.
+
+Prompt-to-artifact checklist:
+
+- Evidence substrate: P0-P13 raw drawer storage, citation-bearing search, and
+  P54 `runtime_adoption_events` provide durable evidence and runtime outcome
+  storage. Evidence remains raw and cited; search/context do not rewrite source
+  content.
+- Knowledge governance: P12-P28 typed `dao_tian` / `dao_ren` / `shu` / `qi`
+  drawers, policy surfaces, distill, gate, promote/demote, and anchor
+  publication provide governed knowledge lifecycle for Stage-1 drawers.
+- Knowledge cards: P31-P45 implement card schema, evidence links, append-only
+  events, CLI/MCP lifecycle, backfill, retrieval, and explicit card-aware
+  context without making cards an implicit search/default source.
+- Research bridge: P49/P59/P67/P68 ensure external research enters as evidence
+  or evidence-backed candidate insight suggestions. Research output cannot
+  directly define dao or bypass gates.
+- Runtime feedback loop: P54-P69 provide runtime adoption event storage,
+  guidance, prepare/check helpers, review/readiness/gate reports, and
+  quality-gated `record_checked` writes.
+- Self-evolution replay: P71 `tests/phase3_self_evolution_replay.rs` proves the
+  composed path research -> evidence -> card promotion -> context -> checked
+  adoption record.
+- Live adoption boundary: P77 `instrumentation_policy` defines the safe boundary
+  for future live wrappers: opt-in, preserve opt-out, no silent event append,
+  and route writes through checked capture or `record_checked`.
+- Runtime default control: P74/P78 provide proposal-ready and explicit
+  `default-control` paths for card-aware context. Default change requires
+  runtime evidence and rollback criteria; request-level overrides still win.
+- Rollback and default control: P79 `rollback-control` turns rollback evidence
+  into an explicit reversible config action, setting
+  `context.include_cards_default=false` only with `--execute` and without
+  writing runtime events or lifecycle state.
+- Evaluator boundary: P50/P58/P73 keep evaluators advisory-only.
+  `evaluator_advise` is replayable, returns `lifecycle_authority=false`, and
+  cannot satisfy reviewer authority or bypass deterministic gates.
+- Lifecycle authority boundary: P80 declares autonomous promotion out of scope.
+  Human/operator-triggered promote/demote commands with evidence refs and gates
+  remain the only durable lifecycle mutation path.
+- Spec completeness: P76 requires every numbered P to leave a matching task spec
+  and plan. P77-P81 follow this rule.
+- Mainline verification: PR #68 through PR #72 are merged to main. Main CI runs
+  `25805677837`, `25806999068`, `25808402185`, `25809830828`, and
+  `25810588996` all completed with success across `fmt`, `default`, and `rest`
+  jobs.
+
+P81 conclusion: complete.
+
+The active objective is complete under the governed human-gated definition. The
+system now has an auditable loop from evidence intake to governed knowledge,
+runtime context, feedback capture, policy evaluation, explicit default control,
+and explicit rollback. It does not grant agents silent durable lifecycle
+authority, and that is an intentional design boundary rather than a missing
+implementation.
+
+Residual boundary: fully autonomous lifecycle mutation remains out of scope. If
+future work requires an agent to promote or demote durable knowledge without a
+human/operator-triggered lifecycle command, that is a new objective and must be
+opened as a separate P-level spec with its own evidence, rollback, safety, and
+acceptance criteria.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-13-p81-self-evolution-completion-audit.md
+++ b/docs/plans/2026-05-13-p81-self-evolution-completion-audit.md
@@ -1,0 +1,25 @@
+# P81 Self-Evolution Completion Audit
+
+Spec: `specs/p81-self-evolution-completion-audit.spec.md`
+
+## Checklist
+
+- [x] Add P81 task contract and plan.
+- [x] Update `docs/MIND-MODEL-DESIGN.md` with final objective restatement, prompt-to-artifact checklist, evidence, conclusion, and residual boundary.
+- [x] Update AGENTS/CLAUDE spec and plan inventory.
+- [x] Verify spec parse/lint, grep-based acceptance checks, diff boundary, fmt/check, and mainline evidence references.
+
+## Verification
+
+```bash
+agent-spec parse specs/p81-self-evolution-completion-audit.spec.md
+agent-spec lint specs/p81-self-evolution-completion-audit.spec.md --min-score 0.7
+rg -n "P81 self-evolution completion audit|Objective restatement|governed human-gated complete self-evolving agent system" docs/MIND-MODEL-DESIGN.md
+rg -n "Prompt-to-artifact checklist|Evidence substrate|Knowledge governance|Runtime feedback loop|Rollback and default control|Lifecycle authority boundary|Mainline verification" docs/MIND-MODEL-DESIGN.md
+rg -n "P81 conclusion: complete|Residual boundary|fully autonomous lifecycle mutation remains out of scope" docs/MIND-MODEL-DESIGN.md
+rg -n "p81-self-evolution-completion-audit|P81 self-evolution completion audit" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+cargo fmt -- --check
+cargo check
+git diff --check
+```

--- a/specs/p81-self-evolution-completion-audit.spec.md
+++ b/specs/p81-self-evolution-completion-audit.spec.md
@@ -1,0 +1,107 @@
+spec: task
+name: "P81: self-evolution completion audit"
+inherits: project
+tags: [phase-3, completion, audit, self-evolution]
+---
+
+## Intent
+
+P80 resolved autonomous promotion as an explicit out-of-scope boundary, leaving
+the active objective to be audited under the governed human-gated definition of
+a complete self-evolving agent system. P81 performs that final completion audit:
+restate the objective as concrete deliverables, map each deliverable to actual
+artifacts and verification evidence, identify uncovered requirements, and state
+whether the objective is complete under the current design boundary.
+
+## Decisions
+
+- P81 must leave its own spec and plan per the P76 invariant.
+- The audited objective is `完整自进化 agent 系统`.
+- "Complete" means complete under the P80 governed boundary: autonomous evidence
+  capture/proposal/retrieval/adoption support is allowed, but durable lifecycle
+  mutation remains human/operator-triggered.
+- The audit must not rely on green CI alone; it must map concrete requirements
+  to artifacts, tests, specs, protocol, and merged PR/main CI evidence.
+- If fully autonomous lifecycle mutation is required, the audit must mark the
+  objective incomplete and identify that as a separate future requirement.
+- P81 is docs/audit only and must not implement new runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+
+- specs/p81-self-evolution-completion-audit.spec.md
+- docs/plans/2026-05-13-p81-self-evolution-completion-audit.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+
+### Forbidden
+
+- Do not change Rust runtime code.
+- Do not change MCP protocol behavior.
+- Do not change schema or tests.
+- Do not mark completion without prompt-to-artifact evidence.
+- Do not redefine autonomous promotion back into scope.
+
+## Acceptance Criteria
+
+Scenario: P81 spec and plan are present
+  Test:
+    Filter: agent-spec parse specs/p81-self-evolution-completion-audit.spec.md && agent-spec lint specs/p81-self-evolution-completion-audit.spec.md --min-score 0.7
+    Targets: P76 spec completeness invariant.
+  Given P81 is a numbered P
+  When checking repository artifacts
+  Then `specs/p81-self-evolution-completion-audit.spec.md` exists
+  And `docs/plans/2026-05-13-p81-self-evolution-completion-audit.md` exists
+
+Scenario: MIND-MODEL contains the final objective restatement
+  Test:
+    Filter: rg -n "P81 self-evolution completion audit|Objective restatement|governed human-gated complete self-evolving agent system" docs/MIND-MODEL-DESIGN.md
+    Targets: Completion audit narrative.
+  Given P81 audits the active objective
+  When reading `docs/MIND-MODEL-DESIGN.md`
+  Then it restates `完整自进化 agent 系统` as concrete deliverables
+  And it names the governed human-gated boundary from P80
+
+Scenario: MIND-MODEL maps prompts to artifacts and evidence
+  Test:
+    Filter: rg -n "Prompt-to-artifact checklist|Evidence substrate|Knowledge governance|Runtime feedback loop|Rollback and default control|Lifecycle authority boundary|Mainline verification" docs/MIND-MODEL-DESIGN.md
+    Targets: Audit checklist.
+  Given completion cannot rely on CI alone
+  When reading the P81 section
+  Then each deliverable is mapped to concrete specs, files, tests, or PR/CI evidence
+  And the audit mentions mainline verification evidence
+
+Scenario: MIND-MODEL states completion result and residual boundary
+  Test:
+    Filter: rg -n "P81 conclusion: complete|Residual boundary|fully autonomous lifecycle mutation remains out of scope" docs/MIND-MODEL-DESIGN.md
+    Targets: Completion conclusion.
+  Given P80 excludes autonomous lifecycle mutation
+  When reading the P81 conclusion
+  Then the objective is marked complete under the governed boundary
+  And fully autonomous lifecycle mutation remains explicitly out of scope
+
+Scenario: AGENTS and CLAUDE inventories include P81
+  Test:
+    Filter: rg -n "p81-self-evolution-completion-audit|P81 self-evolution completion audit" AGENTS.md CLAUDE.md
+    Targets: Repository agent inventories.
+  Given repository-level agent instructions list completed specs and plans
+  When checking `AGENTS.md` and `CLAUDE.md`
+  Then both files list the P81 spec
+  And both files list the P81 plan
+
+Scenario: Audit-only boundary is preserved
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: Changed file boundary.
+  Given P81 is docs/audit only
+  When inspecting changed paths
+  Then changed files are limited to P81 spec, P81 plan, AGENTS, CLAUDE, and MIND-MODEL
+
+## Out of Scope
+
+- New runtime features.
+- New tests or schema.
+- Autonomous lifecycle mutation.
+- Updating goal status before the audit PR lands on main and CI is green.


### PR DESCRIPTION
## Summary

- add P81 spec and plan for the final self-evolution completion audit
- restate the objective as a governed human-gated complete self-evolving agent system
- map each deliverable to concrete artifacts, tests/specs/protocol, and mainline CI evidence
- conclude complete under the P80 boundary, with fully autonomous lifecycle mutation explicitly out of scope

## Validation

- `agent-spec parse specs/p81-self-evolution-completion-audit.spec.md`
- `agent-spec lint specs/p81-self-evolution-completion-audit.spec.md --min-score 0.7`
- grep acceptance checks for objective restatement, prompt-to-artifact checklist, conclusion, and inventory
- changed paths limited to audit docs/spec/plan/inventory
- `cargo fmt -- --check`
- `cargo check`
- `git diff --check`
