### PR TITLE
[codex] complete self-evolution and cowork runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,22 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 | `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
 | `specs/p81-self-evolution-completion-audit.spec.md` | 完成 | P81 self-evolution completion audit：按 P80 human-gated 边界审计完整自进化 agent 系统目标并确认完成 |
+| `specs/p82-opt-in-runtime-instrumentation-wrapper.spec.md` | 完成 | P82 opt-in runtime instrumentation wrapper：`mempal phase3 adoption wrap` 显式包裹一次 child command，并通过 P72/P69 checked capture 记录 runtime adoption evidence |
+| `specs/p83-cognitive-brief.spec.md` | 完成 | P83 cognitive brief：`mempal brief` 生成 deterministic citation-first brief，组织 key facts / evidence / cards / uncertainty / next actions，不调用 LLM、不写 DB |
+| `specs/p84-multi-agent-cowork-bus.spec.md` | 完成 | P84 multi-agent cowork bus：`agent_id` registry + per-agent inbox + CLI send/broadcast/drain/status，支持同项目多 agent 实例隔离通信 |
+| `specs/p85-mcp-multi-agent-cowork-bus.spec.md` | 完成 | P85 MCP multi-agent cowork bus：`mempal_cowork_bus` 暴露 register/list/send/broadcast/drain，让 agent runtime 使用 concrete `agent_id` 总线 |
+| `specs/p86-tmux-cowork-transport.spec.md` | 完成 | P86 tmux cowork transport：`transport=tmux` 显式使用 `tmux send-keys` 投递到 concrete agent pane，不经 shell、不 fallback 到 inbox |
+| `specs/p87-cowork-bus-event-log.spec.md` | 完成 | P87 cowork bus event log：`events.jsonl` append-only 记录 register/send/broadcast/drain/tmux failure，并通过 `cowork-events` / `mempal_cowork_bus action=events` 回放 |
+| `specs/p88-cowork-delivery-ack-status.spec.md` | 完成 | P88 cowork delivery ack/status：delivery event id 作为 `message_id`，通过 `cowork-deliveries` / `cowork-ack` 和 MCP `deliveries` / `ack` 回放 pending/drained/acked/failed |
+| `specs/p89-cowork-agent-presence.spec.md` | 完成 | P89 cowork agent presence：显式 `cowork-heartbeat` / MCP `heartbeat` 更新 `last_seen_at`，`cowork-agents` / MCP `list` 推导 online/stale/never_seen |
+| `specs/p90-cowork-threads-channels.spec.md` | 完成 | P90 cowork threads/channels：send/broadcast/channel_send 支持 `thread_id` / `channel` 元数据，`cowork-channel-set` / MCP `channel_set` 管理 channel membership |
+| `specs/p91-tmux-live-peek.spec.md` | 完成 | P91 tmux live peek：`cowork-tmux-peek` / MCP `tmux_peek` 只读捕获已注册 tmux agent pane，不写 events/inbox/registry/DB |
+| `specs/p92-multi-agent-runbook.spec.md` | 完成 | P92 multi-agent cowork runbook：`docs/COWORK-RUNBOOK.md` + `cowork-runbook` read-only CLI 固化三方/多方 agent 操作流程 |
+| `specs/p93-cowork-doctor.spec.md` | 完成 | P93 cowork doctor：`cowork-doctor` / MCP `doctor` 只读诊断 registry、presence、pending deliveries、sessions、channels、可选 tmux probe |
+| `specs/p94-cowork-team-session.spec.md` | 完成 | P94 cowork team session：runtime `sessions.json` + CLI/MCP session create/list/status，不写 palace.db |
+| `specs/p95-cowork-handoff-summary.spec.md` | 完成 | P95 cowork handoff summary：`cowork-handoff` / MCP `handoff` 汇总 sessions、agents、pending deliveries、recent events，支持 thread/channel/session filter |
+| `specs/p96-cowork-memory-capture.spec.md` | 完成 | P96 cowork memory capture：`cowork-capture` / MCP `capture` 显式把 handoff summary 写入 evidence drawer，默认 dry-run |
+| `specs/p97-maintenance-runbook.spec.md` | 完成 | P97 maintenance runbook：`docs/MAINTENANCE-RUNBOOK.md` + `maintenance-runbook` read-only CLI 固化 research->evidence->knowledge/card->context/adoption/cowork capture 维护流程 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -222,6 +238,22 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 - `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
 - `docs/plans/2026-05-13-p81-self-evolution-completion-audit.md` — P81 self-evolution completion audit（已完成）
+- `docs/plans/2026-05-25-p82-opt-in-runtime-instrumentation-wrapper.md` — P82 opt-in runtime instrumentation wrapper（已完成）
+- `docs/plans/2026-05-25-p83-cognitive-brief.md` — P83 cognitive brief（已完成）
+- `docs/plans/2026-05-25-p84-multi-agent-cowork-bus.md` — P84 multi-agent cowork bus（已完成）
+- `docs/plans/2026-05-25-p85-mcp-multi-agent-cowork-bus.md` — P85 MCP multi-agent cowork bus（已完成）
+- `docs/plans/2026-05-25-p86-tmux-cowork-transport.md` — P86 tmux cowork transport（已完成）
+- `docs/plans/2026-05-25-p87-cowork-bus-event-log.md` — P87 cowork bus event log（已完成）
+- `docs/plans/2026-05-25-p88-cowork-delivery-ack-status.md` — P88 cowork delivery ack/status（已完成）
+- `docs/plans/2026-05-25-p89-cowork-agent-presence.md` — P89 cowork agent presence（已完成）
+- `docs/plans/2026-05-25-p90-cowork-threads-channels.md` — P90 cowork threads/channels（已完成）
+- `docs/plans/2026-05-25-p91-tmux-live-peek.md` — P91 tmux live peek（已完成）
+- `docs/plans/2026-05-26-p92-multi-agent-runbook.md` — P92 multi-agent cowork runbook（已完成）
+- `docs/plans/2026-05-26-p93-cowork-doctor.md` — P93 cowork doctor（已完成）
+- `docs/plans/2026-05-26-p94-cowork-team-session.md` — P94 cowork team session（已完成）
+- `docs/plans/2026-05-26-p95-cowork-handoff-summary.md` — P95 cowork handoff summary（已完成）
+- `docs/plans/2026-05-26-p96-cowork-memory-capture.md` — P96 cowork memory capture（已完成）
+- `docs/plans/2026-05-26-p97-maintenance-runbook.md` — P97 maintenance runbook（已完成）
 
 ### Spec 使用方式
 
@@ -242,7 +274,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，17 条规则
 
-## MCP 工具（19 个）
+## MCP 工具（21 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -265,6 +297,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_tunnels` | 跨 Wing 链接发现 |
 | `mempal_peek_partner` | 读 partner agent 当前 session（live，不存储） |
 | `mempal_cowork_push` | 主动投递 ephemeral handoff 到 partner inbox（at-next-submit 交付） |
+| `mempal_cowork_bus` | 多 agent concrete `agent_id` 总线：register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/handoff/capture，支持 opt-in `transport=tmux`、event replay、delivery ack/status、presence、group channels、read-only tmux pane peek、诊断、session、handoff summary、显式 handoff-to-evidence capture（P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96） |
 | `mempal_fact_check` | 离线矛盾检测（SimilarNameConflict / RelationContradiction / StaleFact）—— P9 |
 
 ## mempal 检索纪律

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,22 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 | `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
 | `specs/p81-self-evolution-completion-audit.spec.md` | 完成 | P81 self-evolution completion audit：按 P80 human-gated 边界审计完整自进化 agent 系统目标并确认完成 |
+| `specs/p82-opt-in-runtime-instrumentation-wrapper.spec.md` | 完成 | P82 opt-in runtime instrumentation wrapper：`mempal phase3 adoption wrap` 显式包裹一次 child command，并通过 P72/P69 checked capture 记录 runtime adoption evidence |
+| `specs/p83-cognitive-brief.spec.md` | 完成 | P83 cognitive brief：`mempal brief` 生成 deterministic citation-first brief，组织 key facts / evidence / cards / uncertainty / next actions，不调用 LLM、不写 DB |
+| `specs/p84-multi-agent-cowork-bus.spec.md` | 完成 | P84 multi-agent cowork bus：`agent_id` registry + per-agent inbox + CLI send/broadcast/drain/status，支持同项目多 agent 实例隔离通信 |
+| `specs/p85-mcp-multi-agent-cowork-bus.spec.md` | 完成 | P85 MCP multi-agent cowork bus：`mempal_cowork_bus` 暴露 register/list/send/broadcast/drain，让 agent runtime 使用 concrete `agent_id` 总线 |
+| `specs/p86-tmux-cowork-transport.spec.md` | 完成 | P86 tmux cowork transport：`transport=tmux` 显式使用 `tmux send-keys` 投递到 concrete agent pane，不经 shell、不 fallback 到 inbox |
+| `specs/p87-cowork-bus-event-log.spec.md` | 完成 | P87 cowork bus event log：`events.jsonl` append-only 记录 register/send/broadcast/drain/tmux failure，并通过 `cowork-events` / `mempal_cowork_bus action=events` 回放 |
+| `specs/p88-cowork-delivery-ack-status.spec.md` | 完成 | P88 cowork delivery ack/status：delivery event id 作为 `message_id`，通过 `cowork-deliveries` / `cowork-ack` 和 MCP `deliveries` / `ack` 回放 pending/drained/acked/failed |
+| `specs/p89-cowork-agent-presence.spec.md` | 完成 | P89 cowork agent presence：显式 `cowork-heartbeat` / MCP `heartbeat` 更新 `last_seen_at`，`cowork-agents` / MCP `list` 推导 online/stale/never_seen |
+| `specs/p90-cowork-threads-channels.spec.md` | 完成 | P90 cowork threads/channels：send/broadcast/channel_send 支持 `thread_id` / `channel` 元数据，`cowork-channel-set` / MCP `channel_set` 管理 channel membership |
+| `specs/p91-tmux-live-peek.spec.md` | 完成 | P91 tmux live peek：`cowork-tmux-peek` / MCP `tmux_peek` 只读捕获已注册 tmux agent pane，不写 events/inbox/registry/DB |
+| `specs/p92-multi-agent-runbook.spec.md` | 完成 | P92 multi-agent cowork runbook：`docs/COWORK-RUNBOOK.md` + `cowork-runbook` read-only CLI 固化三方/多方 agent 操作流程 |
+| `specs/p93-cowork-doctor.spec.md` | 完成 | P93 cowork doctor：`cowork-doctor` / MCP `doctor` 只读诊断 registry、presence、pending deliveries、sessions、channels、可选 tmux probe |
+| `specs/p94-cowork-team-session.spec.md` | 完成 | P94 cowork team session：runtime `sessions.json` + CLI/MCP session create/list/status，不写 palace.db |
+| `specs/p95-cowork-handoff-summary.spec.md` | 完成 | P95 cowork handoff summary：`cowork-handoff` / MCP `handoff` 汇总 sessions、agents、pending deliveries、recent events，支持 thread/channel/session filter |
+| `specs/p96-cowork-memory-capture.spec.md` | 完成 | P96 cowork memory capture：`cowork-capture` / MCP `capture` 显式把 handoff summary 写入 evidence drawer，默认 dry-run |
+| `specs/p97-maintenance-runbook.spec.md` | 完成 | P97 maintenance runbook：`docs/MAINTENANCE-RUNBOOK.md` + `maintenance-runbook` read-only CLI 固化 research->evidence->knowledge/card->context/adoption/cowork capture 维护流程 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -220,6 +236,22 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 - `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
 - `docs/plans/2026-05-13-p81-self-evolution-completion-audit.md` — P81 self-evolution completion audit（已完成）
+- `docs/plans/2026-05-25-p82-opt-in-runtime-instrumentation-wrapper.md` — P82 opt-in runtime instrumentation wrapper（已完成）
+- `docs/plans/2026-05-25-p83-cognitive-brief.md` — P83 cognitive brief（已完成）
+- `docs/plans/2026-05-25-p84-multi-agent-cowork-bus.md` — P84 multi-agent cowork bus（已完成）
+- `docs/plans/2026-05-25-p85-mcp-multi-agent-cowork-bus.md` — P85 MCP multi-agent cowork bus（已完成）
+- `docs/plans/2026-05-25-p86-tmux-cowork-transport.md` — P86 tmux cowork transport（已完成）
+- `docs/plans/2026-05-25-p87-cowork-bus-event-log.md` — P87 cowork bus event log（已完成）
+- `docs/plans/2026-05-25-p88-cowork-delivery-ack-status.md` — P88 cowork delivery ack/status（已完成）
+- `docs/plans/2026-05-25-p89-cowork-agent-presence.md` — P89 cowork agent presence（已完成）
+- `docs/plans/2026-05-25-p90-cowork-threads-channels.md` — P90 cowork threads/channels（已完成）
+- `docs/plans/2026-05-25-p91-tmux-live-peek.md` — P91 tmux live peek（已完成）
+- `docs/plans/2026-05-26-p92-multi-agent-runbook.md` — P92 multi-agent cowork runbook（已完成）
+- `docs/plans/2026-05-26-p93-cowork-doctor.md` — P93 cowork doctor（已完成）
+- `docs/plans/2026-05-26-p94-cowork-team-session.md` — P94 cowork team session（已完成）
+- `docs/plans/2026-05-26-p95-cowork-handoff-summary.md` — P95 cowork handoff summary（已完成）
+- `docs/plans/2026-05-26-p96-cowork-memory-capture.md` — P96 cowork memory capture（已完成）
+- `docs/plans/2026-05-26-p97-maintenance-runbook.md` — P97 maintenance runbook（已完成）
 
 ### Spec 使用方式
 
@@ -240,7 +272,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，17 条规则
 
-## MCP 工具（19 个）
+## MCP 工具（21 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -263,6 +295,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_tunnels` | 跨 Wing 链接发现 |
 | `mempal_peek_partner` | 读 partner agent 当前 session（live，不存储） |
 | `mempal_cowork_push` | 主动投递 ephemeral handoff 到 partner inbox（at-next-submit 交付） |
+| `mempal_cowork_bus` | 多 agent concrete `agent_id` 总线：register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/handoff/capture，支持 opt-in `transport=tmux`、event replay、delivery ack/status、presence、group channels、read-only tmux pane peek、诊断、session、handoff summary、显式 handoff-to-evidence capture（P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96） |
 | `mempal_fact_check` | 离线矛盾检测（SimilarNameConflict / RelationContradiction / StaleFact）—— P9 |
 
 ## mempal 检索纪律

--- a/docs/COWORK-RUNBOOK.md
+++ b/docs/COWORK-RUNBOOK.md
@@ -1,0 +1,141 @@
+# Multi-Agent Cowork Runbook
+
+This runbook describes the operational workflow for using mempal with more
+than two live agent instances in the same project.
+
+## 1. Register Concrete Agents
+
+Every live participant gets a stable `agent_id`.
+
+```bash
+mempal cowork-register --cwd "$PWD" --agent-id claude-main --tool claude
+mempal cowork-register --cwd "$PWD" --agent-id codex-a --tool codex
+mempal cowork-register --cwd "$PWD" --agent-id codex-b --tool codex
+```
+
+For tmux-backed agents, register the pane explicitly:
+
+```bash
+mempal cowork-register \
+  --cwd "$PWD" \
+  --agent-id codex-a \
+  --tool codex \
+  --transport tmux \
+  --tmux-target mempal:0.1
+```
+
+## 2. Inspect Presence And Inbox State
+
+```bash
+mempal cowork-agents --cwd "$PWD"
+mempal cowork-heartbeat --cwd "$PWD" --agent-id codex-a
+```
+
+Presence is explicit. mempal does not run a daemon and does not infer liveness
+unless an agent reports a heartbeat or is re-registered.
+
+## 3. Send Direct Messages
+
+```bash
+mempal cowork-send \
+  --cwd "$PWD" \
+  --from claude-main \
+  --to codex-a \
+  --thread-id p92-review \
+  --message "Please review the doctor design."
+```
+
+Inbox agents receive JSONL inbox messages. tmux agents receive direct pane
+delivery through `tmux send-keys`.
+
+## 4. Broadcast Or Use Channels
+
+For ad hoc fanout:
+
+```bash
+mempal cowork-broadcast \
+  --cwd "$PWD" \
+  --from claude-main \
+  --to codex-a \
+  --to codex-b \
+  --message "Sync point: review P93 tests."
+```
+
+For stable groups:
+
+```bash
+mempal cowork-channel-set \
+  --cwd "$PWD" \
+  --channel review \
+  --agent codex-a \
+  --agent codex-b
+
+mempal cowork-channel-send \
+  --cwd "$PWD" \
+  --from claude-main \
+  --channel review \
+  --thread-id p92-review \
+  --message "Review the current patch."
+```
+
+## 5. Drain, Ack, And Audit
+
+```bash
+mempal cowork-agent-drain --cwd "$PWD" --agent-id codex-a
+mempal cowork-deliveries --cwd "$PWD" --agent-id codex-a
+mempal cowork-ack --cwd "$PWD" --agent-id codex-a --message-id evt-...
+mempal cowork-events --cwd "$PWD" --limit 20
+```
+
+`cowork-events` is an operational event log. It is not durable memory and it
+does not replace explicit ingest.
+
+## 6. Use tmux Live Peek
+
+```bash
+mempal cowork-tmux-peek --cwd "$PWD" --agent-id codex-a --lines 80
+```
+
+Peek is read-only. It does not write events, inboxes, sessions, or `palace.db`.
+
+## 7. Diagnose Before Escalating
+
+```bash
+mempal cowork-doctor --cwd "$PWD"
+mempal cowork-doctor --cwd "$PWD" --probe-tmux --format json
+```
+
+Doctor reports registry, stale presence, pending deliveries, channels,
+sessions, and optional tmux reachability.
+
+## 8. Create Sessions And Handoffs
+
+```bash
+mempal cowork-session-create \
+  --cwd "$PWD" \
+  --session-id p92-review \
+  --title "P92-P97 implementation" \
+  --agent claude-main \
+  --agent codex-a \
+  --thread-id p92-review \
+  --goal "Finish specs, implementation, and verification."
+
+mempal cowork-handoff --cwd "$PWD" --session-id p92-review
+```
+
+Sessions and handoffs are runtime coordination artifacts. They do not write
+durable project memory unless explicitly captured.
+
+## 9. Explicitly Capture Durable Memory
+
+```bash
+mempal cowork-capture \
+  --cwd "$PWD" \
+  --summary-source handoff \
+  --session-id p92-review \
+  --execute \
+  --format json
+```
+
+Capture is the intentional bridge from runtime operations to evidence memory.
+It is never automatic.

--- a/docs/MAINTENANCE-RUNBOOK.md
+++ b/docs/MAINTENANCE-RUNBOOK.md
@@ -1,0 +1,101 @@
+# Maintenance Runbook
+
+This runbook describes the governed maintenance loop for mempal's mind-model
+and self-evolution substrate. It is a checklist, not an autonomous daemon.
+
+## 1. Gather External Evidence
+
+Use research tooling to produce a reproducible report, then validate the report
+before ingesting anything:
+
+```bash
+mempal phase3 research-validate-plan report.json --format json
+mempal phase3 research-ingest-plan report.json --format json
+mempal phase3 research-ingest-plan report.json --execute --format json
+```
+
+Research output enters mempal as evidence or evidence-backed candidate
+insights. It does not directly define `dao`.
+
+## 2. Distill Candidate Knowledge
+
+Use existing evidence refs to create candidate knowledge:
+
+```bash
+mempal knowledge distill \
+  --tier dao_ren \
+  --statement "A stable domain rule..." \
+  --supporting-ref drawer_...
+```
+
+The result remains candidate until deterministic gates and human review allow
+promotion.
+
+## 3. Govern Cards And Lifecycle
+
+Use knowledge-card gates before lifecycle changes:
+
+```bash
+mempal knowledge-card gate card_...
+mempal knowledge-card promote card_... --target-status active --evidence-ref drawer_...
+mempal knowledge-card demote card_... --status retired --reason "counterexample" --evidence-ref drawer_...
+```
+
+Cards are governed artifacts, not automatic beliefs.
+
+## 4. Assemble Context And Record Adoption
+
+Use context packs during real work and record observed outcomes:
+
+```bash
+mempal context "current task" --include-cards
+mempal phase3 adoption capture \
+  --surface card-context \
+  --outcome accepted \
+  --card-id card_... \
+  --query "current task" \
+  --execute
+```
+
+Runtime adoption evidence is the feedback layer that proves whether context
+actually helped.
+
+## 5. Review Readiness And Rollback
+
+```bash
+mempal phase3 adoption review --format json
+mempal phase3 readiness card-context-default --format json
+mempal phase3 default-proposal card-context-default \
+  --rollback-criterion "disable if rejection rate exceeds threshold"
+mempal phase3 rollback-control card-context --format json
+```
+
+Default changes require evidence and rollback criteria.
+
+## 6. Maintain Cowork State
+
+For multi-agent work, summarize operational state before ending a session:
+
+```bash
+mempal cowork-doctor --cwd "$PWD"
+mempal cowork-handoff --cwd "$PWD" --format plain
+mempal cowork-capture --cwd "$PWD" --summary-source handoff --execute
+```
+
+`cowork-capture` is explicit evidence capture. Runtime communication remains
+ephemeral unless this bridge is invoked.
+
+## 7. Auto-Dream Boundary
+
+Auto-dream or manual dream can use this checklist, but mempal does not install
+background maintenance workers. The governed loop is:
+
+1. validate evidence
+2. ingest evidence
+3. distill candidates
+4. gate lifecycle changes
+5. use context
+6. record runtime adoption
+7. review and rollback when needed
+
+No step grants autonomous promotion authority.

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1676,6 +1676,396 @@ human/operator-triggered lifecycle command, that is a new objective and must be
 opened as a separate P-level spec with its own evidence, rollback, safety, and
 acceptance criteria.
 
+## Post-P81 Opt-In Instrumentation
+
+P82 implements the first concrete `opt_in_wrapper` allowed by P77. CLI
+`mempal phase3 adoption wrap` explicitly runs one child command after `--`,
+observes its exit status, maps `0` to `accepted` and non-zero to `rejected`
+unless `--outcome` overrides the mapping, and returns a wrapper report with the
+child exit code plus the nested capture report.
+
+P82 preserves the governed runtime boundary:
+
+- no hooks, daemons, background workers, or silent capture are installed
+- no MCP-side shell command execution is added
+- no runtime adoption event is written unless `--execute` is supplied
+- all writes reuse P72 capture mapping and P69 checked-record quality gates
+- warning-quality captures remain blocked unless `--allow-warnings` is supplied
+- non-zero child exits are propagated after the wrapper report is emitted
+
+This makes runtime evidence capture less manual while keeping instrumentation
+explicit, opt-in, quality-gated, and reversible through existing rollback
+evidence policies.
+
+## Cognitive Brief
+
+P83 adds `mempal brief`, the first deterministic cognitive brief surface. It
+does not replace `mempal search` or `mempal context`; it uses the existing
+context assembly path with evidence and cards enabled, then organizes the result
+into a citation-first report.
+
+The P83 brief contains:
+
+- key facts from governed knowledge/context items
+- cited evidence items
+- active knowledge cards and their linked evidence citations
+- simple entity cues extracted from cited text
+- unresolved-item cues such as action items, blockers, or remaining work
+- uncertainty signals such as missing evidence, missing governed knowledge,
+  missing cards, unresolved work, or conflict/stale language
+- deterministic next actions
+
+P83 deliberately avoids LLM synthesis, MCP command execution, schema changes,
+fact-check side effects, dream-cycle maintenance, or runtime adoption writes.
+Its purpose is to make the system "read for you" in a safe first step: organize
+cited memory into an actionable brief while preserving uncertainty instead of
+hallucinating confidence.
+
+## Multi-Agent Cowork Bus
+
+P84 upgrades cowork from a two-tool Claude/Codex pair protocol into a
+project-scoped multi-agent bus. The old P8 path routes to tool-family inboxes
+such as `claude` or `codex`; that is insufficient when one project has one
+Claude Code instance and multiple Codex instances, because both Codex instances
+race on the same shared `codex` inbox.
+
+The P84 bus introduces stable `agent_id` addressing:
+
+- `cowork-register` records concrete instances such as `claude-main`,
+  `codex-a`, and `codex-b`
+- `cowork-send` targets one concrete `agent_id`
+- `cowork-broadcast` fans out independent inbox copies to multiple targets
+- `cowork-agent-drain` drains one concrete agent inbox
+- `cowork-agents` lists registered agents and pending per-agent inbox state
+
+State lives under `~/.mempal/cowork-bus/<encoded_project_identity>/`, outside
+`palace.db`. P84 remains ephemeral and file-backed: it does not write drawers,
+cards, runtime adoption events, audit entries, or schema state. The legacy
+`cowork-drain --target claude|codex` and `mempal_cowork_push` path remains
+available unchanged for backward compatibility.
+
+P84 stores optional transport metadata but only inbox delivery is active. tmux
+send/capture is intentionally left to the next P-level task so that instance
+identity and per-agent routing are proven before adding a more invasive
+terminal-injection transport.
+
+## MCP Multi-Agent Cowork Bus
+
+P85 exposes the P84 bus to agent runtimes through one MCP tool:
+`mempal_cowork_bus`. This is the point where the bus becomes usable by agents
+directly, not only by shell commands.
+
+The MCP surface is action-based:
+
+- `action=register` registers or updates a concrete `agent_id`
+- `action=list` reports project bus agents and pending inbox counts
+- `action=send` delivers one message to one concrete target
+- `action=broadcast` fans out independent inbox copies to multiple targets
+- `action=drain` returns and consumes one concrete agent's inbox
+
+P85 deliberately does not infer concrete instances from MCP `client_info.name`.
+Client names can identify a tool family such as Codex, but they cannot
+distinguish `codex-a` from `codex-b`. The multi-agent bus therefore requires
+explicit `agent_id` values and remains separate from legacy
+`mempal_cowork_push`, which is still the simpler Claude<->Codex partner
+handoff path.
+
+The MCP tool uses the same file-backed bus state under
+`~/.mempal/cowork-bus/<encoded_project_identity>/`. It does not write
+`palace.db`, drawers, cards, runtime adoption events, or schema state. tmux
+transport remains a later layer on top of the now-explicit agent registry and
+per-agent routing model.
+
+## Tmux Cowork Transport
+
+P86 activates tmux as an explicit transport for the multi-agent bus. `inbox`
+remains the default safe path. A target agent can opt into near-real-time pane
+delivery by registering with `transport=tmux` and a concrete `tmux_target`.
+
+Example:
+
+```bash
+mempal cowork-register \
+  --agent-id codex-a \
+  --tool codex \
+  --cwd "$PWD" \
+  --transport tmux \
+  --tmux-target mempal:0.1
+```
+
+After that, `cowork-send`, `cowork-broadcast`, and
+`mempal_cowork_bus action=send|broadcast` use the same transport-aware bus core.
+For tmux targets, mempal invokes the local `tmux` binary directly with
+`std::process::Command`; it does not execute through a shell. The delivered text
+is a plain envelope containing source agent id, target agent id, and message
+content.
+
+P86 intentionally does not silently fall back to inbox if tmux fails. A tmux
+transport target means "deliver to this pane"; if that pane or binary is
+unavailable, the send fails and no inbox copy is written. This prevents
+ambiguous double-delivery semantics where a pane may receive a message and then
+later drain the same message from an inbox.
+
+This gives mempal three cowork layers:
+
+- legacy partner handoff: `mempal_cowork_push` for Claude<->Codex pairs
+- multi-agent bus inbox: explicit `agent_id` routing with per-agent inbox files
+- tmux transport: explicit pane delivery for registered concrete agents
+
+## Cowork Bus Event Log
+
+P87 adds an operational event log to the multi-agent bus. Communication is no
+longer only "fire and inspect inbox"; every important bus action also appends a
+JSON Lines event under:
+
+```text
+~/.mempal/cowork-bus/<encoded_project_identity>/events.jsonl
+```
+
+The event stream records:
+
+- `register` events when a concrete agent id is registered or updated
+- `send` and `broadcast` delivery events for successful inbox or tmux delivery
+- `send` / `broadcast` failure events for tmux hard failures
+- `drain` events when an agent drains its per-agent inbox
+
+Replay is intentionally read-only. `mempal cowork-events --cwd <repo>` and
+`mempal_cowork_bus action=events` list the operational event stream; they do
+not redeliver messages, drain inboxes, trigger tmux, or ingest anything into
+`palace.db`. Message bodies are represented as bounded `message_preview`
+fields, so the event stream is an operational audit trail rather than a second
+durable memory store.
+
+This is the first runtime-ops layer above P84-P86. It gives later delivery
+ack/status, presence, thread/channel, and tmux peek work a shared evidence
+source for "what happened on the bus" without changing the core memory schema.
+
+## Cowork Delivery Ack And Status
+
+P88 derives delivery status from the P87 event stream. There is no mutable
+status table and no database migration. The event id of each successful or
+failed delivery is the `message_id` surfaced to CLI and MCP callers.
+
+Status is computed by replaying `events.jsonl`:
+
+- `pending`: delivery succeeded and has not been drained or acked
+- `drained`: a later drain event consumed the target agent's inbox message
+- `acked`: the target agent explicitly appended an ack event for that
+  `message_id`
+- `failed`: the original delivery event was a hard transport failure
+
+The user-facing surfaces are:
+
+```bash
+mempal cowork-deliveries --cwd "$PWD" --agent-id codex-a
+mempal cowork-ack --cwd "$PWD" --agent-id codex-a --message-id evt-...
+```
+
+The MCP surface reuses `mempal_cowork_bus` with `action=deliveries` and
+`action=ack`. Ack is explicit and append-only: it does not mutate inbox files,
+does not redeliver messages, and does not write `palace.db`. This keeps the
+bus operationally observable while preserving the original ephemeral cowork
+boundary.
+
+## Cowork Agent Presence
+
+P89 adds explicit heartbeat-based presence. Registration gives each concrete
+agent a `last_seen_at`, and agents can refresh it with:
+
+```bash
+mempal cowork-heartbeat --cwd "$PWD" --agent-id codex-a
+```
+
+Presence is derived when listing agents:
+
+- `online`: last seen within the default 10 minute stale threshold
+- `stale`: last seen exists but is older than the stale threshold
+- `never_seen`: legacy or hand-edited records without `last_seen_at`
+
+The same semantics are exposed through `mempal_cowork_bus action=heartbeat`
+and `action=list`. This remains an explicit signal: mempal does not install a
+daemon, does not infer liveness from tmux panes, and does not silently record
+background heartbeat events. That keeps presence useful for coordination
+without pretending to know more than the agent instances have explicitly
+reported.
+
+## Cowork Threads And Channels
+
+P90 adds two coordination scopes above raw agent addressing:
+
+- `thread_id` separates work streams such as `p90-review` or `release-audit`
+- `channel` names a group of concrete agents such as `review` or `frontend`
+
+Direct `cowork-send` and `cowork-broadcast` can attach `thread_id` and
+`channel` metadata. The metadata is carried into bus inbox messages, events,
+and delivery status replay, so a receiver can see which work stream a message
+belongs to when draining its inbox.
+
+Channels are explicit registry entries, not inferred from tool family names:
+
+```bash
+mempal cowork-channel-set \
+  --cwd "$PWD" \
+  --channel review \
+  --agent codex-a \
+  --agent codex-b
+
+mempal cowork-channel-send \
+  --cwd "$PWD" \
+  --from claude-main \
+  --channel review \
+  --thread-id p90-review \
+  --message "review this patch"
+```
+
+`cowork-channel-set` replaces membership for one channel, and
+`cowork-channel-send` fans out through the same delivery core as broadcast. The
+MCP surface exposes the same behavior as `mempal_cowork_bus`
+`action=channel_set|channel_list|channel_send`.
+
+P90 still does not make channels durable memory. They are operational routing
+state under `~/.mempal/cowork-bus/<project>/`, and they do not write
+`palace.db`.
+
+## Cowork Tmux Live Peek
+
+P91 completes the tmux runtime-ops loop by adding explicit read-only pane
+inspection for agents registered with `transport=tmux` and a concrete
+`tmux_target`.
+
+```bash
+mempal cowork-tmux-peek \
+  --cwd "$PWD" \
+  --agent-id codex-a \
+  --lines 80
+```
+
+The MCP surface is `mempal_cowork_bus action=tmux_peek`. Both CLI and MCP use
+the same adapter: a direct `std::process::Command` invocation of the local
+`tmux` binary with `capture-pane`. It is not executed through a shell, and it
+does not discover panes automatically. The registered `tmux_target` is the
+authority.
+
+Peek is deliberately not delivery. It does not append `events.jsonl`, does not
+write an inbox message, does not update channel or agent registry state, and
+does not write `palace.db`. Capture failure is a hard error rather than a
+fallback to inbox or legacy `mempal_peek_partner`.
+
+This preserves the separation between:
+
+- agent live observation: read-only tmux pane capture
+- operational communication: inbox/tmux send through the cowork bus
+- durable memory: explicit ingest into the palace database
+
+## Multi-Agent Cowork Runbook
+
+P92 makes the multi-agent runtime surfaces operationally usable by adding the
+authoritative [COWORK-RUNBOOK](COWORK-RUNBOOK.md) plus a read-only CLI surface:
+
+```bash
+mempal cowork-runbook --format plain
+mempal cowork-runbook --format json
+```
+
+The runbook describes concrete agent registration, direct send, broadcast,
+channels, threads, drain, delivery status, ack, presence, tmux delivery, tmux
+peek, doctor, sessions, handoff summaries, and explicit memory capture. Reading
+the runbook does not touch `~/.mempal` or `palace.db`.
+
+## Cowork Doctor
+
+P93 adds deterministic runtime diagnostics:
+
+```bash
+mempal cowork-doctor --cwd "$PWD"
+mempal cowork-doctor --cwd "$PWD" --probe-tmux --format json
+```
+
+The MCP equivalent is `mempal_cowork_bus action=doctor`. Doctor checks registry
+size, channel count, session count, stale or never-seen agents, pending
+deliveries, and optional tmux target reachability. tmux probing uses direct
+`tmux has-session -t <target>` invocation, not a shell.
+
+Doctor is read-only. It does not append events, drain inboxes, update
+heartbeats, repair state, or write memory.
+
+## Cowork Team Sessions
+
+P94 adds runtime team sessions stored under:
+
+```text
+~/.mempal/cowork-bus/<encoded_project_identity>/sessions.json
+```
+
+Sessions bind a collaboration goal to concrete agents, optional channels, and
+an optional thread id:
+
+```bash
+mempal cowork-session-create \
+  --cwd "$PWD" \
+  --session-id p94-review \
+  --title "P94 review" \
+  --agent claude-main \
+  --agent codex-a \
+  --thread-id p94-review
+
+mempal cowork-sessions --cwd "$PWD"
+mempal cowork-session-status --cwd "$PWD" --session-id p94-review --status paused
+```
+
+The MCP actions are `session_create`, `session_list`, and `session_status`.
+Session changes append operational events, but they do not become durable
+project memory and they do not change message delivery semantics.
+
+## Cowork Handoff Summary
+
+P95 adds deterministic handoff summaries:
+
+```bash
+mempal cowork-handoff --cwd "$PWD"
+mempal cowork-handoff --cwd "$PWD" --thread-id p95-review --format json
+```
+
+The MCP action is `mempal_cowork_bus action=handoff`. A handoff summarizes
+active sessions, agents and presence, pending deliveries, and recent events. It
+supports `thread_id`, `channel`, `session_id`, and `limit` filters. It does not
+call an LLM, drain inboxes, ack deliveries, or persist memory.
+
+## Cowork Memory Capture
+
+P96 adds the explicit bridge from runtime cowork state to durable evidence:
+
+```bash
+mempal cowork-capture \
+  --cwd "$PWD" \
+  --summary-source handoff \
+  --session-id p95-review \
+  --execute \
+  --format json
+```
+
+The MCP action is `mempal_cowork_bus action=capture`. Capture defaults to
+dry-run. With `--execute` / `execute=true`, it writes one evidence drawer under
+wing `cowork-capture` by default. It does not capture raw tmux pane text, does
+not promote knowledge, does not create knowledge cards, and does not alter
+delivery status. This keeps runtime communication ephemeral unless an agent or
+human explicitly crosses the memory boundary.
+
+## Maintenance Runbook
+
+P97 adds the authoritative [MAINTENANCE-RUNBOOK](MAINTENANCE-RUNBOOK.md) plus a
+read-only CLI:
+
+```bash
+mempal maintenance-runbook --format plain
+mempal maintenance-runbook --format json
+```
+
+The runbook stitches together research validation, research evidence ingest,
+knowledge distill, card lifecycle gates, context adoption, runtime adoption
+review, rollback, cowork handoff, and explicit cowork capture. It is a
+checklist for dream-cycle style maintenance, not a daemon or scheduler.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-25-p82-opt-in-runtime-instrumentation-wrapper.md
+++ b/docs/plans/2026-05-25-p82-opt-in-runtime-instrumentation-wrapper.md
@@ -1,0 +1,35 @@
+# P82 Opt-In Runtime Instrumentation Wrapper
+
+Goal: implement the first explicit `opt_in_wrapper` runtime instrumentation path
+without hooks, background capture, MCP command execution, or lifecycle authority.
+
+Spec: `specs/p82-opt-in-runtime-instrumentation-wrapper.spec.md`
+
+## Plan
+
+- [x] Add P82 task contract and plan.
+- [x] Add failing CLI tests for wrapper dry-run, execute, failure mapping,
+      warning-quality block, and missing child command.
+- [x] Implement CLI `mempal phase3 adoption wrap` in `src/main.rs`.
+- [x] Reuse P72 capture mapping and P69 checked-record quality gate for all
+      wrapper writes.
+- [x] Update MEMORY_PROTOCOL, MIND-MODEL, AGENTS, and CLAUDE inventories.
+- [x] Run spec validation and targeted tests.
+- [x] Run full Rust verification before completion.
+
+## Verification
+
+```bash
+agent-spec parse specs/p82-opt-in-runtime-instrumentation-wrapper.spec.md
+agent-spec lint specs/p82-opt-in-runtime-instrumentation-wrapper.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_dry_run_executes_child_without_writing
+cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_execute_writes_ready_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_failure_maps_rejected_and_exits_nonzero
+cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_blocks_warning_by_default
+cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_rejects_missing_child_command
+rg -n "p82-opt-in-runtime-instrumentation-wrapper|P82 opt-in runtime instrumentation wrapper|phase3 adoption wrap" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md src/core/protocol.rs
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test
+```

--- a/docs/plans/2026-05-25-p83-cognitive-brief.md
+++ b/docs/plans/2026-05-25-p83-cognitive-brief.md
@@ -1,0 +1,38 @@
+# P83 Cognitive Brief
+
+Goal: add a deterministic, citation-first `mempal brief` CLI report that
+organizes existing context into a cognitive brief without LLM synthesis or DB
+mutation.
+
+Spec: `specs/p83-cognitive-brief.spec.md`
+
+## Plan
+
+- [x] Add P83 task contract and implementation plan.
+- [x] Add failing CLI tests for JSON brief, plain brief, empty uncertainty, and
+      invalid format.
+- [x] Implement `src/brief.rs` using existing context assembly with evidence and
+      cards enabled.
+- [x] Wire top-level CLI `mempal brief <query>` with plain and JSON output.
+- [x] Update MEMORY_PROTOCOL, MIND-MODEL, AGENTS, and CLAUDE inventories.
+- [x] Run spec validation, targeted tests, and full Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p83-cognitive-brief.spec.md
+agent-spec lint specs/p83-cognitive-brief.spec.md --min-score 0.7
+cargo test --test cognitive_brief test_cli_brief_json_includes_citations_uncertainty_and_actions
+cargo test --test cognitive_brief test_cli_brief_plain_lists_sections_and_citations
+cargo test --test cognitive_brief test_cli_brief_no_evidence_reports_uncertainty
+cargo test --test cognitive_brief test_cli_brief_rejects_invalid_format
+rg -n "p83-cognitive-brief|P83 cognitive brief|mempal brief" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md src/core/protocol.rs
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+cargo test --features rest
+git diff --check
+```

--- a/docs/plans/2026-05-25-p84-multi-agent-cowork-bus.md
+++ b/docs/plans/2026-05-25-p84-multi-agent-cowork-bus.md
@@ -1,0 +1,39 @@
+# P84 Multi-Agent Cowork Bus
+
+Goal: upgrade cowork from tool-family pair routing (`claude` / `codex`) to a
+project-scoped bus with concrete `agent_id` addressing and per-agent inboxes.
+
+Spec: `specs/p84-multi-agent-cowork-bus.spec.md`
+
+## Plan
+
+- [x] Add P84 task contract and implementation plan.
+- [x] Add failing CLI tests for register/list, unicast drain isolation,
+      broadcast fanout, invalid addressing, and legacy compatibility.
+- [x] Implement `src/cowork/bus.rs` with registry, agent id validation, and
+      per-agent inbox helpers.
+- [x] Wire CLI commands `cowork-register`, `cowork-send`,
+      `cowork-broadcast`, `cowork-agent-drain`, and `cowork-agents`.
+- [x] Update MIND-MODEL, AGENTS, and CLAUDE inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p84-multi-agent-cowork-bus.spec.md
+agent-spec lint specs/p84-multi-agent-cowork-bus.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_register_and_agents_list
+cargo test --test cowork_bus test_cli_cowork_send_drains_only_target_agent
+cargo test --test cowork_bus test_cli_cowork_broadcast_fans_out_to_each_agent
+cargo test --test cowork_bus test_cli_cowork_bus_rejects_invalid_addressing
+cargo test --test cowork_bus test_legacy_cowork_status_still_lists_tool_inboxes
+rg -n "p84-multi-agent-cowork-bus|P84 multi-agent cowork bus|cowork-register|cowork-send" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test --test cowork_bus
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+git diff --check
+```

--- a/docs/plans/2026-05-25-p85-mcp-multi-agent-cowork-bus.md
+++ b/docs/plans/2026-05-25-p85-mcp-multi-agent-cowork-bus.md
@@ -1,0 +1,37 @@
+# P85 MCP Multi-Agent Cowork Bus
+
+Goal: expose the P84 concrete `agent_id` cowork bus through one MCP tool so
+agents can use multi-instance routing without shell-only coordination.
+
+Spec: `specs/p85-mcp-multi-agent-cowork-bus.spec.md`
+
+## Plan
+
+- [x] Add P85 task contract and implementation plan.
+- [x] Add failing MCP handler tests for register/list, send/drain isolation,
+      broadcast fanout, invalid addressing, and protocol/tool registry.
+- [x] Add `mempal_cowork_bus` DTOs in `src/mcp/tools.rs`.
+- [x] Implement action-based MCP handler in `src/mcp/server.rs`.
+- [x] Update MEMORY_PROTOCOL, MIND-MODEL, AGENTS, and CLAUDE inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p85-mcp-multi-agent-cowork-bus.spec.md
+agent-spec lint specs/p85-mcp-multi-agent-cowork-bus.spec.md --min-score 0.7
+cargo test --lib test_mcp_cowork_bus_register_and_list
+cargo test --lib test_mcp_cowork_bus_send_drains_only_target
+cargo test --lib test_mcp_cowork_bus_broadcast_fans_out
+cargo test --lib test_mcp_cowork_bus_rejects_invalid_action_and_addressing
+cargo test --lib test_mcp_tool_registry_and_protocol_include_cowork_bus
+rg -n "p85-mcp-multi-agent-cowork-bus|P85 MCP multi-agent cowork bus|mempal_cowork_bus|agent_id" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md src/core/protocol.rs
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test --lib test_mcp_cowork_bus
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+git diff --check
+```

--- a/docs/plans/2026-05-25-p86-tmux-cowork-transport.md
+++ b/docs/plans/2026-05-25-p86-tmux-cowork-transport.md
@@ -1,0 +1,37 @@
+# P86 Tmux Cowork Transport
+
+Goal: make `transport=tmux` an active opt-in delivery path for concrete
+`agent_id` bus targets while keeping `inbox` as the safe default.
+
+Spec: `specs/p86-tmux-cowork-transport.spec.md`
+
+## Plan
+
+- [x] Add P86 task contract and implementation plan.
+- [x] Add failing CLI and MCP tests using fake `tmux` binaries.
+- [x] Extend bus delivery reports for transport-aware output.
+- [x] Implement direct `tmux send-keys` delivery with no shell and hard failure
+      on non-zero exit.
+- [x] Update MIND-MODEL, AGENTS, and CLAUDE inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p86-tmux-cowork-transport.spec.md
+agent-spec lint specs/p86-tmux-cowork-transport.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_send_to_tmux_transport_invokes_tmux
+cargo test --test cowork_bus test_cli_cowork_register_tmux_requires_target
+cargo test --test cowork_bus test_cli_cowork_tmux_failure_does_not_write_inbox
+cargo test --lib test_mcp_cowork_bus_send_to_tmux_transport_invokes_tmux
+rg -n "p86-tmux-cowork-transport|P86 tmux cowork transport|transport=tmux|tmux_target" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test --test cowork_bus
+cargo test --lib test_mcp_cowork_bus
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+git diff --check
+```

--- a/docs/plans/2026-05-25-p87-cowork-bus-event-log.md
+++ b/docs/plans/2026-05-25-p87-cowork-bus-event-log.md
@@ -1,0 +1,39 @@
+# P87 Cowork Bus Event Log
+
+Spec: `specs/p87-cowork-bus-event-log.spec.md`
+
+## Plan
+
+- [x] Define P87 task contract and implementation plan.
+- [x] Add append-only `events.jsonl` storage helpers to `src/cowork/bus.rs`.
+- [x] Record register, send/broadcast delivery, drain, and tmux failure events.
+- [x] Expose CLI `cowork-events --cwd <path> [--limit N] [--format plain|json]`.
+- [x] Expose MCP `mempal_cowork_bus action=events`.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p87-cowork-bus-event-log.spec.md
+agent-spec lint specs/p87-cowork-bus-event-log.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_events_records_register_send_drain
+cargo test --test cowork_bus test_cli_cowork_events_limit_returns_latest
+cargo test --test cowork_bus test_cli_cowork_events_records_tmux_failure
+cargo test --lib test_mcp_cowork_bus_events_lists_log
+rg -n "p87-cowork-bus-event-log|P87 cowork bus event log|cowork-events|action=events" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md src/core/protocol.rs
+```
+
+## Broader Regression
+
+```bash
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test --test cowork_bus
+cargo test --lib test_mcp_cowork_bus
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+git diff --check
+```

--- a/docs/plans/2026-05-25-p88-cowork-delivery-ack-status.md
+++ b/docs/plans/2026-05-25-p88-cowork-delivery-ack-status.md
@@ -1,0 +1,40 @@
+# P88 Cowork Delivery Ack Status
+
+Spec: `specs/p88-cowork-delivery-ack-status.spec.md`
+
+## Plan
+
+- [x] Define P88 task contract and implementation plan.
+- [x] Add delivery status replay over P87 `events.jsonl`.
+- [x] Expose delivery event id as `message_id` from CLI/MCP send reports.
+- [x] Add CLI `cowork-deliveries` and `cowork-ack`.
+- [x] Add MCP actions `deliveries` and `ack`.
+- [x] Add CLI/MCP tests for pending, drained, acked, and failed states.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p88-cowork-delivery-ack-status.spec.md
+agent-spec lint specs/p88-cowork-delivery-ack-status.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_delivery_status_pending
+cargo test --test cowork_bus test_cli_cowork_delivery_status_drained
+cargo test --test cowork_bus test_cli_cowork_ack_marks_delivery_acked
+cargo test --test cowork_bus test_cli_cowork_failed_delivery_cannot_be_acked
+cargo test --lib test_mcp_cowork_bus_deliveries_and_ack
+```
+
+## Broader Regression
+
+```bash
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test --test cowork_bus
+cargo test --lib test_mcp_cowork_bus
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+git diff --check
+```

--- a/docs/plans/2026-05-25-p89-cowork-agent-presence.md
+++ b/docs/plans/2026-05-25-p89-cowork-agent-presence.md
@@ -1,0 +1,38 @@
+# P89 Cowork Agent Presence
+
+Spec: `specs/p89-cowork-agent-presence.spec.md`
+
+## Plan
+
+- [x] Define P89 task contract and implementation plan.
+- [x] Add `last_seen_at` and read-time presence derivation to bus registry.
+- [x] Add CLI `cowork-heartbeat` and extend `cowork-agents` output.
+- [x] Add MCP `heartbeat` action and list presence DTO fields.
+- [x] Add deterministic CLI/MCP tests with explicit timestamps.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p89-cowork-agent-presence.spec.md
+agent-spec lint specs/p89-cowork-agent-presence.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_heartbeat_updates_presence
+cargo test --test cowork_bus test_cli_cowork_agents_marks_stale_presence
+cargo test --test cowork_bus test_cli_cowork_heartbeat_rejects_unknown_agent
+cargo test --lib test_mcp_cowork_bus_heartbeat_and_presence
+```
+
+## Broader Regression
+
+```bash
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test --test cowork_bus
+cargo test --lib test_mcp_cowork_bus
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+git diff --check
+```

--- a/docs/plans/2026-05-25-p90-cowork-threads-channels.md
+++ b/docs/plans/2026-05-25-p90-cowork-threads-channels.md
@@ -1,0 +1,41 @@
+# P90 Cowork Threads And Channels
+
+Spec: `specs/p90-cowork-threads-channels.spec.md`
+
+## Plan
+
+- [x] Define P90 task contract and implementation plan.
+- [x] Add thread/channel metadata to bus messages, events, and delivery status.
+- [x] Add channel membership storage in the bus registry.
+- [x] Add CLI `cowork-channel-set` and `cowork-channel-send`.
+- [x] Add MCP `channel_set`, `channel_list`, and `channel_send` actions.
+- [x] Add CLI/MCP tests for thread metadata and channel fanout.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p90-cowork-threads-channels.spec.md
+agent-spec lint specs/p90-cowork-threads-channels.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_send_with_thread_metadata
+cargo test --test cowork_bus test_cli_cowork_channel_send_fans_out
+cargo test --test cowork_bus test_cli_cowork_channel_set_replaces_members
+cargo test --test cowork_bus test_cli_cowork_channel_send_rejects_unknown_channel
+cargo test --lib test_mcp_cowork_bus_channel_send
+```
+
+## Broader Regression
+
+```bash
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test --test cowork_bus
+cargo test --lib test_mcp_cowork_bus
+cargo test --test cowork_inbox
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+git diff --check
+```

--- a/docs/plans/2026-05-25-p91-tmux-live-peek.md
+++ b/docs/plans/2026-05-25-p91-tmux-live-peek.md
@@ -1,0 +1,39 @@
+# P91 Tmux Live Peek
+
+Spec: `specs/p91-tmux-live-peek.spec.md`
+
+## Plan
+
+- [x] Define P91 task contract and implementation plan.
+- [x] Add read-only tmux capture adapter to bus core.
+- [x] Add CLI `cowork-tmux-peek`.
+- [x] Add MCP `mempal_cowork_bus action=tmux_peek`.
+- [x] Add CLI/MCP tests for success, rejection, and read-only side effects.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p91-tmux-live-peek.spec.md
+agent-spec lint specs/p91-tmux-live-peek.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_tmux_peek_captures_pane
+cargo test --test cowork_bus test_cli_cowork_tmux_peek_rejects_inbox_agent
+cargo test --test cowork_bus test_cli_cowork_tmux_peek_has_no_bus_side_effects
+cargo test --test cowork_bus test_cli_cowork_tmux_peek_does_not_write_file_output
+cargo test --lib test_mcp_cowork_bus_tmux_peek
+```
+
+## Broader Regression
+
+```bash
+cargo fmt -- --check
+cargo check
+cargo clippy -- -D warnings
+cargo test --test cowork_bus
+cargo test --lib test_mcp_cowork_bus
+cargo test
+cargo check --features rest
+cargo clippy --features rest -- -D warnings
+git diff --check
+```

--- a/docs/plans/2026-05-26-p92-multi-agent-runbook.md
+++ b/docs/plans/2026-05-26-p92-multi-agent-runbook.md
@@ -1,0 +1,23 @@
+# P92 Multi-Agent Cowork Runbook
+
+Spec: `specs/p92-multi-agent-runbook.spec.md`
+
+## Plan
+
+- [x] Define P92 task contract and implementation plan.
+- [x] Add `docs/COWORK-RUNBOOK.md`.
+- [x] Add read-only CLI `cowork-runbook --format plain|json`.
+- [x] Add CLI tests for plain, JSON, invalid format, and side effects.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p92-multi-agent-runbook.spec.md
+agent-spec lint specs/p92-multi-agent-runbook.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_runbook_plain
+cargo test --test cowork_bus test_cli_cowork_runbook_json
+cargo test --test cowork_bus test_cli_cowork_runbook_rejects_invalid_format
+rg -n "p92-multi-agent-runbook|P92 multi-agent cowork runbook|COWORK-RUNBOOK" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+```

--- a/docs/plans/2026-05-26-p93-cowork-doctor.md
+++ b/docs/plans/2026-05-26-p93-cowork-doctor.md
@@ -1,0 +1,24 @@
+# P93 Cowork Doctor
+
+Spec: `specs/p93-cowork-doctor.spec.md`
+
+## Plan
+
+- [x] Define P93 task contract and implementation plan.
+- [x] Add read-only doctor report types and derivation in cowork bus core.
+- [x] Add CLI `cowork-doctor`.
+- [x] Add MCP `mempal_cowork_bus action=doctor`.
+- [x] Add CLI/MCP tests for empty registry, stale/pending state, tmux probe, and read-only behavior.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p93-cowork-doctor.spec.md
+agent-spec lint specs/p93-cowork-doctor.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_doctor_empty_registry
+cargo test --test cowork_bus test_cli_cowork_doctor_reports_stale_and_pending
+cargo test --test cowork_bus test_cli_cowork_doctor_json_tmux_probe
+cargo test --lib test_mcp_cowork_bus_doctor
+```

--- a/docs/plans/2026-05-26-p94-cowork-team-session.md
+++ b/docs/plans/2026-05-26-p94-cowork-team-session.md
@@ -1,0 +1,24 @@
+# P94 Cowork Team Session
+
+Spec: `specs/p94-cowork-team-session.spec.md`
+
+## Plan
+
+- [x] Define P94 task contract and implementation plan.
+- [x] Add session runtime file model in cowork bus core.
+- [x] Add CLI create/list/status commands.
+- [x] Add MCP session actions.
+- [x] Add CLI/MCP tests for create/list/status/error paths.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p94-cowork-team-session.spec.md
+agent-spec lint specs/p94-cowork-team-session.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_session_create_and_list
+cargo test --test cowork_bus test_cli_cowork_session_rejects_unknown_agent
+cargo test --test cowork_bus test_cli_cowork_session_status_update
+cargo test --lib test_mcp_cowork_bus_sessions
+```

--- a/docs/plans/2026-05-26-p95-cowork-handoff-summary.md
+++ b/docs/plans/2026-05-26-p95-cowork-handoff-summary.md
@@ -1,0 +1,24 @@
+# P95 Cowork Handoff Summary
+
+Spec: `specs/p95-cowork-handoff-summary.spec.md`
+
+## Plan
+
+- [x] Define P95 task contract and implementation plan.
+- [x] Add deterministic handoff summary builder in cowork bus core.
+- [x] Add CLI `cowork-handoff`.
+- [x] Add MCP `mempal_cowork_bus action=handoff`.
+- [x] Add CLI/MCP tests for summary shape, filters, invalid format, and read-only behavior.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p95-cowork-handoff-summary.spec.md
+agent-spec lint specs/p95-cowork-handoff-summary.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_handoff_plain
+cargo test --test cowork_bus test_cli_cowork_handoff_filters_thread
+cargo test --test cowork_bus test_cli_cowork_handoff_rejects_invalid_format
+cargo test --lib test_mcp_cowork_bus_handoff
+```

--- a/docs/plans/2026-05-26-p96-cowork-memory-capture.md
+++ b/docs/plans/2026-05-26-p96-cowork-memory-capture.md
@@ -1,0 +1,24 @@
+# P96 Cowork Memory Capture
+
+Spec: `specs/p96-cowork-memory-capture.spec.md`
+
+## Plan
+
+- [x] Define P96 task contract and implementation plan.
+- [x] Add explicit capture plan and execute writer in cowork bus core.
+- [x] Add CLI `cowork-capture`.
+- [x] Add MCP `mempal_cowork_bus action=capture`.
+- [x] Add CLI/MCP tests for dry-run, execute, unsupported source, and no automatic side effects.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p96-cowork-memory-capture.spec.md
+agent-spec lint specs/p96-cowork-memory-capture.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_capture_dry_run_no_write
+cargo test --test cowork_bus test_cli_cowork_capture_execute_writes_evidence
+cargo test --test cowork_bus test_cli_cowork_capture_rejects_unknown_source
+cargo test --lib test_mcp_cowork_bus_capture
+```

--- a/docs/plans/2026-05-26-p97-maintenance-runbook.md
+++ b/docs/plans/2026-05-26-p97-maintenance-runbook.md
@@ -1,0 +1,23 @@
+# P97 Maintenance Runbook
+
+Spec: `specs/p97-maintenance-runbook.spec.md`
+
+## Plan
+
+- [x] Define P97 task contract and implementation plan.
+- [x] Add `docs/MAINTENANCE-RUNBOOK.md`.
+- [x] Add read-only CLI `maintenance-runbook --format plain|json`.
+- [x] Add CLI tests for plain, JSON, invalid format, and side effects.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL-DESIGN inventories.
+- [x] Run spec validation, targeted tests, and Rust verification.
+
+## Verification
+
+```bash
+agent-spec parse specs/p97-maintenance-runbook.spec.md
+agent-spec lint specs/p97-maintenance-runbook.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_maintenance_runbook_plain
+cargo test --test cowork_bus test_cli_maintenance_runbook_json
+cargo test --test cowork_bus test_cli_maintenance_runbook_rejects_invalid_format
+rg -n "p97-maintenance-runbook|P97 maintenance runbook|MAINTENANCE-RUNBOOK" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+```

--- a/specs/p82-opt-in-runtime-instrumentation-wrapper.spec.md
+++ b/specs/p82-opt-in-runtime-instrumentation-wrapper.spec.md
@@ -1,0 +1,127 @@
+spec: task
+name: "P82: opt-in runtime instrumentation wrapper"
+inherits: project
+tags: [phase-3, runtime-adoption, instrumentation, wrapper, cli]
+---
+
+## Intent
+
+P77 allowed `opt_in_wrapper` as the only semi-automatic instrumentation mode,
+but it intentionally stopped before implementing a wrapper. P82 adds the first
+explicit runtime wrapper: a user-invoked CLI command that runs one child command,
+maps the observed exit status into an adoption outcome, and routes any write
+through the existing checked capture path. This closes the smallest practical
+live instrumentation gap without adding hooks, daemons, silent background
+capture, or autonomous lifecycle authority.
+
+## Decisions
+
+- P82 must leave its own `specs/p82-*.spec.md` and matching plan document.
+- Add CLI `mempal phase3 adoption wrap`.
+- The wrapper is explicit opt-in: it only runs when the user invokes the wrap
+  command around a child command.
+- The wrapper executes exactly one child command after `--`.
+- Default outcome is `auto`: child exit code `0` maps to `accepted`, and
+  non-zero exit maps to `rejected`.
+- A caller may override the observed outcome with `--outcome`.
+- Runtime adoption writes only happen when `--execute` is supplied.
+- Any write must reuse the existing P72 capture mapping and P69 checked-record
+  quality gate.
+- Warning-quality writes remain blocked unless `--allow-warnings` is supplied.
+- The wrapper must report child exit code, mapped outcome, capture report, and
+  whether evidence was written.
+- The wrapper must not install hooks, spawn background workers, or change
+  runtime defaults.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p82-opt-in-runtime-instrumentation-wrapper.spec.md
+- docs/plans/2026-05-25-p82-opt-in-runtime-instrumentation-wrapper.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/main.rs
+- src/core/protocol.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema migrations.
+- Do not add MCP write access for shell command execution.
+- Do not install shell hooks, daemon processes, or background capture.
+- Do not bypass `capture` / `record_checked` quality gates.
+- Do not write events unless `--execute` is explicitly supplied.
+- Do not change existing `capture`, `record_checked`, gate, context, search, or
+  default-control semantics.
+- Do not grant autonomous promote/demote authority.
+
+## Acceptance Criteria
+
+Scenario: CLI wrap dry-run executes child but does not write evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_dry_run_executes_child_without_writing
+    Targets: CLI wrapper dry-run behavior and DB side effects.
+  Given an empty runtime adoption event table
+  When running `mempal phase3 adoption wrap --surface runtime-context --query "context pack" --format json -- sh -c "exit 0"`
+  Then the child command is executed
+  And stdout is valid wrapper JSON with `writes=false`
+  And `child_exit_code=0`
+  And `outcome=accepted`
+  And no runtime adoption event is persisted
+
+Scenario: CLI wrap execute writes ready accepted evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_execute_writes_ready_event
+    Targets: CLI wrapper checked capture write path.
+  Given an empty runtime adoption event table
+  When running wrap with `--execute --surface runtime-context --query "context pack" --note "wrapper helped" --format json -- sh -c "exit 0"`
+  Then the report has `writes=true`
+  And the nested checked-record report has `blocked=false`
+  And exactly one runtime adoption event is persisted with `signal=accepted`
+
+Scenario: CLI wrap maps child failure to rejected and propagates failure
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_failure_maps_rejected_and_exits_nonzero
+    Targets: CLI wrapper failure mapping and process exit behavior.
+  Given an empty runtime adoption event table
+  When running wrap with `--surface runtime-context --format json -- sh -c "exit 7"`
+  Then stdout is valid wrapper JSON with `child_exit_code=7`
+  And `outcome=rejected`
+  And the wrapper exits with code `7`
+  And no runtime adoption event is persisted
+
+Scenario: CLI wrap blocks warning-quality writes by default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_blocks_warning_by_default
+    Targets: CLI wrapper checked quality gate.
+  Given an empty runtime adoption event table
+  When running wrap with `--execute --surface card-context --format json -- sh -c "exit 0"` without `--card-id`
+  Then stdout is valid wrapper JSON with `writes=false`
+  And the nested checked-record report has `blocked=true`
+  And no runtime adoption event is persisted
+
+Scenario: CLI wrap rejects missing child command
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_wrap_rejects_missing_child_command
+    Targets: CLI wrapper input validation.
+  Given the wrapper command without a child command
+  When running `mempal phase3 adoption wrap --surface runtime-context`
+  Then the command fails
+  And stderr mentions that a child command is required
+
+Scenario: Protocol and inventories include P82
+  Test:
+    Filter: rg -n "p82-opt-in-runtime-instrumentation-wrapper|P82 opt-in runtime instrumentation wrapper|phase3 adoption wrap" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md src/core/protocol.rs
+    Targets: Project inventories, design document, and embedded protocol.
+  Given project documentation and protocol instructions
+  When searching for P82 and the wrapper command
+  Then the P82 spec, plan, design summary, and protocol guidance are recorded
+
+## Out of Scope
+
+- MCP-side command execution.
+- Automatic live agent tool wrapping.
+- Hook installation.
+- Background adoption capture.
+- Changing card context defaults.
+- Automatic knowledge promotion or demotion.

--- a/specs/p83-cognitive-brief.spec.md
+++ b/specs/p83-cognitive-brief.spec.md
@@ -1,0 +1,115 @@
+spec: task
+name: "P83: cognitive brief"
+inherits: project
+tags: [phase-3, cognitive-brief, synthesis, cli, evidence]
+---
+
+## Intent
+
+P83 adds a deterministic `mempal brief` surface that moves one step beyond
+retrieval: it assembles a cited, uncertainty-aware cognitive brief for a query.
+The brief is not an LLM answer and must not invent facts; it organizes existing
+context, evidence, cards, unresolved cues, uncertainty signals, and suggested
+next actions into a compact report that an agent or human can act on.
+
+## Decisions
+
+- Add top-level CLI `mempal brief <query>`.
+- The brief reuses existing context assembly semantics rather than creating a
+  new retrieval stack.
+- The brief includes `key_facts`, `evidence`, `cards`, `entities`,
+  `unresolved_items`, `uncertainty`, and `next_actions`.
+- Every fact, evidence item, card, unresolved item, and uncertainty item with a
+  source must include drawer/source citation metadata.
+- The brief is deterministic and does not call an LLM.
+- The brief is read-only and must not write drawers, cards, runtime adoption
+  events, config, or audit entries.
+- The CLI supports `--format plain|json`, `--domain`, `--field`, `--cwd`,
+  `--max-items`, and `--dao-tian-limit`.
+- The default brief includes evidence and cards, because the purpose is a
+  synthesis-oriented report rather than a narrow runtime context pack.
+- P83 must leave its own spec and plan per the P76 invariant.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p83-cognitive-brief.spec.md
+- docs/plans/2026-05-25-p83-cognitive-brief.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/brief.rs
+- src/lib.rs
+- src/main.rs
+- src/core/protocol.rs
+- tests/cognitive_brief.rs
+
+### Forbidden
+- Do not add an LLM dependency or network synthesis call.
+- Do not add MCP `mempal_brief`; P83 is CLI-only.
+- Do not add schema migrations.
+- Do not mutate any database state while generating a brief.
+- Do not change existing `mempal search`, `mempal context`, card retrieval, or
+  Phase-3 adoption semantics.
+- Do not claim uncertainty is resolved when supporting evidence is absent.
+- Do not auto-promote, demote, distill, ingest, or record runtime adoption
+  evidence from brief generation.
+
+## Acceptance Criteria
+
+Scenario: CLI brief JSON assembles cited cognitive report
+  Test:
+    Filter: cargo test --test cognitive_brief test_cli_brief_json_includes_citations_uncertainty_and_actions
+    Targets: CLI `mempal brief` JSON behavior and citation shape.
+  Given a test palace with cited knowledge, evidence, and one active linked card whose text contains `Alice pricing`
+  When running `mempal brief "Alice pricing" --format json`
+  Then stdout is valid JSON
+  And it includes `key_facts`, `evidence`, `cards`, `uncertainty`, and `next_actions`
+  And key facts cite `drawer_id` and `source_file`
+  And card entries cite `card_id` plus linked evidence
+  And no runtime adoption event or other database row is written
+
+Scenario: CLI brief plain output is human-readable and citation-first
+  Test:
+    Filter: cargo test --test cognitive_brief test_cli_brief_plain_lists_sections_and_citations
+    Targets: CLI plain renderer.
+  Given the same cited brief fixture
+  When running `mempal brief "Alice pricing"`
+  Then stdout contains `## Summary`, `## Key Facts`, `## Evidence`, `## Uncertainty`, and `## Next Actions`
+  And stdout contains drawer and source citations
+
+Scenario: CLI brief no-evidence case surfaces uncertainty instead of hallucinating
+  Test:
+    Filter: cargo test --test cognitive_brief test_cli_brief_no_evidence_reports_uncertainty
+    Targets: Empty-result behavior.
+  Given an empty palace
+  When running `mempal brief "Unknown account" --format json`
+  Then stdout reports zero evidence items
+  And uncertainty includes a `no_evidence` item
+  And next actions suggest ingesting or adding evidence
+
+Scenario: CLI brief rejects unsupported format
+  Test:
+    Filter: cargo test --test cognitive_brief test_cli_brief_rejects_invalid_format
+    Targets: CLI error handling.
+  Given the brief command
+  When running `mempal brief "Alice pricing" --format yaml`
+  Then the command fails
+  And stderr contains `unsupported brief format`
+
+Scenario: Protocol and inventories include P83
+  Test:
+    Filter: rg -n "p83-cognitive-brief|P83 cognitive brief|mempal brief" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md src/core/protocol.rs
+    Targets: Project inventories, design document, and embedded protocol.
+  Given project documentation and protocol instructions
+  When searching for P83 and the brief command
+  Then the P83 spec, plan, design summary, and protocol guidance are recorded
+
+## Out of Scope
+
+- LLM-generated prose synthesis.
+- MCP brief tool.
+- Browser/UI rendering.
+- Automatic dream-cycle maintenance.
+- Entity graph extraction or KG mutation.
+- Fact-check execution inside brief generation.

--- a/specs/p84-multi-agent-cowork-bus.spec.md
+++ b/specs/p84-multi-agent-cowork-bus.spec.md
@@ -1,0 +1,116 @@
+spec: task
+name: "P84: multi-agent cowork bus"
+inherits: project
+tags: [cowork, multi-agent, cli, inbox, phase-4]
+---
+
+## Intent
+
+P84 upgrades cowork from a Claude/Codex pair protocol into a concrete
+multi-agent bus for several agent instances working in the same project. The
+bus introduces stable `agent_id` addressing, a project-scoped agent registry,
+and per-agent inbox files so that one Claude instance and multiple Codex
+instances can exchange messages without racing on the same `codex` inbox.
+
+## Decisions
+
+- Add a project-scoped multi-agent registry keyed by `agent_id`.
+- Store bus state under `~/.mempal/cowork-bus/<encoded_project_identity>/`.
+- Keep legacy `cowork-drain --target claude|codex` and `mempal_cowork_push`
+  behavior unchanged for backward compatibility.
+- Add CLI commands `cowork-register`, `cowork-send`, `cowork-broadcast`,
+  `cowork-agent-drain`, and `cowork-agents`.
+- `cowork-send` and `cowork-broadcast` address concrete `agent_id` values, not
+  tool families.
+- Each target `agent_id` has its own inbox file; broadcast writes one message to
+  each target inbox.
+- The bus is file-backed and ephemeral like P8 cowork inbox; it must not write
+  palace.db, drawers, cards, runtime adoption events, or schema state.
+- P84 records optional `transport` metadata but only `inbox` delivery is active.
+  tmux delivery is reserved for a later P and must not be silently attempted.
+- `agent_id` accepts ASCII letters, digits, `_`, `-`, and `.`, with length 1-64.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p84-multi-agent-cowork-bus.spec.md
+- docs/plans/2026-05-25-p84-multi-agent-cowork-bus.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/**
+- src/main.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not change palace.db schema or `CURRENT_SCHEMA_VERSION`.
+- Do not write drawers, triples, cards, runtime adoption events, or audit rows.
+- Do not remove or change legacy P8 `cowork-drain`, `cowork-status`, or
+  `cowork-install-hooks` behavior.
+- Do not make `mempal_cowork_push` require `agent_id` in P84.
+- Do not implement tmux send/capture in P84.
+- Do not introduce new runtime dependencies.
+
+## Acceptance Criteria
+
+Scenario: CLI registers concrete agent instances in one project
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_register_and_agents_list
+    Targets: CLI registry behavior and project-scoped state.
+  Given a temporary HOME and one project cwd
+  When registering `claude-main`, `codex-a`, and `codex-b`
+  Then `mempal cowork-agents --cwd <project>` lists all three agent ids
+  And each record preserves its tool name and transport
+  And the registry file exists under `~/.mempal/cowork-bus/<encoded_project_identity>/agents.json`
+  And no palace.db file is created
+
+Scenario: CLI send targets one Codex instance without leaking to another
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_send_drains_only_target_agent
+    Targets: per-agent inbox routing.
+  Given registered agents `claude-main`, `codex-a`, and `codex-b` in the same project
+  When `claude-main` sends a message to `codex-a`
+  Then `mempal cowork-agent-drain --agent-id codex-a` prints the message
+  And `mempal cowork-agent-drain --agent-id codex-b` prints nothing
+  And a second drain of `codex-a` prints nothing
+
+Scenario: CLI broadcast fans out independent inbox copies
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_broadcast_fans_out_to_each_agent
+    Targets: broadcast fanout semantics.
+  Given registered agents `claude-main`, `codex-a`, and `codex-b`
+  When `claude-main` broadcasts one message to `codex-a` and `codex-b`
+  Then draining `codex-a` returns one copy
+  And draining `codex-b` returns one copy
+  And neither drain consumes the other agent's inbox
+
+Scenario: CLI rejects invalid addressing without side effects
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_bus_rejects_invalid_addressing
+    Targets: validation and failure behavior.
+  Given a registered `codex-a`
+  When registering agent id `bad/id`
+  Then the command fails with an invalid agent id error
+  When `codex-a` sends to itself
+  Then the command fails with a self-send error
+  When sending to missing `codex-missing`
+  Then the command fails with an unknown target error
+
+Scenario: Legacy cowork pair behavior remains available
+  Test:
+    Filter: cargo test --test cowork_bus test_legacy_cowork_status_still_lists_tool_inboxes
+    Targets: P8 compatibility boundary.
+  Given a project cwd
+  When running `mempal cowork-status --cwd <project>`
+  Then stdout still contains `claude inbox`
+  And stdout still contains `codex inbox`
+  And it does not require any multi-agent registry file
+
+## Out of Scope
+
+- MCP multi-agent bus surface.
+- tmux send/capture transport.
+- Hook auto-installation for individual `agent_id` values.
+- Cross-machine transport.
+- Durable message history after drain.
+- Message threading, acknowledgement, or retry protocol.

--- a/specs/p85-mcp-multi-agent-cowork-bus.spec.md
+++ b/specs/p85-mcp-multi-agent-cowork-bus.spec.md
@@ -1,0 +1,104 @@
+spec: task
+name: "P85: MCP multi-agent cowork bus"
+inherits: project
+tags: [cowork, multi-agent, mcp, inbox, phase-4]
+---
+
+## Intent
+
+P85 exposes the P84 multi-agent cowork bus to agent runtimes through MCP. Agents
+should be able to register concrete `agent_id` instances, list the project bus,
+send or broadcast messages, and drain their own per-agent inbox without falling
+back to shell-only CLI coordination.
+
+## Decisions
+
+- Add one MCP tool `mempal_cowork_bus` with action-based requests.
+- Supported actions are `register`, `list`, `send`, `broadcast`, and `drain`.
+- The MCP tool reuses P84 file-backed registry and per-agent inbox functions.
+- The MCP tool requires explicit `agent_id` values; it must not infer concrete
+  instances from `client_info.name`.
+- `send` and `broadcast` write only to per-agent bus inboxes under
+  `~/.mempal/cowork-bus/<encoded_project_identity>/`.
+- `drain` returns and consumes only the requested `agent_id` inbox.
+- The tool must be read/write only for ephemeral bus files and must not write
+  palace.db, drawers, cards, runtime adoption events, or schema state.
+- tmux transport remains out of scope for P85.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p85-mcp-multi-agent-cowork-bus.spec.md
+- docs/plans/2026-05-25-p85-mcp-multi-agent-cowork-bus.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/core/protocol.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+
+### Forbidden
+- Do not change P84 CLI behavior.
+- Do not change palace.db schema or `CURRENT_SCHEMA_VERSION`.
+- Do not write drawers, triples, cards, runtime adoption events, or audit rows.
+- Do not add a separate MCP tool for each bus action.
+- Do not implement tmux send/capture in P85.
+- Do not make legacy `mempal_cowork_push` depend on P84 registry.
+
+## Acceptance Criteria
+
+Scenario: MCP registers and lists concrete agents
+  Test:
+    Filter: test_mcp_cowork_bus_register_and_list
+    Targets: `mempal_cowork_bus` register/list actions.
+  Given a temporary HOME and one project cwd
+  When calling `mempal_cowork_bus` with action `register` for `claude-main`, `codex-a`, and `codex-b`
+  And calling action `list`
+  Then the response contains all three registered agent ids
+  And no palace.db side effect is required for bus state
+
+Scenario: MCP send drains only the addressed agent
+  Test:
+    Filter: test_mcp_cowork_bus_send_drains_only_target
+    Targets: `mempal_cowork_bus` send/drain actions.
+  Given registered agents `claude-main`, `codex-a`, and `codex-b`
+  When action `send` sends a message from `claude-main` to `codex-a`
+  Then action `drain` for `codex-a` returns the message
+  And action `drain` for `codex-b` returns zero messages
+
+Scenario: MCP broadcast fans out per target
+  Test:
+    Filter: test_mcp_cowork_bus_broadcast_fans_out
+    Targets: `mempal_cowork_bus` broadcast action.
+  Given registered agents `claude-main`, `codex-a`, and `codex-b`
+  When action `broadcast` sends one message to `codex-a` and `codex-b`
+  Then draining each target returns one independent copy
+
+Scenario: MCP rejects invalid action and addressing without mutation
+  Test:
+    Filter: test_mcp_cowork_bus_rejects_invalid_action_and_addressing
+    Targets: MCP error mapping.
+  Given a registered `codex-a`
+  When action `register` uses agent id `bad/id`
+  Then the call fails with invalid params
+  When action `send` sends from `codex-a` to `codex-a`
+  Then the call fails with invalid params
+  When action `unknown` is used
+  Then the call fails with invalid params
+
+Scenario: Protocol advertises the multi-agent bus boundary
+  Test:
+    Filter: test_mcp_tool_registry_and_protocol_include_cowork_bus
+    Targets: MCP tool registry and MEMORY_PROTOCOL.
+  Given the MCP server tool registry and embedded protocol
+  When inspecting tool names and instructions
+  Then `mempal_cowork_bus` is present
+  And protocol text says concrete `agent_id` bus routing is separate from legacy partner push
+
+## Out of Scope
+
+- tmux transport.
+- Hook installation per `agent_id`.
+- Auto-discovering agent ids from MCP client names.
+- Durable bus message history.
+- Replacing legacy `mempal_cowork_push`.

--- a/specs/p86-tmux-cowork-transport.spec.md
+++ b/specs/p86-tmux-cowork-transport.spec.md
@@ -1,0 +1,101 @@
+spec: task
+name: "P86: tmux cowork transport"
+inherits: project
+tags: [cowork, multi-agent, tmux, transport, phase-4]
+---
+
+## Intent
+
+P86 activates tmux as an explicit delivery transport for the P84/P85
+multi-agent cowork bus. A registered `agent_id` can opt into `transport=tmux`
+with a concrete tmux pane target, allowing near-real-time delivery to that pane
+while preserving inbox as the safe default transport.
+
+## Decisions
+
+- `transport=inbox` remains the default and continues to append to per-agent
+  inbox files.
+- `transport=tmux` requires `tmux_target` at registration time.
+- Sending to a `transport=tmux` target invokes the local `tmux` binary with
+  direct `std::process::Command` arguments; no shell is used.
+- The tmux payload is a plain text envelope containing source agent id, target
+  agent id, and message content.
+- tmux delivery does not write an inbox copy, avoiding duplicate delivery when
+  the pane receives the message immediately.
+- tmux command failure is a hard send failure and must not silently fall back
+  to inbox.
+- P86 reuses the existing P84 CLI and P85 MCP `send` / `broadcast` surfaces.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p86-tmux-cowork-transport.spec.md
+- docs/plans/2026-05-25-p86-tmux-cowork-transport.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not make tmux the default transport.
+- Do not execute tmux through a shell.
+- Do not install hooks, daemons, watchers, or background processes.
+- Do not write palace.db, drawers, cards, runtime adoption events, or schema
+  state.
+- Do not silently fall back to inbox if tmux delivery fails.
+- Do not change legacy `mempal_cowork_push` behavior.
+
+## Acceptance Criteria
+
+Scenario: CLI sends to tmux transport through direct tmux command
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_send_to_tmux_transport_invokes_tmux
+    Targets: CLI send path and tmux adapter.
+  Given a fake `tmux` executable first in PATH
+  And registered `claude-main` with `transport=inbox`
+  And registered `codex-a` with `transport=tmux` and `tmux_target=mempal:0.1`
+  When `mempal cowork-send --from claude-main --to codex-a` sends a message
+  Then the fake tmux log records `send-keys`, `-t`, `mempal:0.1`, and the message envelope
+  And `mempal cowork-agent-drain --agent-id codex-a` returns no inbox message
+
+Scenario: CLI rejects tmux transport without target
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_register_tmux_requires_target
+    Targets: registration validation.
+  Given a project cwd
+  When registering `codex-a` with `transport=tmux` and no `tmux_target`
+  Then the command fails
+  And stderr contains `tmux_target is required`
+
+Scenario: CLI tmux failure is not silently converted to inbox delivery
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_tmux_failure_does_not_write_inbox
+    Targets: failure boundary.
+  Given a fake `tmux` executable that exits non-zero
+  And registered `codex-a` with `transport=tmux`
+  When sending a message to `codex-a`
+  Then the send command fails
+  And draining `codex-a` returns no message
+
+Scenario: MCP send uses tmux transport through shared bus core
+  Test:
+    Filter: test_mcp_cowork_bus_send_to_tmux_transport_invokes_tmux
+    Targets: src/mcp/server.rs MCP send path and shared bus core.
+  Given fake tmux in PATH
+  And the MCP server handler in `src/mcp/server.rs` is the exercised entry point
+  And registered `codex-a` with `transport=tmux` through `mempal_cowork_bus`
+  When `mempal_cowork_bus action=send` targets `codex-a`
+  Then the response reports delivery transport `tmux`
+  And fake tmux receives the message envelope
+
+## Out of Scope
+
+- tmux pane discovery.
+- tmux capture-pane based peek.
+- Retrying failed tmux sends.
+- Cross-machine tmux or SSH transport.
+- Shell-specific quoting behavior.

--- a/specs/p87-cowork-bus-event-log.spec.md
+++ b/specs/p87-cowork-bus-event-log.spec.md
@@ -1,0 +1,118 @@
+spec: task
+name: "P87: cowork bus event log"
+inherits: project
+tags: [cowork, multi-agent, event-log, replay, phase-4]
+---
+
+## Intent
+
+P87 adds an append-only operational event log to the P84-P86 multi-agent
+cowork bus. The bus can already route messages between concrete agent
+instances; this task makes those actions inspectable and replayable as an
+audit trail without writing `palace.db`.
+
+## Decisions
+
+- Store bus events as JSON Lines at
+  `~/.mempal/cowork-bus/<encoded_project_identity>/events.jsonl`.
+- Record successful register, send, broadcast delivery, and drain actions.
+- Record tmux delivery failure events before returning the hard send failure.
+- Event replay means listing the recorded operational events; it does not
+  redeliver messages or mutate inbox state.
+- Expose replay through CLI command `cowork-events` and MCP action
+  `mempal_cowork_bus action=events`.
+- Keep message content as a bounded `message_preview`, not a second full
+  durable message store.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p87-cowork-bus-event-log.spec.md
+- docs/plans/2026-05-25-p87-cowork-bus-event-log.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/cowork/mod.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not write `palace.db`, drawers, cards, runtime adoption events, or schema
+  state.
+- Do not make event replay redeliver inbox or tmux messages.
+- Do not store full message bodies in event records.
+- Do not change legacy `mempal_cowork_push` or `mempal_peek_partner`
+  behavior.
+- Do not introduce a daemon, watcher, hook, or background event collector.
+
+## Acceptance Criteria
+
+Scenario: CLI replay records register, send, and drain events
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_events_records_register_send_drain
+    Targets: `cowork-register`, `cowork-send`, `cowork-agent-drain`, `cowork-events`, and events.jsonl file output.
+  Given a project with registered `claude-main` and `codex-a`
+  When `claude-main` sends an inbox message to `codex-a`
+  And `codex-a` drains its inbox
+  Then `mempal cowork-events --cwd <repo>` prints register, send, and drain events
+  And the output includes event ids, status values, actor agent ids, and target agent ids
+  And the event file exists under `cowork-bus/<project>/events.jsonl`
+
+Scenario: CLI JSON replay is machine-readable
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_events_json_is_machine_readable
+    Targets: `cowork-events --format json` stdout behavior.
+  Given recorded bus events
+  When `mempal cowork-events --cwd <repo> --format json` runs
+  Then stdout parses as a JSON array of event records
+  And stderr is empty
+
+Scenario: JSONL file output is append-only
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_events_file_output_is_append_only
+    Targets: `events.jsonl` file output.
+  Given an existing `events.jsonl` file with register events
+  When a send event is recorded
+  Then the file output gains one JSON line
+  And the existing event lines remain unchanged
+
+Scenario: CLI replay limit returns the latest events only
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_events_limit_returns_latest
+    Targets: `cowork-events --limit`.
+  Given more than two recorded bus events
+  When `mempal cowork-events --cwd <repo> --limit 2` runs
+  Then exactly two event lines are printed
+  And they correspond to the latest recorded events in append order
+
+Scenario: CLI logs tmux delivery failure without inbox fallback
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_events_records_tmux_failure
+    Targets: tmux failure path and event log append.
+  Given a fake `tmux` executable that exits non-zero
+  And registered `codex-a` with `transport=tmux`
+  When sending a message to `codex-a`
+  Then the send command fails
+  And `cowork-events` includes a failed tmux delivery event
+  And draining `codex-a` returns no inbox message
+
+Scenario: MCP events action replays the shared bus event log
+  Test:
+    Filter: test_mcp_cowork_bus_events_lists_log
+    Targets: `src/mcp/server.rs` `mempal_cowork_bus action=events`.
+  Given bus events created through `mempal_cowork_bus`
+  And the MCP server handler in `src/mcp/server.rs` is the exercised entry point
+  When `mempal_cowork_bus action=events` is called with a limit
+  Then the response includes recorded event DTOs
+  And it does not drain inbox messages or write database state
+
+## Out of Scope
+
+- Delivery acknowledgements or pending/acked state machines.
+- Agent heartbeats or online/stale presence.
+- Thread, channel, or group routing.
+- tmux `capture-pane` live peek.
+- Durable memory ingestion of cowork events.

--- a/specs/p88-cowork-delivery-ack-status.spec.md
+++ b/specs/p88-cowork-delivery-ack-status.spec.md
@@ -1,0 +1,104 @@
+spec: task
+name: "P88: cowork delivery ack status"
+inherits: project
+tags: [cowork, multi-agent, ack, status, phase-4]
+---
+
+## Intent
+
+P88 adds delivery-level acknowledgement and status inspection on top of the
+P87 cowork bus event log. Operators and agents should be able to see whether a
+bus delivery is pending, drained, acked, or failed without introducing a
+database table or background worker.
+
+## Decisions
+
+- Use the P87 delivery event id as the `message_id` exposed by send/broadcast.
+- Derive delivery status by replaying `events.jsonl`; do not add a sidecar
+  mutable status file.
+- `pending` means delivered but not yet drained or acked.
+- `drained` means a later drain event consumed the target inbox message.
+- `acked` means the target agent explicitly appended an ack event for that
+  `message_id`.
+- `failed` means the original delivery event recorded a hard delivery failure.
+- Expose status through CLI `cowork-deliveries` and MCP action `deliveries`.
+- Expose explicit acknowledgement through CLI `cowork-ack` and MCP action
+  `ack`.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p88-cowork-delivery-ack-status.spec.md
+- docs/plans/2026-05-25-p88-cowork-delivery-ack-status.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not add SQLite schema, tables, migrations, or `palace.db` writes.
+- Do not add daemons, watchers, hooks, or automatic background ack capture.
+- Do not make ack mutate inbox message files.
+- Do not acknowledge failed deliveries.
+- Do not change legacy `mempal_cowork_push` or `mempal_peek_partner`
+  behavior.
+
+## Acceptance Criteria
+
+Scenario: CLI send exposes message id and pending status
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_delivery_status_pending
+    Targets: `cowork-send` and `cowork-deliveries`.
+  Given `claude-main` sends an inbox delivery to `codex-a`
+  When `mempal cowork-deliveries --cwd <repo>` runs
+  Then the send output includes `message_id=evt-...`
+  And the delivery status output includes the same message id
+  And the status is `pending`
+
+Scenario: CLI drain changes pending delivery to drained
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_delivery_status_drained
+    Targets: `cowork-agent-drain` and event-log status replay.
+  Given a pending inbox delivery for `codex-a`
+  When `codex-a` drains its inbox
+  Then `cowork-deliveries --agent-id codex-a` reports that delivery as `drained`
+
+Scenario: CLI ack marks a delivery acked without touching inbox
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_ack_marks_delivery_acked
+    Targets: `cowork-ack` and `cowork-deliveries`.
+  Given a pending inbox delivery for `codex-a`
+  When `mempal cowork-ack --agent-id codex-a --message-id <id>` runs
+  Then `cowork-deliveries --agent-id codex-a` reports status `acked`
+  And draining `codex-a` still returns the original message
+
+Scenario: CLI failed tmux delivery reports failed and cannot be acked
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_failed_delivery_cannot_be_acked
+    Targets: tmux failure status and ack rejection.
+  Given a failed tmux delivery event for `codex-a`
+  When `cowork-deliveries --agent-id codex-a` runs
+  Then the status is `failed`
+  And `cowork-ack --agent-id codex-a --message-id <failed_id>` fails
+
+Scenario: MCP deliveries and ack actions use the same event replay
+  Test:
+    Filter: test_mcp_cowork_bus_deliveries_and_ack
+    Targets: `src/mcp/server.rs` `mempal_cowork_bus action=deliveries|ack`.
+  Given a delivery created through `mempal_cowork_bus action=send`
+  And the MCP server handler in `src/mcp/server.rs` is the exercised entry point
+  When `action=ack` acknowledges its message id
+  Then `action=deliveries` returns status `acked`
+  And no `palace.db` file is created
+
+## Out of Scope
+
+- Automatic ack from hook execution.
+- Per-message retry or redelivery.
+- Cross-process locking around status replay.
+- Thread or channel routing.
+- Presence or heartbeat status.

--- a/specs/p89-cowork-agent-presence.spec.md
+++ b/specs/p89-cowork-agent-presence.spec.md
@@ -1,0 +1,96 @@
+spec: task
+name: "P89: cowork agent presence"
+inherits: project
+tags: [cowork, multi-agent, presence, heartbeat, phase-4]
+---
+
+## Intent
+
+P89 adds explicit heartbeat-based presence to the multi-agent cowork bus.
+Agents and operators should be able to distinguish registered-but-never-seen,
+online, and stale agents without adding a daemon or automatic background
+collector.
+
+## Decisions
+
+- Add `last_seen_at` to each bus agent registry record.
+- `cowork-register` initializes `last_seen_at` to registration time.
+- `cowork-heartbeat --agent-id <id>` updates `last_seen_at` and appends a
+  heartbeat event.
+- Presence states are derived at read time: `never_seen`, `online`, or `stale`.
+- Default stale threshold is 10 minutes.
+- CLI `cowork-agents` displays presence and last seen fields.
+- MCP `mempal_cowork_bus action=list` returns presence and last seen fields,
+  and action `heartbeat` updates one agent.
+- Tests may pass explicit `--now` / `--seen-at` timestamps for deterministic
+  stale calculations.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p89-cowork-agent-presence.spec.md
+- docs/plans/2026-05-25-p89-cowork-agent-presence.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not add a daemon, watcher, hook, or silent heartbeat capture.
+- Do not write `palace.db`, drawers, cards, runtime adoption events, or schema
+  state.
+- Do not infer presence from tmux pane state.
+- Do not change legacy `mempal_cowork_push` or `mempal_peek_partner`
+  behavior.
+
+## Acceptance Criteria
+
+Scenario: CLI heartbeat updates presence and last seen
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_heartbeat_updates_presence
+    Targets: `src/main.rs` `cowork-heartbeat` and `cowork-agents`.
+  Given registered `codex-a`
+  And the CLI handler in `src/main.rs` is the exercised entry point
+  When `mempal cowork-heartbeat --agent-id codex-a --seen-at 2026-05-25T00:00:00Z` runs
+  And `mempal cowork-agents --now 2026-05-25T00:05:00Z` lists agents
+  Then `codex-a` has `presence=online`
+  And `last_seen_at=2026-05-25T00:00:00Z`
+
+Scenario: CLI stale threshold marks old heartbeat stale
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_agents_marks_stale_presence
+    Targets: presence replay in `cowork-agents`.
+  Given registered `codex-a` last seen at `2026-05-25T00:00:00Z`
+  When `cowork-agents --now 2026-05-25T00:11:00Z` runs
+  Then `codex-a` has `presence=stale`
+
+Scenario: CLI heartbeat rejects unknown agent
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_heartbeat_rejects_unknown_agent
+    Targets: heartbeat validation.
+  Given no registered `codex-missing`
+  When `cowork-heartbeat --agent-id codex-missing` runs
+  Then the command fails
+  And stderr contains `unknown agent`
+
+Scenario: MCP heartbeat and list expose presence
+  Test:
+    Filter: test_mcp_cowork_bus_heartbeat_and_presence
+    Targets: `src/mcp/server.rs` `mempal_cowork_bus action=heartbeat|list`.
+  Given registered `codex-a` through MCP
+  And the MCP server handler in `src/mcp/server.rs` is the exercised entry point
+  When `action=heartbeat` updates `codex-a`
+  Then `action=list` returns `presence=online`
+  And no `palace.db` file is created
+
+## Out of Scope
+
+- Automatic heartbeat from shell hooks.
+- tmux pane liveness detection.
+- Cross-machine presence.
+- Scheduling or cleanup of stale agents.
+- Delivery ack/status changes.

--- a/specs/p90-cowork-threads-channels.spec.md
+++ b/specs/p90-cowork-threads-channels.spec.md
@@ -1,0 +1,106 @@
+spec: task
+name: "P90: cowork threads and channels"
+inherits: project
+tags: [cowork, multi-agent, threads, channels, phase-4]
+---
+
+## Intent
+
+P90 adds thread and channel routing metadata to the multi-agent cowork bus.
+Agents should be able to keep work streams separated by `thread_id`, and
+operators should be able to send one message to a named channel without
+retyping every agent id.
+
+## Decisions
+
+- Add optional `thread_id` and `channel` metadata to bus messages, delivery
+  events, and delivery status replay.
+- Add channel membership to the existing file-backed bus registry.
+- `cowork-channel-set` replaces the membership list for one channel.
+- `cowork-channel-send` fans out to the current channel members using the same
+  delivery core as broadcast.
+- Channel and thread identifiers use the same safe token rules as `agent_id`.
+- MCP reuses `mempal_cowork_bus` actions `channel_set`, `channel_list`, and
+  `channel_send`.
+- Existing `cowork-send` and `cowork-broadcast` remain valid without thread or
+  channel metadata.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p90-cowork-threads-channels.spec.md
+- docs/plans/2026-05-25-p90-cowork-threads-channels.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/cowork/inbox.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+- tests/cowork_inbox.rs
+
+### Forbidden
+- Do not add SQLite schema, migrations, or `palace.db` writes.
+- Do not make channel membership implicit from tool family names.
+- Do not send to unknown channel members.
+- Do not change legacy `mempal_cowork_push` or `mempal_peek_partner`
+  behavior.
+- Do not implement threaded search or persistent memory ingestion.
+
+## Acceptance Criteria
+
+Scenario: CLI send preserves thread metadata in drain output and events
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_send_with_thread_metadata
+    Targets: `cowork-send --thread-id` and bus inbox formatting.
+  Given registered `claude-main` and `codex-a`
+  When `cowork-send --thread-id p90-review` sends a message
+  Then draining `codex-a` includes `thread=p90-review`
+  And `cowork-events` includes `thread_id=p90-review`
+
+Scenario: CLI channel send fans out to channel members
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_channel_send_fans_out
+    Targets: `cowork-channel-set` and `cowork-channel-send`.
+  Given channel `review` contains `codex-a` and `codex-b`
+  When `cowork-channel-send --channel review` sends a message
+  Then both `codex-a` and `codex-b` drain that message
+  And delivery status includes `channel=review`
+
+Scenario: CLI channel set replaces existing membership
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_channel_set_replaces_members
+    Targets: `cowork-channel-set` replacement behavior.
+  Given channel `review` already contains `codex-a` and `codex-b`
+  When `cowork-channel-set --channel review --agent codex-b` runs
+  Then `cowork-channel-send --channel review` sends only to `codex-b`
+  And `codex-a` drains no message
+
+Scenario: CLI channel send rejects unknown channel
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_channel_send_rejects_unknown_channel
+    Targets: channel validation.
+  Given no channel named `missing`
+  When `cowork-channel-send --channel missing` runs
+  Then the command fails
+  And stderr contains `unknown channel`
+
+Scenario: MCP channel actions use shared routing
+  Test:
+    Filter: test_mcp_cowork_bus_channel_send
+    Targets: `src/mcp/server.rs` `mempal_cowork_bus action=channel_set|channel_send`.
+  Given channel `review` is set through MCP
+  And the MCP server handler in `src/mcp/server.rs` is the exercised entry point
+  When `action=channel_send` sends a message
+  Then delivery reports target both channel members
+  And no `palace.db` file is created
+
+## Out of Scope
+
+- Thread-specific search or context assembly.
+- Channel membership discovery from tmux sessions.
+- Role-based permissions.
+- Cross-project channels.
+- Automatic channel cleanup.

--- a/specs/p91-tmux-live-peek.spec.md
+++ b/specs/p91-tmux-live-peek.spec.md
@@ -1,0 +1,104 @@
+spec: task
+name: "P91: tmux live peek"
+inherits: project
+tags: [cowork, multi-agent, tmux, peek, phase-4]
+---
+
+## Intent
+
+P91 adds explicit read-only tmux pane peek for agents registered with
+`transport=tmux`. This complements P86 tmux send by letting an operator or
+agent inspect the live pane state without changing inboxes, events, or memory.
+
+## Decisions
+
+- Add CLI `cowork-tmux-peek --agent-id <id> --cwd <repo>`.
+- Add MCP action `mempal_cowork_bus action=tmux_peek`.
+- Only agents registered with `transport=tmux` and `tmux_target` can be peeked.
+- Use direct `std::process::Command` invocation of `tmux capture-pane`; do not
+  execute through a shell.
+- Default capture size is 80 lines; accepted line range is 1..=500.
+- tmux capture failure is a hard error and does not fall back to inbox or
+  legacy live session peek.
+- The operation is read-only: no `events.jsonl`, inbox, registry, or
+  `palace.db` writes.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p91-tmux-live-peek.spec.md
+- docs/plans/2026-05-25-p91-tmux-live-peek.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not execute tmux through a shell.
+- Do not mutate bus events, inbox messages, channel registry, or delivery
+  status during peek.
+- Do not fall back to `mempal_peek_partner`.
+- Do not implement tmux pane discovery.
+- Do not change legacy `mempal_peek_partner` behavior.
+
+## Acceptance Criteria
+
+Scenario: CLI tmux peek captures registered pane
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_tmux_peek_captures_pane
+    Targets: `src/main.rs` `cowork-tmux-peek` and direct tmux capture adapter.
+  Given fake `tmux` first in PATH
+  And the CLI handler in `src/main.rs` is the exercised entry point
+  And registered `codex-a` with `transport=tmux` and `tmux_target=mempal:0.1`
+  When `cowork-tmux-peek --agent-id codex-a --lines 20` runs
+  Then stdout contains the fake pane output
+  And stderr is empty
+  And the fake tmux log records `capture-pane`, `-t`, `mempal:0.1`, `-p`, `-S`, and `-20`
+
+Scenario: CLI tmux peek rejects non-tmux agent
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_tmux_peek_rejects_inbox_agent
+    Targets: transport validation.
+  Given registered `codex-a` with default `transport=inbox`
+  When `cowork-tmux-peek --agent-id codex-a` runs
+  Then the command fails
+  And stderr contains `not registered with transport=tmux`
+
+Scenario: CLI tmux peek has no bus side effects
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_tmux_peek_has_no_bus_side_effects
+    Targets: read-only boundary and events.jsonl file output.
+  Given a registered tmux agent and an existing event log
+  When `cowork-tmux-peek` runs
+  Then `events.jsonl` is unchanged
+  And no `palace.db` file is created
+
+Scenario: CLI tmux peek does not write file output
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_tmux_peek_does_not_write_file_output
+    Targets: absence of file-output side effects.
+  Given a registered tmux agent
+  When `cowork-tmux-peek` runs
+  Then no new file-output artifact is created under the project bus directory
+
+Scenario: MCP tmux peek uses the same capture adapter
+  Test:
+    Filter: test_mcp_cowork_bus_tmux_peek
+    Targets: `src/mcp/server.rs` `mempal_cowork_bus action=tmux_peek`.
+  Given fake tmux in PATH
+  And the MCP server handler in `src/mcp/server.rs` is the exercised entry point
+  When `action=tmux_peek` targets a registered tmux agent
+  Then the response includes captured pane text
+  And no `palace.db` file is created
+
+## Out of Scope
+
+- tmux pane discovery.
+- Streaming pane follow mode.
+- Cross-machine or SSH tmux.
+- OCR or semantic parsing of terminal output.
+- Persisting captured pane text as memory.

--- a/specs/p92-multi-agent-runbook.spec.md
+++ b/specs/p92-multi-agent-runbook.spec.md
@@ -1,0 +1,84 @@
+spec: task
+name: "P92: multi-agent cowork runbook"
+inherits: project
+tags: [cowork, multi-agent, runbook, phase-4]
+---
+
+## Intent
+
+P92 turns the P84-P91 multi-agent runtime surfaces into an operator-facing
+runbook. The goal is not to add a new communication primitive; it is to make
+register, send, broadcast, drain, ack, presence, channels, threads, tmux send,
+and tmux peek usable as one deterministic workflow.
+
+## Decisions
+
+- Add authoritative documentation at `docs/COWORK-RUNBOOK.md`.
+- Add read-only CLI `mempal cowork-runbook --format plain|json`.
+- The CLI prints bundled static runbook content and never reads or writes
+  `~/.mempal`, bus state, or `palace.db`.
+- JSON output includes the runbook title and content as machine-readable fields.
+- P92 does not add MCP actions; MCP users already have direct bus actions.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p92-multi-agent-runbook.spec.md
+- docs/plans/2026-05-26-p92-multi-agent-runbook.md
+- docs/COWORK-RUNBOOK.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/main.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not change cowork bus message delivery behavior.
+- Do not write runtime bus files from `cowork-runbook`.
+- Do not write `palace.db` from `cowork-runbook`.
+
+## Acceptance Criteria
+
+Scenario: CLI runbook plain output covers the multi-agent workflow
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_runbook_plain
+    Targets: `src/main.rs` `cowork-runbook`.
+  When `mempal cowork-runbook --format plain` runs
+  Then stdout contains `cowork-register`
+  And stdout contains `cowork-channel-send`
+  And stdout contains `cowork-tmux-peek`
+  And stderr is empty
+
+Scenario: CLI runbook JSON output is machine readable
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_runbook_json
+    Targets: `src/main.rs` JSON output for `cowork-runbook`.
+  When `mempal cowork-runbook --format json` runs
+  Then stdout is valid JSON
+  And JSON field `title` contains `Multi-Agent Cowork Runbook`
+  And JSON field `content` contains `cowork-deliveries`
+
+Scenario: CLI runbook rejects unsupported format without side effects
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_runbook_rejects_invalid_format
+    Targets: `src/main.rs` format validation.
+  Given a clean fake HOME
+  When `mempal cowork-runbook --format yaml` runs
+  Then the command fails
+  And no `.mempal` directory is created
+
+Scenario: Documentation inventory references P92
+  Test:
+    Filter: rg -n "p92-multi-agent-runbook|P92 multi-agent cowork runbook|COWORK-RUNBOOK" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: inventory and design documentation.
+  When the inventory files are inspected
+  Then they mention the P92 spec
+  And they mention the matching P92 plan
+  And the design document mentions `COWORK-RUNBOOK`
+
+## Out of Scope
+
+- New cowork transport modes.
+- New MCP actions.
+- Automatic agent registration.
+- Persisting runbook reads as adoption evidence.

--- a/specs/p93-cowork-doctor.spec.md
+++ b/specs/p93-cowork-doctor.spec.md
@@ -1,0 +1,92 @@
+spec: task
+name: "P93: cowork doctor"
+inherits: project
+tags: [cowork, multi-agent, diagnostics, mcp, phase-4]
+---
+
+## Intent
+
+P93 adds a deterministic diagnostic surface for the multi-agent cowork bus.
+Operators and agents should be able to inspect registry health, stale
+presence, pending deliveries, channel/session state, and optional tmux target
+reachability without mutating runtime state or memory.
+
+## Decisions
+
+- Add CLI `mempal cowork-doctor --cwd <repo> [--now RFC3339] [--probe-tmux]`.
+- Add MCP action `mempal_cowork_bus action=doctor`.
+- Default output is plain; `--format json` returns a stable diagnostic object.
+- `--probe-tmux` uses direct `std::process::Command` invocation of
+  `tmux has-session -t <target>` and never executes through a shell.
+- Without `--probe-tmux`, tmux agents are reported as `not_probed`.
+- Doctor is read-only: it does not append events, drain inboxes, update
+  heartbeat, modify sessions, or write `palace.db`.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p93-cowork-doctor.spec.md
+- docs/plans/2026-05-26-p93-cowork-doctor.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/cowork/mod.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not add background daemons, watchers, hooks, or automatic heartbeats.
+- Do not write bus events from doctor.
+- Do not fall back to shell execution for tmux probes.
+
+## Acceptance Criteria
+
+Scenario: CLI doctor reports empty registry warning
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_doctor_empty_registry
+    Targets: `src/main.rs` `cowork-doctor`.
+  Given no registered agents for a project
+  When `mempal cowork-doctor --cwd <repo>` runs
+  Then stdout contains `status=warning`
+  And stdout contains `no registered agents`
+  And no `events.jsonl` file is created
+
+Scenario: CLI doctor reports stale agents and pending deliveries
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_doctor_reports_stale_and_pending
+    Targets: doctor status derivation from presence and deliveries.
+  Given one stale agent and one pending delivery
+  When `cowork-doctor --now 2026-05-25T00:20:00Z` runs
+  Then stdout contains `stale_agents=1`
+  And stdout contains `pending_deliveries=1`
+  And stdout contains `status=warning`
+
+Scenario: CLI doctor JSON includes tmux probe result
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_doctor_json_tmux_probe
+    Targets: `--format json` and direct tmux probe behavior.
+  Given fake `tmux` first in PATH
+  And a registered tmux agent
+  When `cowork-doctor --probe-tmux --format json` runs
+  Then stdout is valid JSON
+  And JSON includes `tmux.ok`
+  And the fake tmux log records `has-session`, `-t`, and the registered target
+
+Scenario: MCP doctor mirrors CLI diagnostics
+  Test:
+    Filter: test_mcp_cowork_bus_doctor
+    Targets: `src/mcp/server.rs` `mempal_cowork_bus action=doctor`.
+  Given registered agents and pending delivery state
+  When MCP action `doctor` runs
+  Then the response includes a doctor payload
+  And no `palace.db` file is created
+
+## Out of Scope
+
+- Auto-repair.
+- Killing or restarting tmux panes.
+- Sending reminder messages.
+- Persisting diagnostic reports as memory.

--- a/specs/p94-cowork-team-session.spec.md
+++ b/specs/p94-cowork-team-session.spec.md
@@ -1,0 +1,87 @@
+spec: task
+name: "P94: cowork team session"
+inherits: project
+tags: [cowork, multi-agent, session, mcp, phase-4]
+---
+
+## Intent
+
+P94 adds an explicit team-session runtime object above agents, channels, and
+threads. A session records the current collaboration goal and membership for a
+project without becoming durable memory and without changing message delivery.
+
+## Decisions
+
+- Store sessions in `~/.mempal/cowork-bus/<project>/sessions.json`.
+- Add CLI `cowork-session-create`, `cowork-sessions`, and
+  `cowork-session-status`.
+- Add MCP actions `session_create`, `session_list`, and `session_status` to
+  `mempal_cowork_bus`.
+- Session ids use the same safe token rule as agent ids.
+- Session status is one of `active`, `paused`, or `closed`.
+- Session changes append operational bus events but do not write `palace.db`.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p94-cowork-team-session.spec.md
+- docs/plans/2026-05-26-p94-cowork-team-session.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/cowork/mod.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not migrate SQLite schema.
+- Do not alter send/broadcast/channel delivery semantics.
+- Do not auto-create agents or channels.
+
+## Acceptance Criteria
+
+Scenario: CLI creates and lists a team session
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_session_create_and_list
+    Targets: `cowork-session-create` and `cowork-sessions`.
+  Given registered `claude-main` and `codex-a`
+  When `cowork-session-create --session-id review-1 --agent claude-main --agent codex-a` runs
+  Then `cowork-sessions --cwd <repo>` prints `review-1`
+  And `sessions.json` exists under the project bus directory
+
+Scenario: CLI rejects sessions with unknown agents
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_session_rejects_unknown_agent
+    Targets: session membership validation.
+  Given only `claude-main` is registered
+  When creating a session with `codex-missing`
+  Then the command fails
+  And `sessions.json` is not created
+
+Scenario: CLI updates session status
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_session_status_update
+    Targets: `cowork-session-status`.
+  Given an active session
+  When `cowork-session-status --session-id review-1 --status paused` runs
+  Then `cowork-sessions --format json` reports status `paused`
+  And `cowork-events` includes `session_status`
+
+Scenario: MCP creates and lists sessions
+  Test:
+    Filter: test_mcp_cowork_bus_sessions
+    Targets: `src/mcp/server.rs` session actions.
+  Given registered agents
+  When MCP action `session_create` runs
+  Then MCP action `session_list` returns the created session
+  And no `palace.db` file is created
+
+## Out of Scope
+
+- Durable project memory for sessions.
+- Scheduling.
+- Assignment state machines.
+- Cross-project sessions.

--- a/specs/p95-cowork-handoff-summary.spec.md
+++ b/specs/p95-cowork-handoff-summary.spec.md
@@ -1,0 +1,88 @@
+spec: task
+name: "P95: cowork handoff summary"
+inherits: project
+tags: [cowork, multi-agent, handoff, mcp, phase-4]
+---
+
+## Intent
+
+P95 adds a deterministic handoff summary for multi-agent cowork state. A new or
+returning agent should be able to inspect active sessions, recent events,
+pending deliveries, stale agents, and thread/channel context without reading
+raw JSONL files or relying on an LLM-generated summary.
+
+## Decisions
+
+- Add CLI `mempal cowork-handoff --cwd <repo>`.
+- Add MCP action `mempal_cowork_bus action=handoff`.
+- Support optional filters `--thread-id`, `--channel`, `--session-id`, and
+  `--limit`.
+- Output formats are `plain` and `json`.
+- The summary is read-only and does not write events, inboxes, sessions, or
+  `palace.db`.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p95-cowork-handoff-summary.spec.md
+- docs/plans/2026-05-26-p95-cowork-handoff-summary.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/cowork/mod.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not call an LLM.
+- Do not persist the summary as memory.
+- Do not drain inboxes or ack deliveries.
+
+## Acceptance Criteria
+
+Scenario: CLI handoff summarizes sessions and pending deliveries
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_handoff_plain
+    Targets: `cowork-handoff` plain output.
+  Given an active session and a pending delivery
+  When `mempal cowork-handoff --cwd <repo>` runs
+  Then stdout contains `Active sessions`
+  And stdout contains the session id
+  And stdout contains `Pending deliveries`
+
+Scenario: CLI handoff filters by thread id
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_handoff_filters_thread
+    Targets: thread filter behavior.
+  Given deliveries for `thread-a` and `thread-b`
+  When `cowork-handoff --thread-id thread-a --format json` runs
+  Then JSON includes `thread-a`
+  And JSON does not include `thread-b`
+
+Scenario: CLI handoff rejects invalid format without side effects
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_handoff_rejects_invalid_format
+    Targets: format validation and read-only boundary.
+  Given an existing event log
+  When `cowork-handoff --format yaml` runs
+  Then the command fails
+  And `events.jsonl` is unchanged
+
+Scenario: MCP handoff returns the same summary shape
+  Test:
+    Filter: test_mcp_cowork_bus_handoff
+    Targets: `src/mcp/server.rs` `mempal_cowork_bus action=handoff`.
+  Given an active session and pending delivery
+  When MCP action `handoff` runs
+  Then the response includes a handoff payload
+  And no `palace.db` file is created
+
+## Out of Scope
+
+- Natural-language LLM summarization.
+- Automatic memory capture.
+- Cross-project handoffs.
+- Modifying delivery status.

--- a/specs/p96-cowork-memory-capture.spec.md
+++ b/specs/p96-cowork-memory-capture.spec.md
@@ -1,0 +1,90 @@
+spec: task
+name: "P96: cowork memory capture"
+inherits: project
+tags: [cowork, memory, evidence, mcp, phase-4]
+---
+
+## Intent
+
+P96 adds an explicit bridge from ephemeral cowork runtime state to durable
+memory. Agents can preview or execute a capture of the deterministic P95
+handoff summary into an evidence drawer, but mempal still never silently stores
+runtime chat or terminal content.
+
+## Decisions
+
+- Add CLI `mempal cowork-capture --cwd <repo>`.
+- Add MCP action `mempal_cowork_bus action=capture`.
+- Default mode is dry-run; writes require explicit `--execute` or
+  `execute=true`.
+- Only `--summary-source handoff` is supported in P96.
+- Execute writes one evidence drawer using wing `cowork-capture` by default.
+- Capture does not write vectors, does not promote knowledge, and does not
+  alter cowork events or delivery status.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p96-cowork-memory-capture.spec.md
+- docs/plans/2026-05-26-p96-cowork-memory-capture.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/cowork/mod.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not add automatic capture hooks.
+- Do not ingest raw terminal pane content from `tmux_peek`.
+- Do not bypass evidence drawer governance.
+- Do not create knowledge cards or promote knowledge.
+
+## Acceptance Criteria
+
+Scenario: CLI capture dry-run previews drawer without writing
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_capture_dry_run_no_write
+    Targets: `cowork-capture` dry-run behavior.
+  Given a handoff summary exists
+  When `mempal cowork-capture --summary-source handoff --format json` runs
+  Then JSON reports `writes=false`
+  And no `palace.db` file is created
+
+Scenario: CLI capture execute writes an evidence drawer
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_capture_execute_writes_evidence
+    Targets: evidence drawer write path.
+  Given a handoff summary exists
+  When `cowork-capture --execute --format json` runs
+  Then JSON reports `writes=true`
+  And JSON includes a `drawer_id`
+  And loading that `drawer_id` returns an evidence drawer in wing `cowork-capture`
+  And the drawer content contains the captured handoff
+
+Scenario: CLI capture rejects unsupported source
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_capture_rejects_unknown_source
+    Targets: source validation.
+  When `cowork-capture --summary-source tmux` runs
+  Then the command fails
+  And stderr mentions `unsupported cowork capture summary source`
+
+Scenario: MCP capture supports dry-run and execute
+  Test:
+    Filter: test_mcp_cowork_bus_capture
+    Targets: `src/mcp/server.rs` `mempal_cowork_bus action=capture`.
+  Given an MCP capture request with `execute=false`
+  Then no `palace.db` file is created
+  When the same request uses `execute=true`
+  Then the response includes a drawer id
+
+## Out of Scope
+
+- Automatic capture.
+- Capturing raw tmux pane text.
+- Knowledge card creation.
+- Vector embedding for captured evidence.

--- a/specs/p97-maintenance-runbook.spec.md
+++ b/specs/p97-maintenance-runbook.spec.md
@@ -1,0 +1,85 @@
+spec: task
+name: "P97: maintenance runbook"
+inherits: project
+tags: [self-evolution, auto-dream, maintenance, phase-4]
+---
+
+## Intent
+
+P97 documents the operational maintenance loop that connects research,
+evidence, distillation, card governance, context adoption, runtime adoption
+evidence, cowork handoff, and explicit cowork capture. It gives humans and
+agents a deterministic checklist for dream-cycle style maintenance without
+introducing autonomous background behavior.
+
+## Decisions
+
+- Add authoritative documentation at `docs/MAINTENANCE-RUNBOOK.md`.
+- Add read-only CLI `mempal maintenance-runbook --format plain|json`.
+- The runbook must mention research ingest, knowledge distill, card lifecycle,
+  context adoption review, cowork handoff, and explicit cowork capture.
+- The CLI is read-only and does not run maintenance commands.
+- P97 does not add daemons, timers, hooks, or autonomous promotion.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p97-maintenance-runbook.spec.md
+- docs/plans/2026-05-26-p97-maintenance-runbook.md
+- docs/MAINTENANCE-RUNBOOK.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/main.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not add background auto-dream execution.
+- Do not run research, ingest, distill, promote, demote, or capture from the
+  runbook command.
+- Do not change phase3 lifecycle authority.
+
+## Acceptance Criteria
+
+Scenario: CLI maintenance runbook plain output covers the governed loop
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_maintenance_runbook_plain
+    Targets: `src/main.rs` `maintenance-runbook`.
+  When `mempal maintenance-runbook --format plain` runs
+  Then stdout contains `research-ingest-plan`
+  And stdout contains `knowledge distill`
+  And stdout contains `cowork-capture`
+
+Scenario: CLI maintenance runbook JSON output is machine readable
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_maintenance_runbook_json
+    Targets: JSON output for `maintenance-runbook`.
+  When `mempal maintenance-runbook --format json` runs
+  Then stdout is valid JSON
+  And JSON field `title` contains `Maintenance Runbook`
+  And JSON field `content` contains `runtime adoption`
+
+Scenario: CLI maintenance runbook rejects unsupported format without side effects
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_maintenance_runbook_rejects_invalid_format
+    Targets: format validation and read-only boundary.
+  Given a clean fake HOME
+  When `mempal maintenance-runbook --format yaml` runs
+  Then the command fails
+  And no `.mempal` directory is created
+
+Scenario: Documentation inventory references P97
+  Test:
+    Filter: rg -n "p97-maintenance-runbook|P97 maintenance runbook|MAINTENANCE-RUNBOOK" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: inventory and design documentation.
+  When the inventory files are inspected
+  Then they mention the P97 spec
+  And they mention the matching P97 plan
+  And the design document mentions `MAINTENANCE-RUNBOOK`
+
+## Out of Scope
+
+- Autonomous maintenance execution.
+- Scheduling.
+- Silent capture.
+- Lifecycle promotion without human-gated policy.

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -1,0 +1,384 @@
+#![warn(clippy::all)]
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::context::{ContextError, ContextItem, ContextPack, ContextRequest, assemble_context};
+use crate::core::types::{AnchorKind, KnowledgeEvidenceRole, MemoryDomain};
+use crate::embed::Embedder;
+
+pub type Result<T> = std::result::Result<T, BriefError>;
+
+#[derive(Debug, Error)]
+pub enum BriefError {
+    #[error("failed to assemble brief context")]
+    Context(#[from] ContextError),
+}
+
+#[derive(Debug, Clone)]
+pub struct BriefRequest {
+    pub query: String,
+    pub domain: MemoryDomain,
+    pub field: String,
+    pub cwd: PathBuf,
+    pub max_items: usize,
+    pub dao_tian_limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CognitiveBrief {
+    pub query: String,
+    pub domain: MemoryDomain,
+    pub field: String,
+    pub summary: BriefSummary,
+    pub key_facts: Vec<BriefFact>,
+    pub evidence: Vec<BriefEvidence>,
+    pub cards: Vec<BriefCard>,
+    pub entities: Vec<String>,
+    pub unresolved_items: Vec<BriefUnresolvedItem>,
+    pub uncertainty: Vec<BriefUncertainty>,
+    pub next_actions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BriefSummary {
+    pub narrative: String,
+    pub key_fact_count: usize,
+    pub evidence_count: usize,
+    pub card_count: usize,
+    pub unresolved_count: usize,
+    pub uncertainty_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BriefFact {
+    pub text: String,
+    pub section: String,
+    pub citation: BriefCitation,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BriefEvidence {
+    pub text: String,
+    pub citation: BriefCitation,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BriefCard {
+    pub card_id: String,
+    pub text: String,
+    pub citation: BriefCitation,
+    pub evidence_citations: Vec<BriefEvidenceCitation>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BriefUnresolvedItem {
+    pub text: String,
+    pub citation: BriefCitation,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BriefUncertainty {
+    pub kind: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub citations: Vec<BriefCitation>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BriefCitation {
+    pub drawer_id: String,
+    pub source_file: String,
+    pub anchor_kind: AnchorKind,
+    pub anchor_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BriefEvidenceCitation {
+    pub evidence_drawer_id: String,
+    pub role: KnowledgeEvidenceRole,
+    pub source_file: String,
+}
+
+pub async fn assemble_brief<E: Embedder + ?Sized>(
+    db: &crate::core::db::Database,
+    embedder: &E,
+    request: BriefRequest,
+) -> Result<CognitiveBrief> {
+    let context = assemble_context(
+        db,
+        embedder,
+        ContextRequest {
+            query: request.query,
+            domain: request.domain,
+            field: request.field,
+            cwd: request.cwd,
+            include_evidence: true,
+            include_cards: true,
+            max_items: request.max_items,
+            dao_tian_limit: request.dao_tian_limit,
+        },
+    )
+    .await?;
+    Ok(brief_from_context(context))
+}
+
+pub fn brief_from_context(context: ContextPack) -> CognitiveBrief {
+    let mut key_facts = Vec::new();
+    let mut evidence = Vec::new();
+    let mut cards = Vec::new();
+    let mut unresolved_items = Vec::new();
+    let mut all_text = Vec::new();
+
+    for section in &context.sections {
+        for item in &section.items {
+            all_text.push(item.text.clone());
+            if let Some(card_id) = item.card_id.as_deref() {
+                cards.push(BriefCard {
+                    card_id: card_id.to_string(),
+                    text: item.text.clone(),
+                    citation: citation_from_item(item),
+                    evidence_citations: item
+                        .evidence_citations
+                        .iter()
+                        .map(|citation| BriefEvidenceCitation {
+                            evidence_drawer_id: citation.evidence_drawer_id.clone(),
+                            role: citation.role.clone(),
+                            source_file: citation.source_file.clone(),
+                        })
+                        .collect(),
+                });
+            } else if section.name == "evidence" {
+                evidence.push(BriefEvidence {
+                    text: item.text.clone(),
+                    citation: citation_from_item(item),
+                });
+            } else {
+                key_facts.push(BriefFact {
+                    text: item.text.clone(),
+                    section: section.name.clone(),
+                    citation: citation_from_item(item),
+                });
+            }
+
+            if looks_unresolved(&item.text) {
+                unresolved_items.push(BriefUnresolvedItem {
+                    text: item.text.clone(),
+                    citation: citation_from_item(item),
+                });
+            }
+        }
+    }
+
+    let mut uncertainty = build_uncertainty(&key_facts, &evidence, &cards, &unresolved_items);
+    uncertainty.extend(conflict_uncertainty(&all_text, &context));
+    let next_actions = build_next_actions(&key_facts, &evidence, &cards, &unresolved_items);
+    let entities = extract_entities(&all_text);
+    let summary = BriefSummary {
+        narrative: build_narrative(
+            key_facts.len(),
+            evidence.len(),
+            cards.len(),
+            unresolved_items.len(),
+            uncertainty.len(),
+        ),
+        key_fact_count: key_facts.len(),
+        evidence_count: evidence.len(),
+        card_count: cards.len(),
+        unresolved_count: unresolved_items.len(),
+        uncertainty_count: uncertainty.len(),
+    };
+
+    CognitiveBrief {
+        query: context.query,
+        domain: context.domain,
+        field: context.field,
+        summary,
+        key_facts,
+        evidence,
+        cards,
+        entities,
+        unresolved_items,
+        uncertainty,
+        next_actions,
+    }
+}
+
+fn citation_from_item(item: &ContextItem) -> BriefCitation {
+    BriefCitation {
+        drawer_id: item.drawer_id.clone(),
+        source_file: item.source_file.clone(),
+        anchor_kind: item.anchor_kind.clone(),
+        anchor_id: item.anchor_id.clone(),
+        card_id: item.card_id.clone(),
+    }
+}
+
+fn build_narrative(
+    key_fact_count: usize,
+    evidence_count: usize,
+    card_count: usize,
+    unresolved_count: usize,
+    uncertainty_count: usize,
+) -> String {
+    if key_fact_count == 0 && evidence_count == 0 && card_count == 0 {
+        return "No cited memory was found for this query; treat any answer as unsupported until evidence is ingested.".to_string();
+    }
+
+    format!(
+        "Brief assembled from {key_fact_count} cited key facts, {evidence_count} evidence items, and {card_count} cards; {unresolved_count} unresolved cues and {uncertainty_count} uncertainty signals require review."
+    )
+}
+
+fn build_uncertainty(
+    key_facts: &[BriefFact],
+    evidence: &[BriefEvidence],
+    cards: &[BriefCard],
+    unresolved_items: &[BriefUnresolvedItem],
+) -> Vec<BriefUncertainty> {
+    let mut uncertainty = Vec::new();
+    if evidence.is_empty() {
+        uncertainty.push(BriefUncertainty {
+            kind: "no_evidence".to_string(),
+            message: "No cited evidence was found for this query.".to_string(),
+            citations: Vec::new(),
+        });
+    }
+    if key_facts.is_empty() {
+        uncertainty.push(BriefUncertainty {
+            kind: "no_key_facts".to_string(),
+            message: "No governed knowledge statement was found for this query.".to_string(),
+            citations: Vec::new(),
+        });
+    }
+    if cards.is_empty() {
+        uncertainty.push(BriefUncertainty {
+            kind: "no_cards".to_string(),
+            message: "No active knowledge card was found for this query.".to_string(),
+            citations: Vec::new(),
+        });
+    }
+    if !unresolved_items.is_empty() {
+        uncertainty.push(BriefUncertainty {
+            kind: "unresolved_items".to_string(),
+            message: format!(
+                "{} cited item(s) mention unresolved work or follow-up.",
+                unresolved_items.len()
+            ),
+            citations: unresolved_items
+                .iter()
+                .map(|item| item.citation.clone())
+                .collect(),
+        });
+    }
+    uncertainty
+}
+
+fn conflict_uncertainty(texts: &[String], context: &ContextPack) -> Vec<BriefUncertainty> {
+    let mut citations = Vec::new();
+    for section in &context.sections {
+        for item in &section.items {
+            if mentions_conflict(&item.text) {
+                citations.push(citation_from_item(item));
+            }
+        }
+    }
+    if citations.is_empty() && texts.iter().any(|text| mentions_conflict(text)) {
+        return vec![BriefUncertainty {
+            kind: "conflict_cue".to_string(),
+            message:
+                "Relevant text contains contradiction, rollback, stale, or counterexample language."
+                    .to_string(),
+            citations: Vec::new(),
+        }];
+    }
+    if citations.is_empty() {
+        Vec::new()
+    } else {
+        vec![BriefUncertainty {
+            kind: "conflict_cue".to_string(),
+            message: "Relevant cited text contains contradiction, rollback, stale, or counterexample language.".to_string(),
+            citations,
+        }]
+    }
+}
+
+fn build_next_actions(
+    key_facts: &[BriefFact],
+    evidence: &[BriefEvidence],
+    cards: &[BriefCard],
+    unresolved_items: &[BriefUnresolvedItem],
+) -> Vec<String> {
+    let mut actions = Vec::new();
+    if evidence.is_empty() {
+        actions.push("Ingest or add evidence before relying on this brief.".to_string());
+    }
+    if key_facts.is_empty() {
+        actions
+            .push("Distill candidate knowledge only after supporting evidence exists.".to_string());
+    }
+    if cards.is_empty() {
+        actions.push("Create or retrieve a knowledge card if this topic recurs.".to_string());
+    }
+    if !unresolved_items.is_empty() {
+        actions.push("Review and resolve the cited unresolved items.".to_string());
+    }
+    if actions.is_empty() {
+        actions.push("Review the cited evidence before acting on the brief.".to_string());
+    }
+    actions
+}
+
+fn looks_unresolved(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    [
+        "todo",
+        "action item",
+        "follow up",
+        "unresolved",
+        "remain",
+        "blocked",
+        "next step",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn mentions_conflict(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    ["contradiction", "rollback", "stale", "counterexample"]
+        .iter()
+        .any(|needle| lower.contains(needle))
+}
+
+fn extract_entities(texts: &[String]) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    for text in texts {
+        for raw in text.split(|ch: char| !ch.is_alphanumeric() && ch != '-') {
+            let token = raw.trim_matches('-');
+            if token.chars().count() < 2 || is_entity_stopword(token) {
+                continue;
+            }
+            if token
+                .chars()
+                .next()
+                .is_some_and(|first| first.is_uppercase())
+            {
+                seen.insert(token.to_string());
+            }
+        }
+    }
+    seen.into_iter().collect()
+}
+
+fn is_entity_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "The" | "This" | "That" | "No" | "Brief" | "Use" | "Review"
+    )
+}

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -73,6 +73,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    mempal_search to verify project facts, past decisions, and citations.
    Do not use wake-up as a substitute for mempal_context when you need typed
    dao/shu/qi guidance; wake-up preserves a refresh-oriented L0/L1 shape.
+   Use CLI `mempal brief <query>` when a human or agent needs a compact
+   citation-first cognitive report rather than raw retrieval: it organizes key
+   facts, evidence, cards, unresolved cues, uncertainty, and next actions
+   without LLM synthesis or database writes.
    Use mempal_field_taxonomy when choosing a `field` value for typed evidence,
    knowledge, search, or context. Field taxonomy is guidance only; custom
    field strings remain valid when the recommended fields are too coarse.
@@ -155,6 +159,31 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    On InboxFull error: STOP pushing and wait for partner to drain. Do
    NOT retry — that would just fail again.
 
+10a. MULTI-AGENT COWORK BUS (concrete agent_id routing)
+   Use mempal_cowork_bus when one project has more than two agent
+   instances, for example claude-main, codex-a, and codex-b. This is
+   separate from legacy mempal_cowork_push partner routing: the bus
+   requires explicit agent_id values and does not infer concrete
+   instances from MCP client names.
+
+   Typical flow: action=register once per concrete agent_id, action=list
+   to inspect project bus state, action=send for one target, action=broadcast
+   for fanout, action=drain for the current agent's per-agent inbox,
+   action=events to replay the append-only operational event log,
+   action=deliveries to inspect pending/drained/acked/failed delivery status,
+   action=ack to explicitly acknowledge a delivery message_id, and
+   action=heartbeat to update explicit last-seen presence, and
+   action=channel_set/channel_list/channel_send to manage named group
+   channels. Use action=doctor for read-only diagnostics, session_create/
+   session_list/session_status for runtime team sessions, action=handoff for
+   deterministic handoff summaries, and action=capture only when you
+   explicitly want to lift a handoff summary into evidence memory.
+   Each target has an independent inbox under the project bus, so
+   one Codex instance draining its inbox does not consume another Codex
+   instance's message.
+   transport=inbox is the safe default; transport=tmux is explicit opt-in and
+   sends through a configured tmux_target without shell execution.
+
 11. VERIFY BEFORE INGEST (contradiction detection)
    Before ingesting a decision that asserts relationships between named
    entities ("X is Y's Z", "X works at Y", "X is the Z of Y"), call
@@ -219,7 +248,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    action=instrumentation_policy before building live tool instrumentation:
    live instrumentation is opt-in, must preserve user opt-out, and must route
    writes through checked capture or record_checked instead of silently
-   appending events. Use
+   appending events. Use CLI `mempal phase3 adoption wrap` for the supported
+   opt-in wrapper: it explicitly runs one child command after `--`, maps exit
+   code 0 to accepted and non-zero to rejected unless `--outcome` overrides it,
+   and writes only with `--execute` through checked capture. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
    action=capture when you have a concrete runtime outcome but do not want to
@@ -288,6 +320,7 @@ TOOLS:
   mempal_tunnels       — discover cross-wing room links
   mempal_peek_partner  — read partner agent's live session (Claude ↔ Codex), pure read
   mempal_cowork_push   — send a short handoff message to partner agent (P8)
+  mempal_cowork_bus    — concrete agent_id multi-agent bus register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/handoff/capture, with opt-in transport=tmux, event replay, delivery ack/status, presence, group channels, read-only tmux pane peek, diagnostics, sessions, handoff summaries, and explicit handoff-to-evidence capture (P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96)
   mempal_fact_check    — offline contradiction detection vs KG triples + entities (P9)
 
 Key invariant: mempal stores raw text verbatim. Every search result can be

--- a/src/cowork/bus.rs
+++ b/src/cowork/bus.rs
@@ -1,0 +1,1939 @@
+//! Multi-agent cowork bus for concrete agent instances.
+//!
+//! P8 routes by tool family (`claude` / `codex`). P84 adds `agent_id`
+//! addressing so multiple instances of the same tool can work in one project
+//! without racing on a shared inbox.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+
+use crate::core::{
+    db::{Database, DbError},
+    types::{BootstrapEvidenceArgs, Drawer, SourceType},
+    utils::{build_bootstrap_evidence_drawer_id, current_timestamp},
+};
+
+use super::inbox::{
+    InboxMessage, MAX_MESSAGE_SIZE, MAX_PENDING_MESSAGES, MAX_TOTAL_INBOX_BYTES,
+    encode_project_identity, project_identity,
+};
+use super::peek::{format_rfc3339, parse_rfc3339};
+
+const MAX_EVENT_MESSAGE_PREVIEW_CHARS: usize = 200;
+const PRESENCE_STALE_AFTER_SECONDS: i64 = 10 * 60;
+
+static BUS_EVENT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy)]
+struct MessageMetadata<'a> {
+    thread_id: Option<&'a str>,
+    channel: Option<&'a str>,
+}
+
+#[derive(Debug, Error)]
+pub enum BusError {
+    #[error("invalid agent id `{0}`: expected 1-64 ASCII letters, digits, `_`, `-`, or `.`")]
+    InvalidAgentId(String),
+    #[error("invalid tool name `{0}`: expected 1-64 ASCII letters, digits, `_`, `-`, or `.`")]
+    InvalidTool(String),
+    #[error("unsupported transport `{0}`: expected inbox|tmux")]
+    UnsupportedTransport(String),
+    #[error("invalid channel `{0}`: expected 1-64 ASCII letters, digits, `_`, `-`, or `.`")]
+    InvalidChannel(String),
+    #[error("invalid thread id `{0}`: expected 1-64 ASCII letters, digits, `_`, `-`, or `.`")]
+    InvalidThreadId(String),
+    #[error("unknown channel `{0}`")]
+    UnknownChannel(String),
+    #[error("channel `{0}` must contain at least one agent")]
+    EmptyChannel(String),
+    #[error("tmux_target is required when transport=tmux")]
+    TmuxTargetRequired,
+    #[error("tmux delivery failed with status {0}")]
+    TmuxFailed(String),
+    #[error("tmux capture failed with status {0}")]
+    TmuxCaptureFailed(String),
+    #[error("tmux probe failed with status {0}")]
+    TmuxProbeFailed(String),
+    #[error("agent `{0}` is not registered with transport=tmux")]
+    NotTmuxAgent(String),
+    #[error("invalid tmux capture line count `{0}`: expected 1..=500")]
+    InvalidLineCount(usize),
+    #[error("invalid session id `{0}`: expected 1-64 ASCII letters, digits, `_`, `-`, or `.`")]
+    InvalidSessionId(String),
+    #[error("session `{0}` must contain at least one agent")]
+    EmptySession(String),
+    #[error("unknown session `{0}`")]
+    UnknownSession(String),
+    #[error("unsupported session status `{0}`: expected active|paused|closed")]
+    InvalidSessionStatus(String),
+    #[error("unsupported cowork capture summary source `{0}`: expected handoff")]
+    UnsupportedCaptureSource(String),
+    #[error("capture execute requires an open database")]
+    MissingCaptureDatabase,
+    #[error("invalid timestamp `{0}`: expected RFC3339")]
+    InvalidTimestamp(String),
+    #[error("unknown delivery message id `{0}`")]
+    UnknownDelivery(String),
+    #[error("delivery `{message_id}` is addressed to `{target_agent_id}`, not `{agent_id}`")]
+    DeliveryTargetMismatch {
+        message_id: String,
+        target_agent_id: String,
+        agent_id: String,
+    },
+    #[error("cannot ack failed delivery `{0}`")]
+    CannotAckFailed(String),
+    #[error("unknown source agent `{0}`")]
+    UnknownSource(String),
+    #[error("unknown target agent `{0}`")]
+    UnknownTarget(String),
+    #[error("unknown agent `{0}`")]
+    UnknownAgent(String),
+    #[error("cannot send to self `{0}`")]
+    SelfSend(String),
+    #[error("message content exceeds {MAX_MESSAGE_SIZE} bytes: got {0} bytes")]
+    MessageTooLarge(usize),
+    #[error(
+        "agent inbox full: {current_count} messages / {current_bytes} bytes pending \
+         (limits: {MAX_PENDING_MESSAGES} messages, {MAX_TOTAL_INBOX_BYTES} bytes)"
+    )]
+    InboxFull {
+        current_count: usize,
+        current_bytes: u64,
+    },
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("db error: {0}")]
+    Db(#[from] DbError),
+    #[error("legacy inbox error: {0}")]
+    LegacyInbox(#[from] super::inbox::InboxError),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRecord {
+    pub agent_id: String,
+    pub tool: String,
+    pub transport: String,
+    pub tmux_target: Option<String>,
+    pub registered_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub last_seen_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentRegistry {
+    pub agents: BTreeMap<String, AgentRecord>,
+    #[serde(default)]
+    pub channels: BTreeMap<String, ChannelRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelRecord {
+    pub channel: String,
+    pub agents: Vec<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RegisterAgentRequest {
+    pub agent_id: String,
+    pub tool: String,
+    pub transport: String,
+    pub tmux_target: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SendRequest {
+    pub from: String,
+    pub targets: Vec<String>,
+    pub message: String,
+    pub operation: SendOperation,
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SendOperation {
+    Send,
+    Broadcast,
+}
+
+impl SendOperation {
+    fn event_type(self) -> &'static str {
+        match self {
+            Self::Send => "send",
+            Self::Broadcast => "broadcast",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SendReport {
+    pub delivered: Vec<DeliveryReport>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeliveryReport {
+    pub message_id: String,
+    pub target_agent_id: String,
+    pub transport: String,
+    pub inbox_path: Option<PathBuf>,
+    pub inbox_size_after: Option<u64>,
+    pub tmux_target: Option<String>,
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentStatus {
+    pub record: AgentRecord,
+    pub presence: String,
+    pub pending_count: usize,
+    pub pending_bytes: u64,
+    pub preview: Vec<InboxMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusEvent {
+    pub event_id: String,
+    pub occurred_at: String,
+    pub event_type: String,
+    pub status: String,
+    pub actor_agent_id: Option<String>,
+    pub target_agent_ids: Vec<String>,
+    pub transport: Option<String>,
+    pub message_preview: Option<String>,
+    pub details: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeliveryStatus {
+    pub message_id: String,
+    pub event_type: String,
+    pub status: String,
+    pub from: String,
+    pub target_agent_id: String,
+    pub transport: String,
+    pub message_preview: Option<String>,
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+    pub delivered_at: String,
+    pub updated_at: String,
+    pub acked_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TmuxPeek {
+    pub agent_id: String,
+    pub tmux_target: String,
+    pub lines: usize,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DoctorReport {
+    pub status: String,
+    pub agent_count: usize,
+    pub channel_count: usize,
+    pub session_count: usize,
+    pub stale_agents: usize,
+    pub never_seen_agents: usize,
+    pub pending_deliveries: usize,
+    pub warnings: Vec<String>,
+    pub tmux: Vec<TmuxProbeReport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TmuxProbeReport {
+    pub agent_id: String,
+    pub tmux_target: String,
+    pub status: String,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SessionRegistry {
+    pub sessions: BTreeMap<String, TeamSession>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamSession {
+    pub session_id: String,
+    pub title: String,
+    pub goal: Option<String>,
+    pub agents: Vec<String>,
+    pub channels: Vec<String>,
+    pub thread_id: Option<String>,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateSessionRequest {
+    pub session_id: String,
+    pub title: String,
+    pub goal: Option<String>,
+    pub agents: Vec<String>,
+    pub channels: Vec<String>,
+    pub thread_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HandoffFilters {
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+    pub session_id: Option<String>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandoffSummary {
+    pub filters: HandoffSummaryFilters,
+    pub sessions: Vec<TeamSession>,
+    pub agents: Vec<AgentStatusSummary>,
+    pub pending_deliveries: Vec<DeliveryStatus>,
+    pub recent_events: Vec<BusEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandoffSummaryFilters {
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+    pub session_id: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentStatusSummary {
+    pub agent_id: String,
+    pub tool: String,
+    pub presence: String,
+    pub pending_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoworkCaptureRequest {
+    pub summary_source: String,
+    pub wing: String,
+    pub room: Option<String>,
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+    pub session_id: Option<String>,
+    pub note: Option<String>,
+    pub execute: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoworkCaptureReport {
+    pub writes: bool,
+    pub drawer_id: Option<String>,
+    pub wing: String,
+    pub room: Option<String>,
+    pub source: String,
+    pub content: String,
+}
+
+pub fn validate_agent_id(agent_id: &str) -> Result<(), BusError> {
+    if is_safe_bus_token(agent_id) {
+        Ok(())
+    } else {
+        Err(BusError::InvalidAgentId(agent_id.to_string()))
+    }
+}
+
+fn validate_tool(tool: &str) -> Result<(), BusError> {
+    if is_safe_bus_token(tool) {
+        Ok(())
+    } else {
+        Err(BusError::InvalidTool(tool.to_string()))
+    }
+}
+
+fn validate_channel(channel: &str) -> Result<(), BusError> {
+    if is_safe_bus_token(channel) {
+        Ok(())
+    } else {
+        Err(BusError::InvalidChannel(channel.to_string()))
+    }
+}
+
+fn validate_thread_id(thread_id: &str) -> Result<(), BusError> {
+    if is_safe_bus_token(thread_id) {
+        Ok(())
+    } else {
+        Err(BusError::InvalidThreadId(thread_id.to_string()))
+    }
+}
+
+fn validate_session_id(session_id: &str) -> Result<(), BusError> {
+    if is_safe_bus_token(session_id) {
+        Ok(())
+    } else {
+        Err(BusError::InvalidSessionId(session_id.to_string()))
+    }
+}
+
+fn validate_session_status(status: &str) -> Result<(), BusError> {
+    match status {
+        "active" | "paused" | "closed" => Ok(()),
+        other => Err(BusError::InvalidSessionStatus(other.to_string())),
+    }
+}
+
+fn is_safe_bus_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+}
+
+pub fn project_bus_dir(mempal_home: &Path, cwd: &Path) -> Result<PathBuf, BusError> {
+    let identity = project_identity(cwd);
+    let encoded = encode_project_identity(&identity)?;
+    Ok(mempal_home.join("cowork-bus").join(encoded))
+}
+
+pub fn registry_path(mempal_home: &Path, cwd: &Path) -> Result<PathBuf, BusError> {
+    Ok(project_bus_dir(mempal_home, cwd)?.join("agents.json"))
+}
+
+pub fn agent_inbox_path(
+    mempal_home: &Path,
+    cwd: &Path,
+    agent_id: &str,
+) -> Result<PathBuf, BusError> {
+    validate_agent_id(agent_id)?;
+    Ok(project_bus_dir(mempal_home, cwd)?
+        .join("inbox")
+        .join(format!("{agent_id}.jsonl")))
+}
+
+pub fn events_path(mempal_home: &Path, cwd: &Path) -> Result<PathBuf, BusError> {
+    Ok(project_bus_dir(mempal_home, cwd)?.join("events.jsonl"))
+}
+
+pub fn sessions_path(mempal_home: &Path, cwd: &Path) -> Result<PathBuf, BusError> {
+    Ok(project_bus_dir(mempal_home, cwd)?.join("sessions.json"))
+}
+
+pub fn load_registry(mempal_home: &Path, cwd: &Path) -> Result<AgentRegistry, BusError> {
+    let path = registry_path(mempal_home, cwd)?;
+    if !path.exists() {
+        return Ok(AgentRegistry::default());
+    }
+    let raw = std::fs::read_to_string(path)?;
+    if raw.trim().is_empty() {
+        return Ok(AgentRegistry::default());
+    }
+    Ok(serde_json::from_str(&raw)?)
+}
+
+fn save_registry(mempal_home: &Path, cwd: &Path, registry: &AgentRegistry) -> Result<(), BusError> {
+    let path = registry_path(mempal_home, cwd)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let raw = serde_json::to_string_pretty(registry)?;
+    std::fs::write(path, raw)?;
+    Ok(())
+}
+
+pub fn load_sessions(mempal_home: &Path, cwd: &Path) -> Result<SessionRegistry, BusError> {
+    let path = sessions_path(mempal_home, cwd)?;
+    if !path.exists() {
+        return Ok(SessionRegistry::default());
+    }
+    let raw = std::fs::read_to_string(path)?;
+    if raw.trim().is_empty() {
+        return Ok(SessionRegistry::default());
+    }
+    Ok(serde_json::from_str(&raw)?)
+}
+
+fn save_sessions(
+    mempal_home: &Path,
+    cwd: &Path,
+    sessions: &SessionRegistry,
+) -> Result<(), BusError> {
+    let path = sessions_path(mempal_home, cwd)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let raw = serde_json::to_string_pretty(sessions)?;
+    std::fs::write(path, raw)?;
+    Ok(())
+}
+
+pub fn register_agent(
+    mempal_home: &Path,
+    cwd: &Path,
+    request: RegisterAgentRequest,
+) -> Result<AgentRecord, BusError> {
+    validate_agent_id(&request.agent_id)?;
+    validate_tool(&request.tool)?;
+    if request.transport != "inbox" && request.transport != "tmux" {
+        return Err(BusError::UnsupportedTransport(request.transport));
+    }
+    if request.transport == "tmux"
+        && request
+            .tmux_target
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .is_empty()
+    {
+        return Err(BusError::TmuxTargetRequired);
+    }
+
+    let now = format_rfc3339(SystemTime::now());
+    let mut registry = load_registry(mempal_home, cwd)?;
+    let registered_at = registry
+        .agents
+        .get(&request.agent_id)
+        .map(|existing| existing.registered_at.clone())
+        .unwrap_or_else(|| now.clone());
+    let record = AgentRecord {
+        agent_id: request.agent_id.clone(),
+        tool: request.tool,
+        transport: request.transport,
+        tmux_target: request.tmux_target,
+        registered_at,
+        updated_at: now.clone(),
+        last_seen_at: Some(now),
+    };
+    registry
+        .agents
+        .insert(request.agent_id.clone(), record.clone());
+    save_registry(mempal_home, cwd, &registry)?;
+    let mut details = BTreeMap::new();
+    details.insert("tool".to_string(), record.tool.clone());
+    if let Some(tmux_target) = &record.tmux_target {
+        details.insert("tmux_target".to_string(), tmux_target.clone());
+    }
+    append_bus_event(
+        mempal_home,
+        cwd,
+        "register",
+        "registered",
+        Some(record.agent_id.clone()),
+        vec![record.agent_id.clone()],
+        Some(record.transport.clone()),
+        None,
+        details,
+    )?;
+    Ok(record)
+}
+
+pub fn list_agent_status(mempal_home: &Path, cwd: &Path) -> Result<Vec<AgentStatus>, BusError> {
+    list_agent_status_at(mempal_home, cwd, None)
+}
+
+pub fn list_agent_status_at(
+    mempal_home: &Path,
+    cwd: &Path,
+    now: Option<&str>,
+) -> Result<Vec<AgentStatus>, BusError> {
+    let now_seconds = match now {
+        Some(now) => {
+            parse_rfc3339(now).ok_or_else(|| BusError::InvalidTimestamp(now.to_string()))?
+        }
+        None => current_unix_seconds(),
+    };
+    let registry = load_registry(mempal_home, cwd)?;
+    let mut statuses = Vec::new();
+    for record in registry.agents.values() {
+        let path = agent_inbox_path(mempal_home, cwd, &record.agent_id)?;
+        let (pending_count, pending_bytes, preview) = read_inbox_stats(&path)?;
+        let presence = presence_for(record.last_seen_at.as_deref(), now_seconds);
+        statuses.push(AgentStatus {
+            record: record.clone(),
+            presence,
+            pending_count,
+            pending_bytes,
+            preview,
+        });
+    }
+    Ok(statuses)
+}
+
+pub fn heartbeat_agent(
+    mempal_home: &Path,
+    cwd: &Path,
+    agent_id: &str,
+    seen_at: Option<&str>,
+) -> Result<AgentRecord, BusError> {
+    validate_agent_id(agent_id)?;
+    let seen_at = match seen_at {
+        Some(seen_at) => {
+            parse_rfc3339(seen_at)
+                .ok_or_else(|| BusError::InvalidTimestamp(seen_at.to_string()))?;
+            seen_at.to_string()
+        }
+        None => format_rfc3339(SystemTime::now()),
+    };
+    let mut registry = load_registry(mempal_home, cwd)?;
+    let record = registry
+        .agents
+        .get_mut(agent_id)
+        .ok_or_else(|| BusError::UnknownAgent(agent_id.to_string()))?;
+    record.last_seen_at = Some(seen_at.clone());
+    record.updated_at = seen_at.clone();
+    let record = record.clone();
+    save_registry(mempal_home, cwd, &registry)?;
+
+    let mut details = BTreeMap::new();
+    details.insert("last_seen_at".to_string(), seen_at);
+    append_bus_event(
+        mempal_home,
+        cwd,
+        "heartbeat",
+        "seen",
+        Some(agent_id.to_string()),
+        vec![agent_id.to_string()],
+        Some(record.transport.clone()),
+        None,
+        details,
+    )?;
+    Ok(record)
+}
+
+pub fn set_channel(
+    mempal_home: &Path,
+    cwd: &Path,
+    channel: &str,
+    agents: Vec<String>,
+) -> Result<ChannelRecord, BusError> {
+    validate_channel(channel)?;
+    let agents = dedup_targets(agents)?;
+    if agents.is_empty() {
+        return Err(BusError::EmptyChannel(channel.to_string()));
+    }
+    let mut registry = load_registry(mempal_home, cwd)?;
+    for agent_id in &agents {
+        if !registry.agents.contains_key(agent_id) {
+            return Err(BusError::UnknownAgent(agent_id.clone()));
+        }
+    }
+    let record = ChannelRecord {
+        channel: channel.to_string(),
+        agents,
+        updated_at: format_rfc3339(SystemTime::now()),
+    };
+    registry
+        .channels
+        .insert(channel.to_string(), record.clone());
+    save_registry(mempal_home, cwd, &registry)?;
+    let mut details = BTreeMap::new();
+    details.insert("channel".to_string(), channel.to_string());
+    details.insert("agents".to_string(), record.agents.join(","));
+    append_bus_event(
+        mempal_home,
+        cwd,
+        "channel_set",
+        "updated",
+        None,
+        record.agents.clone(),
+        None,
+        None,
+        details,
+    )?;
+    Ok(record)
+}
+
+pub fn list_channels(mempal_home: &Path, cwd: &Path) -> Result<Vec<ChannelRecord>, BusError> {
+    let registry = load_registry(mempal_home, cwd)?;
+    Ok(registry.channels.values().cloned().collect())
+}
+
+pub fn create_session(
+    mempal_home: &Path,
+    cwd: &Path,
+    request: CreateSessionRequest,
+) -> Result<TeamSession, BusError> {
+    validate_session_id(&request.session_id)?;
+    if let Some(thread_id) = &request.thread_id {
+        validate_thread_id(thread_id)?;
+    }
+    let agents = dedup_targets(request.agents)?;
+    if agents.is_empty() {
+        return Err(BusError::EmptySession(request.session_id));
+    }
+
+    let registry = load_registry(mempal_home, cwd)?;
+    for agent_id in &agents {
+        if !registry.agents.contains_key(agent_id) {
+            return Err(BusError::UnknownAgent(agent_id.clone()));
+        }
+    }
+    let mut channels = Vec::new();
+    let mut seen_channels = BTreeSet::new();
+    for channel in request.channels {
+        validate_channel(&channel)?;
+        if !registry.channels.contains_key(&channel) {
+            return Err(BusError::UnknownChannel(channel));
+        }
+        if seen_channels.insert(channel.clone()) {
+            channels.push(channel);
+        }
+    }
+
+    let now = format_rfc3339(SystemTime::now());
+    let mut sessions = load_sessions(mempal_home, cwd)?;
+    let created_at = sessions
+        .sessions
+        .get(&request.session_id)
+        .map(|existing| existing.created_at.clone())
+        .unwrap_or_else(|| now.clone());
+    let session = TeamSession {
+        session_id: request.session_id.clone(),
+        title: request.title,
+        goal: request.goal,
+        agents,
+        channels,
+        thread_id: request.thread_id,
+        status: "active".to_string(),
+        created_at,
+        updated_at: now,
+    };
+    sessions
+        .sessions
+        .insert(request.session_id.clone(), session.clone());
+    save_sessions(mempal_home, cwd, &sessions)?;
+
+    let mut details = BTreeMap::new();
+    details.insert("session_id".to_string(), session.session_id.clone());
+    details.insert("title".to_string(), session.title.clone());
+    details.insert("status".to_string(), session.status.clone());
+    if let Some(thread_id) = &session.thread_id {
+        details.insert("thread_id".to_string(), thread_id.clone());
+    }
+    append_bus_event(
+        mempal_home,
+        cwd,
+        "session_create",
+        "created",
+        None,
+        session.agents.clone(),
+        None,
+        None,
+        details,
+    )?;
+    Ok(session)
+}
+
+pub fn list_sessions(mempal_home: &Path, cwd: &Path) -> Result<Vec<TeamSession>, BusError> {
+    let sessions = load_sessions(mempal_home, cwd)?;
+    Ok(sessions.sessions.values().cloned().collect())
+}
+
+pub fn update_session_status(
+    mempal_home: &Path,
+    cwd: &Path,
+    session_id: &str,
+    status: &str,
+) -> Result<TeamSession, BusError> {
+    validate_session_id(session_id)?;
+    validate_session_status(status)?;
+    let mut sessions = load_sessions(mempal_home, cwd)?;
+    let session = sessions
+        .sessions
+        .get_mut(session_id)
+        .ok_or_else(|| BusError::UnknownSession(session_id.to_string()))?;
+    session.status = status.to_string();
+    session.updated_at = format_rfc3339(SystemTime::now());
+    let session = session.clone();
+    save_sessions(mempal_home, cwd, &sessions)?;
+
+    let mut details = BTreeMap::new();
+    details.insert("session_id".to_string(), session.session_id.clone());
+    details.insert("status".to_string(), session.status.clone());
+    append_bus_event(
+        mempal_home,
+        cwd,
+        "session_status",
+        status,
+        None,
+        session.agents.clone(),
+        None,
+        None,
+        details,
+    )?;
+    Ok(session)
+}
+
+pub fn send_channel(
+    mempal_home: &Path,
+    cwd: &Path,
+    from: String,
+    channel: String,
+    message: String,
+    thread_id: Option<String>,
+) -> Result<SendReport, BusError> {
+    validate_channel(&channel)?;
+    let registry = load_registry(mempal_home, cwd)?;
+    let record = registry
+        .channels
+        .get(&channel)
+        .ok_or_else(|| BusError::UnknownChannel(channel.clone()))?;
+    send(
+        mempal_home,
+        cwd,
+        SendRequest {
+            from,
+            targets: record.agents.clone(),
+            message,
+            operation: SendOperation::Broadcast,
+            thread_id,
+            channel: Some(channel),
+        },
+    )
+}
+
+pub fn tmux_peek_agent(
+    mempal_home: &Path,
+    cwd: &Path,
+    agent_id: &str,
+    lines: usize,
+) -> Result<TmuxPeek, BusError> {
+    validate_agent_id(agent_id)?;
+    if !(1..=500).contains(&lines) {
+        return Err(BusError::InvalidLineCount(lines));
+    }
+    let registry = load_registry(mempal_home, cwd)?;
+    let record = registry
+        .agents
+        .get(agent_id)
+        .ok_or_else(|| BusError::UnknownAgent(agent_id.to_string()))?;
+    if record.transport != "tmux" {
+        return Err(BusError::NotTmuxAgent(agent_id.to_string()));
+    }
+    let tmux_target = record
+        .tmux_target
+        .as_deref()
+        .ok_or(BusError::TmuxTargetRequired)?;
+    let content = capture_tmux(tmux_target, lines)?;
+    Ok(TmuxPeek {
+        agent_id: agent_id.to_string(),
+        tmux_target: tmux_target.to_string(),
+        lines,
+        content,
+    })
+}
+
+pub fn doctor(
+    mempal_home: &Path,
+    cwd: &Path,
+    now: Option<&str>,
+    probe_tmux: bool,
+) -> Result<DoctorReport, BusError> {
+    let statuses = list_agent_status_at(mempal_home, cwd, now)?;
+    let channels = list_channels(mempal_home, cwd)?;
+    let sessions = list_sessions(mempal_home, cwd)?;
+    let deliveries = list_delivery_statuses(mempal_home, cwd, None)?;
+    let pending_deliveries = deliveries
+        .iter()
+        .filter(|delivery| delivery.status == "pending")
+        .count();
+    let stale_agents = statuses
+        .iter()
+        .filter(|status| status.presence == "stale")
+        .count();
+    let never_seen_agents = statuses
+        .iter()
+        .filter(|status| status.presence == "never_seen")
+        .count();
+
+    let mut warnings = Vec::new();
+    if statuses.is_empty() {
+        warnings.push("no registered agents".to_string());
+    }
+    if stale_agents > 0 {
+        warnings.push(format!("stale agents: {stale_agents}"));
+    }
+    if pending_deliveries > 0 {
+        warnings.push(format!("pending deliveries: {pending_deliveries}"));
+    }
+    if never_seen_agents > 0 {
+        warnings.push(format!("never seen agents: {never_seen_agents}"));
+    }
+
+    let mut tmux = Vec::new();
+    for status in &statuses {
+        if status.record.transport != "tmux" {
+            continue;
+        }
+        let Some(tmux_target) = status.record.tmux_target.clone() else {
+            warnings.push(format!(
+                "tmux agent {} has no target",
+                status.record.agent_id
+            ));
+            tmux.push(TmuxProbeReport {
+                agent_id: status.record.agent_id.clone(),
+                tmux_target: String::new(),
+                status: "missing_target".to_string(),
+                detail: None,
+            });
+            continue;
+        };
+        let probe = if probe_tmux {
+            probe_tmux_target(&tmux_target)
+        } else {
+            TmuxProbeReport {
+                agent_id: status.record.agent_id.clone(),
+                tmux_target: tmux_target.clone(),
+                status: "not_probed".to_string(),
+                detail: None,
+            }
+        };
+        if probe.status == "failed" {
+            warnings.push(format!(
+                "tmux target failed: {} {}",
+                status.record.agent_id, tmux_target
+            ));
+        }
+        tmux.push(TmuxProbeReport {
+            agent_id: status.record.agent_id.clone(),
+            tmux_target,
+            ..probe
+        });
+    }
+
+    let status = if warnings.is_empty() {
+        "ok".to_string()
+    } else {
+        "warning".to_string()
+    };
+    Ok(DoctorReport {
+        status,
+        agent_count: statuses.len(),
+        channel_count: channels.len(),
+        session_count: sessions.len(),
+        stale_agents,
+        never_seen_agents,
+        pending_deliveries,
+        warnings,
+        tmux,
+    })
+}
+
+pub fn build_handoff_summary(
+    mempal_home: &Path,
+    cwd: &Path,
+    filters: HandoffFilters,
+) -> Result<HandoffSummary, BusError> {
+    if let Some(thread_id) = &filters.thread_id {
+        validate_thread_id(thread_id)?;
+    }
+    if let Some(channel) = &filters.channel {
+        validate_channel(channel)?;
+    }
+    if let Some(session_id) = &filters.session_id {
+        validate_session_id(session_id)?;
+    }
+    let limit = filters.limit.unwrap_or(20);
+    let sessions = list_sessions(mempal_home, cwd)?
+        .into_iter()
+        .filter(|session| {
+            filters
+                .session_id
+                .as_ref()
+                .is_none_or(|session_id| &session.session_id == session_id)
+        })
+        .filter(|session| {
+            filters
+                .thread_id
+                .as_ref()
+                .is_none_or(|thread_id| session.thread_id.as_ref() == Some(thread_id))
+        })
+        .filter(|session| {
+            filters
+                .channel
+                .as_ref()
+                .is_none_or(|channel| session.channels.iter().any(|item| item == channel))
+        })
+        .collect::<Vec<_>>();
+    let agents = list_agent_status(mempal_home, cwd)?
+        .into_iter()
+        .map(|status| AgentStatusSummary {
+            agent_id: status.record.agent_id,
+            tool: status.record.tool,
+            presence: status.presence,
+            pending_count: status.pending_count,
+        })
+        .collect::<Vec<_>>();
+    let pending_deliveries = list_delivery_statuses(mempal_home, cwd, None)?
+        .into_iter()
+        .filter(|delivery| delivery.status == "pending")
+        .filter(|delivery| {
+            filters
+                .thread_id
+                .as_ref()
+                .is_none_or(|thread_id| delivery.thread_id.as_ref() == Some(thread_id))
+        })
+        .filter(|delivery| {
+            filters
+                .channel
+                .as_ref()
+                .is_none_or(|channel| delivery.channel.as_ref() == Some(channel))
+        })
+        .collect::<Vec<_>>();
+    let mut recent_events = list_events(mempal_home, cwd, Some(limit))?
+        .into_iter()
+        .filter(|event| {
+            filters.thread_id.as_ref().is_none_or(|thread_id| {
+                event.details.get("thread_id") == Some(thread_id)
+                    || event.details.get("session_id").is_some_and(|session_id| {
+                        sessions.iter().any(|session| {
+                            &session.session_id == session_id
+                                && session.thread_id.as_ref() == Some(thread_id)
+                        })
+                    })
+            })
+        })
+        .filter(|event| {
+            filters
+                .channel
+                .as_ref()
+                .is_none_or(|channel| event.details.get("channel") == Some(channel))
+        })
+        .filter(|event| {
+            filters
+                .session_id
+                .as_ref()
+                .is_none_or(|session_id| event.details.get("session_id") == Some(session_id))
+        })
+        .collect::<Vec<_>>();
+    if recent_events.len() > limit {
+        recent_events.drain(0..recent_events.len() - limit);
+    }
+
+    Ok(HandoffSummary {
+        filters: HandoffSummaryFilters {
+            thread_id: filters.thread_id,
+            channel: filters.channel,
+            session_id: filters.session_id,
+            limit,
+        },
+        sessions,
+        agents,
+        pending_deliveries,
+        recent_events,
+    })
+}
+
+pub fn capture_handoff_to_memory(
+    db: Option<&Database>,
+    mempal_home: &Path,
+    cwd: &Path,
+    request: CoworkCaptureRequest,
+) -> Result<CoworkCaptureReport, BusError> {
+    if request.summary_source != "handoff" {
+        return Err(BusError::UnsupportedCaptureSource(request.summary_source));
+    }
+    let summary = build_handoff_summary(
+        mempal_home,
+        cwd,
+        HandoffFilters {
+            thread_id: request.thread_id,
+            channel: request.channel,
+            session_id: request.session_id,
+            limit: Some(50),
+        },
+    )?;
+    let capture_id = capture_id();
+    let mut content = String::new();
+    content.push_str("# Cowork Handoff Capture\n\n");
+    content.push_str(&format!("capture_id: {capture_id}\n"));
+    content.push_str(&format!("project: {}\n", cwd.display()));
+    content.push_str("summary_source: handoff\n\n");
+    if let Some(note) = request.note.as_deref() {
+        content.push_str("## Note\n\n");
+        content.push_str(note);
+        content.push_str("\n\n");
+    }
+    content.push_str("## Handoff Summary\n\n");
+    content.push_str(&format_handoff_plain(&summary));
+
+    let source_type = SourceType::Manual;
+    let drawer_id = build_bootstrap_evidence_drawer_id(
+        &request.wing,
+        request.room.as_deref(),
+        &content,
+        &source_type,
+    );
+    if request.execute {
+        let db = db.ok_or(BusError::MissingCaptureDatabase)?;
+        let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+            id: drawer_id.clone(),
+            content: content.clone(),
+            wing: request.wing.clone(),
+            room: request.room.clone(),
+            source_file: Some(format!("cowork-capture://{capture_id}")),
+            source_type,
+            added_at: current_timestamp(),
+            chunk_index: Some(0),
+            importance: 3,
+        });
+        db.insert_drawer(&drawer)?;
+    }
+
+    Ok(CoworkCaptureReport {
+        writes: request.execute,
+        drawer_id: Some(drawer_id),
+        wing: request.wing,
+        room: request.room,
+        source: "handoff".to_string(),
+        content,
+    })
+}
+
+pub fn send(mempal_home: &Path, cwd: &Path, request: SendRequest) -> Result<SendReport, BusError> {
+    validate_agent_id(&request.from)?;
+    if let Some(thread_id) = &request.thread_id {
+        validate_thread_id(thread_id)?;
+    }
+    if let Some(channel) = &request.channel {
+        validate_channel(channel)?;
+    }
+    if request.message.len() > MAX_MESSAGE_SIZE {
+        return Err(BusError::MessageTooLarge(request.message.len()));
+    }
+
+    let targets = dedup_targets(request.targets)?;
+    if targets.iter().any(|target| target == &request.from) {
+        return Err(BusError::SelfSend(request.from));
+    }
+
+    let registry = load_registry(mempal_home, cwd)?;
+    let source = registry
+        .agents
+        .get(&request.from)
+        .ok_or_else(|| BusError::UnknownSource(request.from.clone()))?;
+    let mut target_records = Vec::new();
+    for target in &targets {
+        validate_agent_id(target)?;
+        let record = registry
+            .agents
+            .get(target)
+            .ok_or_else(|| BusError::UnknownTarget(target.clone()))?;
+        target_records.push(record.clone());
+    }
+
+    let pushed_at = format_rfc3339(SystemTime::now());
+    let event_type = request.operation.event_type();
+    let message_preview = Some(message_preview(&request.message));
+    let mut delivered = Vec::new();
+    for target in target_records {
+        match target.transport.as_str() {
+            "inbox" => {
+                let (inbox_path, inbox_size_after) = append_to_agent_inbox(
+                    mempal_home,
+                    cwd,
+                    &source.agent_id,
+                    &target.agent_id,
+                    &request.message,
+                    &pushed_at,
+                    MessageMetadata {
+                        thread_id: request.thread_id.as_deref(),
+                        channel: request.channel.as_deref(),
+                    },
+                )?;
+                let mut details = BTreeMap::new();
+                details.insert(
+                    "inbox_path".to_string(),
+                    inbox_path.to_string_lossy().to_string(),
+                );
+                details.insert("inbox_size_after".to_string(), inbox_size_after.to_string());
+                add_optional_detail(&mut details, "thread_id", request.thread_id.as_deref());
+                add_optional_detail(&mut details, "channel", request.channel.as_deref());
+                let event = append_bus_event(
+                    mempal_home,
+                    cwd,
+                    event_type,
+                    "delivered",
+                    Some(source.agent_id.clone()),
+                    vec![target.agent_id.clone()],
+                    Some("inbox".to_string()),
+                    message_preview.clone(),
+                    details,
+                )?;
+                delivered.push(DeliveryReport {
+                    message_id: event.event_id,
+                    target_agent_id: target.agent_id,
+                    transport: "inbox".to_string(),
+                    inbox_path: Some(inbox_path),
+                    inbox_size_after: Some(inbox_size_after),
+                    tmux_target: None,
+                    thread_id: request.thread_id.clone(),
+                    channel: request.channel.clone(),
+                });
+            }
+            "tmux" => {
+                let tmux_target = target
+                    .tmux_target
+                    .as_deref()
+                    .ok_or(BusError::TmuxTargetRequired)?;
+                if let Err(err) = send_tmux(
+                    &source.agent_id,
+                    &target.agent_id,
+                    tmux_target,
+                    &request.message,
+                ) {
+                    let mut details = BTreeMap::new();
+                    details.insert("tmux_target".to_string(), tmux_target.to_string());
+                    details.insert("error".to_string(), err.to_string());
+                    add_optional_detail(&mut details, "thread_id", request.thread_id.as_deref());
+                    add_optional_detail(&mut details, "channel", request.channel.as_deref());
+                    let _ = append_bus_event(
+                        mempal_home,
+                        cwd,
+                        event_type,
+                        "failed",
+                        Some(source.agent_id.clone()),
+                        vec![target.agent_id.clone()],
+                        Some("tmux".to_string()),
+                        message_preview.clone(),
+                        details,
+                    );
+                    return Err(err);
+                }
+                let mut details = BTreeMap::new();
+                details.insert("tmux_target".to_string(), tmux_target.to_string());
+                add_optional_detail(&mut details, "thread_id", request.thread_id.as_deref());
+                add_optional_detail(&mut details, "channel", request.channel.as_deref());
+                let event = append_bus_event(
+                    mempal_home,
+                    cwd,
+                    event_type,
+                    "delivered",
+                    Some(source.agent_id.clone()),
+                    vec![target.agent_id.clone()],
+                    Some("tmux".to_string()),
+                    message_preview.clone(),
+                    details,
+                )?;
+                delivered.push(DeliveryReport {
+                    message_id: event.event_id,
+                    target_agent_id: target.agent_id,
+                    transport: "tmux".to_string(),
+                    inbox_path: None,
+                    inbox_size_after: None,
+                    tmux_target: Some(tmux_target.to_string()),
+                    thread_id: request.thread_id.clone(),
+                    channel: request.channel.clone(),
+                });
+            }
+            other => return Err(BusError::UnsupportedTransport(other.to_string())),
+        }
+    }
+    Ok(SendReport { delivered })
+}
+
+fn dedup_targets(targets: Vec<String>) -> Result<Vec<String>, BusError> {
+    let mut seen = BTreeSet::new();
+    let mut deduped = Vec::new();
+    for target in targets {
+        validate_agent_id(&target)?;
+        if seen.insert(target.clone()) {
+            deduped.push(target);
+        }
+    }
+    Ok(deduped)
+}
+
+fn append_to_agent_inbox(
+    mempal_home: &Path,
+    cwd: &Path,
+    from: &str,
+    target: &str,
+    content: &str,
+    pushed_at: &str,
+    metadata: MessageMetadata<'_>,
+) -> Result<(PathBuf, u64), BusError> {
+    use std::io::Write;
+
+    let path = agent_inbox_path(mempal_home, cwd, target)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let (existing_count, existing_bytes, _) = read_inbox_stats(&path)?;
+    let msg = InboxMessage {
+        pushed_at: pushed_at.to_string(),
+        from: from.to_string(),
+        content: content.to_string(),
+        thread_id: metadata.thread_id.map(str::to_string),
+        channel: metadata.channel.map(str::to_string),
+    };
+    let line = serde_json::to_string(&msg)?;
+    let prospective_count = existing_count + 1;
+    let prospective_bytes = existing_bytes.saturating_add(line.len() as u64 + 1);
+    if prospective_count > MAX_PENDING_MESSAGES || prospective_bytes > MAX_TOTAL_INBOX_BYTES {
+        return Err(BusError::InboxFull {
+            current_count: existing_count,
+            current_bytes: existing_bytes,
+        });
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    writeln!(file, "{line}")?;
+    file.flush()?;
+    let size = std::fs::metadata(&path)?.len();
+    Ok((path, size))
+}
+
+fn send_tmux(from: &str, target: &str, tmux_target: &str, content: &str) -> Result<(), BusError> {
+    let envelope = format!("[mempal bus from {from} to {target}] {content}");
+    let status = std::process::Command::new("tmux")
+        .args(["send-keys", "-t", tmux_target, "--", &envelope, "Enter"])
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(BusError::TmuxFailed(
+            status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "terminated by signal".to_string()),
+        ))
+    }
+}
+
+fn capture_tmux(tmux_target: &str, lines: usize) -> Result<String, BusError> {
+    let start = format!("-{lines}");
+    let output = std::process::Command::new("tmux")
+        .args(["capture-pane", "-t", tmux_target, "-p", "-S", &start])
+        .output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(BusError::TmuxCaptureFailed(
+            output
+                .status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "terminated by signal".to_string()),
+        ))
+    }
+}
+
+fn probe_tmux_target(tmux_target: &str) -> TmuxProbeReport {
+    match std::process::Command::new("tmux")
+        .args(["has-session", "-t", tmux_target])
+        .status()
+    {
+        Ok(status) if status.success() => TmuxProbeReport {
+            agent_id: String::new(),
+            tmux_target: tmux_target.to_string(),
+            status: "ok".to_string(),
+            detail: None,
+        },
+        Ok(status) => TmuxProbeReport {
+            agent_id: String::new(),
+            tmux_target: tmux_target.to_string(),
+            status: "failed".to_string(),
+            detail: Some(
+                status
+                    .code()
+                    .map(|code| code.to_string())
+                    .unwrap_or_else(|| "terminated by signal".to_string()),
+            ),
+        },
+        Err(error) => TmuxProbeReport {
+            agent_id: String::new(),
+            tmux_target: tmux_target.to_string(),
+            status: "failed".to_string(),
+            detail: Some(error.to_string()),
+        },
+    }
+}
+
+fn capture_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let seq = BUS_EVENT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("cowork-capture-{nanos}-{seq}")
+}
+
+pub fn drain_agent(
+    mempal_home: &Path,
+    cwd: &Path,
+    agent_id: &str,
+) -> Result<Vec<InboxMessage>, BusError> {
+    validate_agent_id(agent_id)?;
+    let registry = load_registry(mempal_home, cwd)?;
+    if !registry.agents.contains_key(agent_id) {
+        return Err(BusError::UnknownAgent(agent_id.to_string()));
+    }
+
+    let path = agent_inbox_path(mempal_home, cwd, agent_id)?;
+    let draining = path.with_extension("draining");
+    match std::fs::rename(&path, &draining) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            append_drain_event(mempal_home, cwd, agent_id, 0, 0)?;
+            return Ok(Vec::new());
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    let raw = std::fs::read_to_string(&draining)?;
+    let mut messages = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(msg) = serde_json::from_str::<InboxMessage>(trimmed) {
+            messages.push(msg);
+        }
+    }
+    let _ = std::fs::remove_file(&draining);
+    append_drain_event(mempal_home, cwd, agent_id, messages.len(), raw.len() as u64)?;
+    Ok(messages)
+}
+
+pub fn list_events(
+    mempal_home: &Path,
+    cwd: &Path,
+    limit: Option<usize>,
+) -> Result<Vec<BusEvent>, BusError> {
+    let path = events_path(mempal_home, cwd)?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let raw = std::fs::read_to_string(path)?;
+    let mut events = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        events.push(serde_json::from_str::<BusEvent>(trimmed)?);
+    }
+
+    if let Some(limit) = limit
+        && events.len() > limit
+    {
+        events.drain(0..events.len() - limit);
+    }
+    Ok(events)
+}
+
+pub fn list_delivery_statuses(
+    mempal_home: &Path,
+    cwd: &Path,
+    agent_id: Option<&str>,
+) -> Result<Vec<DeliveryStatus>, BusError> {
+    if let Some(agent_id) = agent_id {
+        validate_agent_id(agent_id)?;
+    }
+    let events = list_events(mempal_home, cwd, None)?;
+    let mut statuses = Vec::<DeliveryStatus>::new();
+    let mut index_by_message_id = BTreeMap::<String, usize>::new();
+
+    for event in events {
+        match event.event_type.as_str() {
+            "send" | "broadcast" if event.status == "delivered" || event.status == "failed" => {
+                let from = event.actor_agent_id.clone().unwrap_or_default();
+                let transport = event.transport.clone().unwrap_or_default();
+                for target in &event.target_agent_ids {
+                    let status = if event.status == "failed" {
+                        "failed"
+                    } else {
+                        "pending"
+                    };
+                    let delivery = DeliveryStatus {
+                        message_id: event.event_id.clone(),
+                        event_type: event.event_type.clone(),
+                        status: status.to_string(),
+                        from: from.clone(),
+                        target_agent_id: target.clone(),
+                        transport: transport.clone(),
+                        message_preview: event.message_preview.clone(),
+                        thread_id: event.details.get("thread_id").cloned(),
+                        channel: event.details.get("channel").cloned(),
+                        delivered_at: event.occurred_at.clone(),
+                        updated_at: event.occurred_at.clone(),
+                        acked_by: None,
+                    };
+                    index_by_message_id.insert(delivery.message_id.clone(), statuses.len());
+                    statuses.push(delivery);
+                }
+            }
+            "drain" if event.status == "drained" => {
+                let Some(target) = event.target_agent_ids.first() else {
+                    continue;
+                };
+                let drained_count = event
+                    .details
+                    .get("drained_count")
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .unwrap_or_default();
+                if drained_count == 0 {
+                    continue;
+                }
+                let mut remaining = drained_count;
+                for status in statuses.iter_mut() {
+                    if remaining == 0 {
+                        break;
+                    }
+                    if status.target_agent_id == *target && status.status == "pending" {
+                        status.status = "drained".to_string();
+                        status.updated_at = event.occurred_at.clone();
+                        remaining -= 1;
+                    }
+                }
+            }
+            "ack" if event.status == "acked" => {
+                let Some(message_id) = event.details.get("delivery_event_id") else {
+                    continue;
+                };
+                let Some(index) = index_by_message_id.get(message_id).copied() else {
+                    continue;
+                };
+                let status = &mut statuses[index];
+                status.status = "acked".to_string();
+                status.updated_at = event.occurred_at.clone();
+                status.acked_by = event.actor_agent_id.clone();
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(agent_id) = agent_id {
+        statuses.retain(|status| status.target_agent_id == agent_id);
+    }
+    Ok(statuses)
+}
+
+pub fn ack_delivery(
+    mempal_home: &Path,
+    cwd: &Path,
+    agent_id: &str,
+    message_id: &str,
+) -> Result<DeliveryStatus, BusError> {
+    validate_agent_id(agent_id)?;
+    let registry = load_registry(mempal_home, cwd)?;
+    if !registry.agents.contains_key(agent_id) {
+        return Err(BusError::UnknownAgent(agent_id.to_string()));
+    }
+
+    let deliveries = list_delivery_statuses(mempal_home, cwd, None)?;
+    let delivery = deliveries
+        .iter()
+        .find(|status| status.message_id == message_id)
+        .ok_or_else(|| BusError::UnknownDelivery(message_id.to_string()))?;
+    if delivery.target_agent_id != agent_id {
+        return Err(BusError::DeliveryTargetMismatch {
+            message_id: message_id.to_string(),
+            target_agent_id: delivery.target_agent_id.clone(),
+            agent_id: agent_id.to_string(),
+        });
+    }
+    if delivery.status == "failed" {
+        return Err(BusError::CannotAckFailed(message_id.to_string()));
+    }
+    if delivery.status != "acked" {
+        let mut details = BTreeMap::new();
+        details.insert("delivery_event_id".to_string(), message_id.to_string());
+        append_bus_event(
+            mempal_home,
+            cwd,
+            "ack",
+            "acked",
+            Some(agent_id.to_string()),
+            vec![agent_id.to_string()],
+            Some(delivery.transport.clone()),
+            None,
+            details,
+        )?;
+    }
+
+    list_delivery_statuses(mempal_home, cwd, Some(agent_id))?
+        .into_iter()
+        .find(|status| status.message_id == message_id)
+        .ok_or_else(|| BusError::UnknownDelivery(message_id.to_string()))
+}
+
+pub fn format_agent_plain(agent_id: &str, messages: &[InboxMessage]) -> String {
+    if messages.is_empty() {
+        return String::new();
+    }
+    let mut out = format!(
+        "[Multi-agent cowork inbox for {} ({} message{} since last check):]\n",
+        agent_id,
+        messages.len(),
+        if messages.len() == 1 { "" } else { "s" }
+    );
+    for msg in messages {
+        let mut metadata = Vec::new();
+        if let Some(thread_id) = &msg.thread_id {
+            metadata.push(format!("thread={thread_id}"));
+        }
+        if let Some(channel) = &msg.channel {
+            metadata.push(format!("channel={channel}"));
+        }
+        let metadata = if metadata.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", metadata.join(" "))
+        };
+        out.push_str(&format!(
+            "- {} from {}{}: {}\n",
+            msg.pushed_at, msg.from, metadata, msg.content
+        ));
+    }
+    out.push_str("[End multi-agent cowork inbox]\n");
+    out
+}
+
+pub fn format_events_plain(events: &[BusEvent]) -> String {
+    let mut out = String::new();
+    for event in events {
+        let actor = event.actor_agent_id.as_deref().unwrap_or("-");
+        let targets = if event.target_agent_ids.is_empty() {
+            "-".to_string()
+        } else {
+            event.target_agent_ids.join(",")
+        };
+        let transport = event.transport.as_deref().unwrap_or("-");
+        let preview = event.message_preview.as_deref().unwrap_or("-");
+        let details = format_details(&event.details);
+        out.push_str(&format!(
+            "{} {} type={} status={} actor={} targets={} transport={} preview={} details={}\n",
+            event.event_id,
+            event.occurred_at,
+            event.event_type,
+            event.status,
+            actor,
+            targets,
+            transport,
+            preview,
+            details
+        ));
+    }
+    out
+}
+
+pub fn format_delivery_statuses_plain(deliveries: &[DeliveryStatus]) -> String {
+    let mut out = String::new();
+    for delivery in deliveries {
+        let preview = delivery.message_preview.as_deref().unwrap_or("-");
+        let thread_id = delivery.thread_id.as_deref().unwrap_or("-");
+        let channel = delivery.channel.as_deref().unwrap_or("-");
+        out.push_str(&format!(
+            "{} {} status={} from={} target={} transport={} thread={} channel={} preview={}\n",
+            delivery.message_id,
+            delivery.updated_at,
+            delivery.status,
+            delivery.from,
+            delivery.target_agent_id,
+            delivery.transport,
+            thread_id,
+            channel,
+            preview
+        ));
+    }
+    out
+}
+
+pub fn format_doctor_plain(report: &DoctorReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "status={} agents={} channels={} sessions={} stale_agents={} never_seen_agents={} pending_deliveries={}\n",
+        report.status,
+        report.agent_count,
+        report.channel_count,
+        report.session_count,
+        report.stale_agents,
+        report.never_seen_agents,
+        report.pending_deliveries
+    ));
+    for warning in &report.warnings {
+        out.push_str(&format!("warning: {warning}\n"));
+    }
+    for probe in &report.tmux {
+        out.push_str(&format!(
+            "tmux agent={} target={} status={} detail={}\n",
+            probe.agent_id,
+            probe.tmux_target,
+            probe.status,
+            probe.detail.as_deref().unwrap_or("-")
+        ));
+    }
+    out
+}
+
+pub fn format_sessions_plain(sessions: &[TeamSession]) -> String {
+    if sessions.is_empty() {
+        return "no sessions\n".to_string();
+    }
+    let mut out = String::new();
+    for session in sessions {
+        out.push_str(&format!(
+            "{} status={} title={} agents={} channels={} thread={} updated_at={}\n",
+            session.session_id,
+            session.status,
+            session.title,
+            session.agents.join(","),
+            if session.channels.is_empty() {
+                "-".to_string()
+            } else {
+                session.channels.join(",")
+            },
+            session.thread_id.as_deref().unwrap_or("-"),
+            session.updated_at
+        ));
+        if let Some(goal) = &session.goal {
+            out.push_str(&format!("  goal={goal}\n"));
+        }
+    }
+    out
+}
+
+pub fn format_handoff_plain(summary: &HandoffSummary) -> String {
+    let mut out = String::new();
+    out.push_str("Cowork Handoff Summary\n");
+    out.push_str(&format!(
+        "filters thread={} channel={} session={} limit={}\n\n",
+        summary.filters.thread_id.as_deref().unwrap_or("-"),
+        summary.filters.channel.as_deref().unwrap_or("-"),
+        summary.filters.session_id.as_deref().unwrap_or("-"),
+        summary.filters.limit
+    ));
+
+    out.push_str("Active sessions\n");
+    let active_sessions = summary
+        .sessions
+        .iter()
+        .filter(|session| session.status == "active")
+        .collect::<Vec<_>>();
+    if active_sessions.is_empty() {
+        out.push_str("- none\n");
+    } else {
+        for session in active_sessions {
+            out.push_str(&format!(
+                "- {} [{}] agents={} thread={} goal={}\n",
+                session.session_id,
+                session.title,
+                session.agents.join(","),
+                session.thread_id.as_deref().unwrap_or("-"),
+                session.goal.as_deref().unwrap_or("-")
+            ));
+        }
+    }
+
+    out.push_str("\nAgents\n");
+    if summary.agents.is_empty() {
+        out.push_str("- none\n");
+    } else {
+        for agent in &summary.agents {
+            out.push_str(&format!(
+                "- {} tool={} presence={} pending={}\n",
+                agent.agent_id, agent.tool, agent.presence, agent.pending_count
+            ));
+        }
+    }
+
+    out.push_str("\nPending deliveries\n");
+    if summary.pending_deliveries.is_empty() {
+        out.push_str("- none\n");
+    } else {
+        for delivery in &summary.pending_deliveries {
+            out.push_str(&format!(
+                "- {} from={} target={} thread={} channel={} preview={}\n",
+                delivery.message_id,
+                delivery.from,
+                delivery.target_agent_id,
+                delivery.thread_id.as_deref().unwrap_or("-"),
+                delivery.channel.as_deref().unwrap_or("-"),
+                delivery.message_preview.as_deref().unwrap_or("-")
+            ));
+        }
+    }
+
+    out.push_str("\nRecent events\n");
+    if summary.recent_events.is_empty() {
+        out.push_str("- none\n");
+    } else {
+        for event in &summary.recent_events {
+            out.push_str(&format!(
+                "- {} type={} status={} actor={} targets={} details={}\n",
+                event.event_id,
+                event.event_type,
+                event.status,
+                event.actor_agent_id.as_deref().unwrap_or("-"),
+                event.target_agent_ids.join(","),
+                format_details(&event.details)
+            ));
+        }
+    }
+    out
+}
+
+pub fn format_capture_plain(report: &CoworkCaptureReport) -> String {
+    format!(
+        "writes={} drawer_id={} wing={} room={} source={}\n",
+        report.writes,
+        report.drawer_id.as_deref().unwrap_or("-"),
+        report.wing,
+        report.room.as_deref().unwrap_or("-"),
+        report.source
+    )
+}
+
+fn append_drain_event(
+    mempal_home: &Path,
+    cwd: &Path,
+    agent_id: &str,
+    drained_count: usize,
+    drained_bytes: u64,
+) -> Result<BusEvent, BusError> {
+    let mut details = BTreeMap::new();
+    details.insert("drained_count".to_string(), drained_count.to_string());
+    details.insert("drained_bytes".to_string(), drained_bytes.to_string());
+    append_bus_event(
+        mempal_home,
+        cwd,
+        "drain",
+        "drained",
+        Some(agent_id.to_string()),
+        vec![agent_id.to_string()],
+        Some("inbox".to_string()),
+        None,
+        details,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_bus_event(
+    mempal_home: &Path,
+    cwd: &Path,
+    event_type: &str,
+    status: &str,
+    actor_agent_id: Option<String>,
+    target_agent_ids: Vec<String>,
+    transport: Option<String>,
+    message_preview: Option<String>,
+    details: BTreeMap<String, String>,
+) -> Result<BusEvent, BusError> {
+    use std::io::Write;
+
+    let event = BusEvent {
+        event_id: new_event_id(),
+        occurred_at: format_rfc3339(SystemTime::now()),
+        event_type: event_type.to_string(),
+        status: status.to_string(),
+        actor_agent_id,
+        target_agent_ids,
+        transport,
+        message_preview,
+        details,
+    };
+    let path = events_path(mempal_home, cwd)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(file, "{}", serde_json::to_string(&event)?)?;
+    file.flush()?;
+    Ok(event)
+}
+
+fn new_event_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let seq = BUS_EVENT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("evt-{nanos}-{seq}")
+}
+
+fn message_preview(content: &str) -> String {
+    let mut preview: String = content
+        .chars()
+        .take(MAX_EVENT_MESSAGE_PREVIEW_CHARS)
+        .collect();
+    if content.chars().count() > MAX_EVENT_MESSAGE_PREVIEW_CHARS {
+        preview.push_str("...");
+    }
+    preview
+}
+
+fn add_optional_detail(details: &mut BTreeMap<String, String>, key: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        details.insert(key.to_string(), value.to_string());
+    }
+}
+
+fn format_details(details: &BTreeMap<String, String>) -> String {
+    if details.is_empty() {
+        return "-".to_string();
+    }
+    details
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn presence_for(last_seen_at: Option<&str>, now_seconds: i64) -> String {
+    let Some(last_seen_at) = last_seen_at else {
+        return "never_seen".to_string();
+    };
+    let Some(last_seen_seconds) = parse_rfc3339(last_seen_at) else {
+        return "stale".to_string();
+    };
+    if now_seconds.saturating_sub(last_seen_seconds) <= PRESENCE_STALE_AFTER_SECONDS {
+        "online".to_string()
+    } else {
+        "stale".to_string()
+    }
+}
+
+fn current_unix_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+fn read_inbox_stats(path: &Path) -> Result<(usize, u64, Vec<InboxMessage>), BusError> {
+    if !path.exists() {
+        return Ok((0, 0, Vec::new()));
+    }
+    let raw = std::fs::read_to_string(path)?;
+    let mut count = 0;
+    let mut preview = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        count += 1;
+        if preview.len() < 3 {
+            if let Ok(msg) = serde_json::from_str::<InboxMessage>(trimmed) {
+                preview.push(msg);
+            }
+        }
+    }
+    Ok((count, raw.len() as u64, preview))
+}

--- a/src/cowork/inbox.rs
+++ b/src/cowork/inbox.rs
@@ -44,6 +44,10 @@ pub struct InboxMessage {
     pub pushed_at: String,
     pub from: String,
     pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
 }
 
 /// Resolve ~/.mempal using the HOME env var. Matches the existing
@@ -143,6 +147,8 @@ pub fn push(
         pushed_at,
         from: caller.dir_name().to_string(),
         content,
+        thread_id: None,
+        channel: None,
     };
     let line = serde_json::to_string(&msg)?;
     // writeln! appends exactly 1 byte for `\n`
@@ -425,6 +431,8 @@ mod tests {
             pushed_at: rfc3339(),
             from: Tool::Claude.dir_name().to_string(),
             content: String::new(),
+            thread_id: None,
+            channel: None,
         };
         let empty_line_bytes = serde_json::to_string(&probe).unwrap().len() + 1;
         assert!(
@@ -502,6 +510,8 @@ mod tests {
             pushed_at: rfc3339(),
             from: Tool::Claude.dir_name().to_string(),
             content: String::new(),
+            thread_id: None,
+            channel: None,
         };
         let probe_empty_line_bytes = serde_json::to_string(&probe).unwrap().len() as u64 + 1;
 
@@ -740,11 +750,15 @@ mod tests {
                 pushed_at: "2026-04-15T01:00:00Z".into(),
                 from: "codex".into(),
                 content: "first".into(),
+                thread_id: None,
+                channel: None,
             },
             InboxMessage {
                 pushed_at: "2026-04-15T01:01:00Z".into(),
                 from: "codex".into(),
                 content: "second".into(),
+                thread_id: None,
+                channel: None,
             },
         ];
         let out = format_plain(Tool::Codex, &msgs);
@@ -761,6 +775,8 @@ mod tests {
             pushed_at: "2026-04-15T01:00:00Z".into(),
             from: "claude".into(),
             content: "test\nwith\nnewlines and \"quotes\"".into(),
+            thread_id: None,
+            channel: None,
         }];
         let out = format_codex_hook_json(Tool::Claude, &msgs).unwrap();
 

--- a/src/cowork/mod.rs
+++ b/src/cowork/mod.rs
@@ -3,11 +3,18 @@
 //! See `docs/specs/2026-04-13-cowork-peek-and-decide.md` (P6 peek) and
 //! `docs/specs/2026-04-14-p8-cowork-inbox-push.md` (P8 push).
 
+pub mod bus;
 pub mod claude;
 pub mod codex;
 pub mod inbox;
 pub mod peek;
 
+pub use bus::{
+    AgentRecord, AgentRegistry, AgentStatus, AgentStatusSummary, BusError, BusEvent,
+    CoworkCaptureReport, CoworkCaptureRequest, CreateSessionRequest, DeliveryReport,
+    DeliveryStatus, DoctorReport, HandoffFilters, HandoffSummary, RegisterAgentRequest,
+    SendOperation, SendReport, SendRequest, TeamSession, TmuxPeek, TmuxProbeReport,
+};
 pub use inbox::{
     InboxError, InboxMessage, MAX_MESSAGE_SIZE, MAX_PENDING_MESSAGES, MAX_TOTAL_INBOX_BYTES,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod aaak;
 #[cfg(feature = "rest")]
 pub mod api;
+pub mod brief;
 pub mod context;
 pub mod core;
 pub mod cowork;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
 #[cfg(feature = "rest")]
 use std::sync::Arc;
 
@@ -11,6 +12,7 @@ use clap::{Parser, Subcommand};
 use mempal::aaak::{AaakCodec, AaakMeta};
 #[cfg(feature = "rest")]
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
+use mempal::brief::{BriefRequest, CognitiveBrief, assemble_brief};
 use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
     anchor,
@@ -151,6 +153,21 @@ enum Commands {
         #[arg(long = "dao-tian-limit", default_value_t = 1)]
         dao_tian_limit: usize,
     },
+    Brief {
+        query: String,
+        #[arg(long, default_value = "general")]
+        field: String,
+        #[arg(long, default_value = "project")]
+        domain: String,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+        #[arg(long, default_value_t = 12)]
+        max_items: usize,
+        #[arg(long = "dao-tian-limit", default_value_t = 1)]
+        dao_tian_limit: usize,
+    },
     WakeUp {
         #[arg(long)]
         format: Option<String>,
@@ -258,11 +275,230 @@ enum Commands {
         #[arg(long)]
         cwd: PathBuf,
     },
+    /// Print the multi-agent cowork runbook.
+    CoworkRunbook {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     /// Install cowork hooks: Claude Code (project-level .claude/hooks)
     /// and optionally Codex (global ~/.codex/hooks.json merge).
     CoworkInstallHooks {
         #[arg(long, default_value_t = false)]
         global_codex: bool,
+    },
+    /// Register or update a concrete agent instance in the multi-agent cowork
+    /// bus.
+    CoworkRegister {
+        #[arg(long)]
+        agent_id: String,
+        #[arg(long)]
+        tool: String,
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long, default_value = "inbox")]
+        transport: String,
+        #[arg(long)]
+        tmux_target: Option<String>,
+    },
+    /// Send one ephemeral message to one concrete agent id.
+    CoworkSend {
+        #[arg(long)]
+        from: String,
+        #[arg(long)]
+        to: String,
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        message: String,
+        #[arg(long)]
+        thread_id: Option<String>,
+        #[arg(long)]
+        channel: Option<String>,
+    },
+    /// Fan out one ephemeral message to several concrete agent ids.
+    CoworkBroadcast {
+        #[arg(long)]
+        from: String,
+        #[arg(long = "to", required = true)]
+        to: Vec<String>,
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        message: String,
+        #[arg(long)]
+        thread_id: Option<String>,
+        #[arg(long)]
+        channel: Option<String>,
+    },
+    /// Drain one concrete agent id's multi-agent bus inbox.
+    CoworkAgentDrain {
+        #[arg(long)]
+        agent_id: String,
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    /// List registered concrete agents and their per-agent inbox state.
+    CoworkAgents {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        now: Option<String>,
+    },
+    /// Replay append-only multi-agent cowork bus events.
+    CoworkEvents {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        limit: Option<usize>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    /// Acknowledge one delivery message id for a concrete agent.
+    CoworkAck {
+        #[arg(long)]
+        agent_id: String,
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        message_id: String,
+    },
+    /// Replay delivery status derived from the multi-agent cowork event log.
+    CoworkDeliveries {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        agent_id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    /// Update one concrete agent's explicit heartbeat timestamp.
+    CoworkHeartbeat {
+        #[arg(long)]
+        agent_id: String,
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        seen_at: Option<String>,
+    },
+    /// Replace one channel membership list with concrete agent ids.
+    CoworkChannelSet {
+        #[arg(long)]
+        channel: String,
+        #[arg(long = "agent", required = true)]
+        agent: Vec<String>,
+        #[arg(long)]
+        cwd: PathBuf,
+    },
+    /// Send one message to all current members of a channel.
+    CoworkChannelSend {
+        #[arg(long)]
+        from: String,
+        #[arg(long)]
+        channel: String,
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        message: String,
+        #[arg(long)]
+        thread_id: Option<String>,
+    },
+    /// Read-only capture of a registered tmux agent pane.
+    CoworkTmuxPeek {
+        #[arg(long)]
+        agent_id: String,
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long, default_value_t = 80)]
+        lines: usize,
+    },
+    /// Diagnose multi-agent cowork bus runtime state.
+    CoworkDoctor {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        now: Option<String>,
+        #[arg(long)]
+        probe_tmux: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    /// Create or replace a runtime team session.
+    CoworkSessionCreate {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        session_id: String,
+        #[arg(long)]
+        title: String,
+        #[arg(long)]
+        goal: Option<String>,
+        #[arg(long = "agent", required = true)]
+        agent: Vec<String>,
+        #[arg(long = "channel")]
+        channel: Vec<String>,
+        #[arg(long)]
+        thread_id: Option<String>,
+    },
+    /// List runtime team sessions.
+    CoworkSessions {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    /// Update a runtime team session status.
+    CoworkSessionStatus {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        session_id: String,
+        #[arg(long)]
+        status: String,
+    },
+    /// Build a deterministic multi-agent handoff summary.
+    CoworkHandoff {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        thread_id: Option<String>,
+        #[arg(long)]
+        channel: Option<String>,
+        #[arg(long)]
+        session_id: Option<String>,
+        #[arg(long)]
+        limit: Option<usize>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    /// Explicitly capture a cowork handoff summary into evidence memory.
+    CoworkCapture {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long, default_value = "handoff")]
+        summary_source: String,
+        #[arg(long, default_value = "cowork-capture")]
+        wing: String,
+        #[arg(long)]
+        room: Option<String>,
+        #[arg(long)]
+        thread_id: Option<String>,
+        #[arg(long)]
+        channel: Option<String>,
+        #[arg(long)]
+        session_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long)]
+        execute: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    /// Print the governed maintenance runbook.
+    MaintenanceRunbook {
+        #[arg(long, default_value = "plain")]
+        format: String,
     },
 }
 
@@ -722,6 +958,36 @@ enum Phase3AdoptionCommands {
         #[arg(long, default_value = "plain")]
         format: String,
     },
+    Wrap {
+        #[arg(long)]
+        surface: String,
+        #[arg(long, default_value = "auto")]
+        outcome: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long)]
+        execute: bool,
+        #[arg(long = "allow-warnings")]
+        allow_warnings: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+        #[arg(last = true, required = true)]
+        command: Vec<String>,
+    },
     CheckRecord {
         #[arg(long)]
         track: String,
@@ -910,8 +1176,190 @@ async fn run() -> Result<()> {
         Commands::CoworkStatus { cwd } => {
             return cowork_status_command(cwd);
         }
+        Commands::CoworkRunbook { format } => {
+            return static_runbook_command(
+                "Multi-Agent Cowork Runbook",
+                include_str!("../docs/COWORK-RUNBOOK.md"),
+                &format,
+            );
+        }
         Commands::CoworkInstallHooks { global_codex } => {
             return cowork_install_hooks_command(global_codex);
+        }
+        Commands::CoworkRegister {
+            agent_id,
+            tool,
+            cwd,
+            transport,
+            tmux_target,
+        } => {
+            return cowork_register_command(agent_id, tool, cwd, transport, tmux_target);
+        }
+        Commands::CoworkSend {
+            from,
+            to,
+            cwd,
+            message,
+            thread_id,
+            channel,
+        } => {
+            return cowork_send_command(
+                from,
+                vec![to],
+                cwd,
+                message,
+                mempal::cowork::bus::SendOperation::Send,
+                thread_id,
+                channel,
+            );
+        }
+        Commands::CoworkBroadcast {
+            from,
+            to,
+            cwd,
+            message,
+            thread_id,
+            channel,
+        } => {
+            return cowork_send_command(
+                from,
+                to,
+                cwd,
+                message,
+                mempal::cowork::bus::SendOperation::Broadcast,
+                thread_id,
+                channel,
+            );
+        }
+        Commands::CoworkAgentDrain {
+            agent_id,
+            cwd,
+            format,
+        } => {
+            return cowork_agent_drain_command(agent_id, cwd, format);
+        }
+        Commands::CoworkAgents { cwd, now } => {
+            return cowork_agents_command(cwd, now);
+        }
+        Commands::CoworkEvents { cwd, limit, format } => {
+            return cowork_events_command(cwd, limit, format);
+        }
+        Commands::CoworkAck {
+            agent_id,
+            cwd,
+            message_id,
+        } => {
+            return cowork_ack_command(agent_id, cwd, message_id);
+        }
+        Commands::CoworkDeliveries {
+            cwd,
+            agent_id,
+            format,
+        } => {
+            return cowork_deliveries_command(cwd, agent_id, format);
+        }
+        Commands::CoworkHeartbeat {
+            agent_id,
+            cwd,
+            seen_at,
+        } => {
+            return cowork_heartbeat_command(agent_id, cwd, seen_at);
+        }
+        Commands::CoworkChannelSet {
+            channel,
+            agent,
+            cwd,
+        } => {
+            return cowork_channel_set_command(channel, agent, cwd);
+        }
+        Commands::CoworkChannelSend {
+            from,
+            channel,
+            cwd,
+            message,
+            thread_id,
+        } => {
+            return cowork_channel_send_command(from, channel, cwd, message, thread_id);
+        }
+        Commands::CoworkTmuxPeek {
+            agent_id,
+            cwd,
+            lines,
+        } => {
+            return cowork_tmux_peek_command(agent_id, cwd, lines);
+        }
+        Commands::CoworkDoctor {
+            cwd,
+            now,
+            probe_tmux,
+            format,
+        } => {
+            return cowork_doctor_command(cwd, now, probe_tmux, format);
+        }
+        Commands::CoworkSessionCreate {
+            cwd,
+            session_id,
+            title,
+            goal,
+            agent,
+            channel,
+            thread_id,
+        } => {
+            return cowork_session_create_command(
+                cwd, session_id, title, goal, agent, channel, thread_id,
+            );
+        }
+        Commands::CoworkSessions { cwd, format } => {
+            return cowork_sessions_command(cwd, format);
+        }
+        Commands::CoworkSessionStatus {
+            cwd,
+            session_id,
+            status,
+        } => {
+            return cowork_session_status_command(cwd, session_id, status);
+        }
+        Commands::CoworkHandoff {
+            cwd,
+            thread_id,
+            channel,
+            session_id,
+            limit,
+            format,
+        } => {
+            return cowork_handoff_command(cwd, thread_id, channel, session_id, limit, format);
+        }
+        Commands::CoworkCapture {
+            cwd,
+            summary_source,
+            wing,
+            room,
+            thread_id,
+            channel,
+            session_id,
+            note,
+            execute,
+            format,
+        } => {
+            return cowork_capture_command(CoworkCaptureCommandArgs {
+                cwd,
+                summary_source,
+                wing,
+                room,
+                thread_id,
+                channel,
+                session_id,
+                note,
+                execute,
+                format,
+            });
+        }
+        Commands::MaintenanceRunbook { format } => {
+            return static_runbook_command(
+                "Maintenance Runbook",
+                include_str!("../docs/MAINTENANCE-RUNBOOK.md"),
+                &format,
+            );
         }
         // All other commands fall through to the db-backed dispatch below.
         _ => {}
@@ -1012,6 +1460,30 @@ async fn run() -> Result<()> {
             )
             .await
         }
+        Commands::Brief {
+            query,
+            field,
+            domain,
+            cwd,
+            format,
+            max_items,
+            dao_tian_limit,
+        } => {
+            brief_command(
+                &db,
+                &config,
+                BriefCommandArgs {
+                    query,
+                    field,
+                    domain,
+                    cwd,
+                    format,
+                    max_items,
+                    dao_tian_limit,
+                },
+            )
+            .await
+        }
         Commands::Delete { drawer_id } => delete_command(&db, &drawer_id),
         Commands::Purge { before } => purge_command(&db, before.as_deref()),
         Commands::WakeUp { format } => wake_up_command(&db, format.as_deref()),
@@ -1040,7 +1512,27 @@ async fn run() -> Result<()> {
         // Cowork commands were already dispatched above and returned early.
         Commands::CoworkDrain { .. }
         | Commands::CoworkStatus { .. }
-        | Commands::CoworkInstallHooks { .. } => unreachable!(),
+        | Commands::CoworkRunbook { .. }
+        | Commands::CoworkInstallHooks { .. }
+        | Commands::CoworkRegister { .. }
+        | Commands::CoworkSend { .. }
+        | Commands::CoworkBroadcast { .. }
+        | Commands::CoworkAgentDrain { .. }
+        | Commands::CoworkAgents { .. }
+        | Commands::CoworkEvents { .. }
+        | Commands::CoworkAck { .. }
+        | Commands::CoworkDeliveries { .. }
+        | Commands::CoworkHeartbeat { .. }
+        | Commands::CoworkChannelSet { .. }
+        | Commands::CoworkChannelSend { .. }
+        | Commands::CoworkTmuxPeek { .. }
+        | Commands::CoworkDoctor { .. }
+        | Commands::CoworkSessionCreate { .. }
+        | Commands::CoworkSessions { .. }
+        | Commands::CoworkSessionStatus { .. }
+        | Commands::CoworkHandoff { .. }
+        | Commands::CoworkCapture { .. }
+        | Commands::MaintenanceRunbook { .. } => unreachable!(),
     }
 }
 
@@ -1063,6 +1555,16 @@ struct ContextCommandArgs {
     include_evidence: bool,
     include_cards: bool,
     no_include_cards: bool,
+    max_items: usize,
+    dao_tian_limit: usize,
+}
+
+struct BriefCommandArgs {
+    query: String,
+    field: String,
+    domain: String,
+    cwd: Option<PathBuf>,
+    format: String,
     max_items: usize,
     dao_tian_limit: usize,
 }
@@ -1307,6 +1809,49 @@ async fn context_command(db: &Database, config: &Config, args: ContextCommandArg
     Ok(())
 }
 
+async fn brief_command(db: &Database, config: &Config, args: BriefCommandArgs) -> Result<()> {
+    if args.max_items == 0 {
+        bail!("--max-items must be greater than 0");
+    }
+    if !matches!(args.format.as_str(), "plain" | "json") {
+        bail!("unsupported brief format: {}", args.format);
+    }
+    let domain = parse_domain(&args.domain)?;
+    let cwd = match args.cwd {
+        Some(cwd) => cwd,
+        None => env::current_dir().context("failed to read current directory")?,
+    };
+
+    let embedder = build_embedder(config).await?;
+    let brief = assemble_brief(
+        db,
+        &*embedder,
+        BriefRequest {
+            query: args.query,
+            domain,
+            field: args.field,
+            cwd,
+            max_items: args.max_items,
+            dao_tian_limit: args.dao_tian_limit,
+        },
+    )
+    .await?;
+
+    match args.format.as_str() {
+        "plain" => print_brief_plain(&brief),
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&brief)
+                    .context("failed to serialize cognitive brief")?
+            );
+        }
+        _ => unreachable!("brief format was validated before embedding"),
+    }
+
+    Ok(())
+}
+
 fn parse_domain(value: &str) -> Result<MemoryDomain> {
     match value {
         "project" => Ok(MemoryDomain::Project),
@@ -1494,6 +2039,96 @@ fn build_cli_search_result(result: mempal::core::types::SearchResult) -> CliSear
         anchor_kind: anchor_kind_slug(&result.anchor_kind).to_string(),
         anchor_id: result.anchor_id,
         parent_anchor_id: result.parent_anchor_id,
+    }
+}
+
+fn print_brief_plain(brief: &CognitiveBrief) {
+    println!("## Summary");
+    println!("{}", brief.summary.narrative);
+
+    println!("## Key Facts");
+    if brief.key_facts.is_empty() {
+        println!("- none");
+    } else {
+        for fact in &brief.key_facts {
+            println!("- {}", fact.text);
+            println!("  drawer: {}", fact.citation.drawer_id);
+            println!("  source: {}", fact.citation.source_file);
+        }
+    }
+
+    println!("## Evidence");
+    if brief.evidence.is_empty() {
+        println!("- none");
+    } else {
+        for evidence in &brief.evidence {
+            println!("- {}", evidence.text);
+            println!("  drawer: {}", evidence.citation.drawer_id);
+            println!("  source: {}", evidence.citation.source_file);
+        }
+    }
+
+    println!("## Cards");
+    if brief.cards.is_empty() {
+        println!("- none");
+    } else {
+        for card in &brief.cards {
+            println!("- {}", card.text);
+            println!("  card: {}", card.card_id);
+            println!("  drawer: {}", card.citation.drawer_id);
+            println!("  source: {}", card.citation.source_file);
+            for citation in &card.evidence_citations {
+                println!(
+                    "  evidence: {} role={}",
+                    citation.evidence_drawer_id,
+                    knowledge_evidence_role_slug(&citation.role)
+                );
+            }
+        }
+    }
+
+    println!("## Entities");
+    if brief.entities.is_empty() {
+        println!("- none");
+    } else {
+        for entity in &brief.entities {
+            println!("- {entity}");
+        }
+    }
+
+    println!("## Unresolved");
+    if brief.unresolved_items.is_empty() {
+        println!("- none");
+    } else {
+        for item in &brief.unresolved_items {
+            println!("- {}", item.text);
+            println!("  drawer: {}", item.citation.drawer_id);
+            println!("  source: {}", item.citation.source_file);
+        }
+    }
+
+    println!("## Uncertainty");
+    if brief.uncertainty.is_empty() {
+        println!("- none");
+    } else {
+        for item in &brief.uncertainty {
+            println!("- {}: {}", item.kind, item.message);
+            for citation in &item.citations {
+                println!(
+                    "  citation: {} {}",
+                    citation.drawer_id, citation.source_file
+                );
+            }
+        }
+    }
+
+    println!("## Next Actions");
+    if brief.next_actions.is_empty() {
+        println!("- none");
+    } else {
+        for action in &brief.next_actions {
+            println!("- {action}");
+        }
     }
 }
 
@@ -2690,6 +3325,47 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             }
             print_runtime_adoption_capture(&report, &format)
         }
+        Phase3AdoptionCommands::Wrap {
+            surface,
+            outcome,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            execute,
+            allow_warnings,
+            format,
+            command,
+        } => {
+            let report = phase3_adoption_wrap_command(
+                db,
+                RuntimeAdoptionWrapArgs {
+                    surface,
+                    outcome,
+                    query,
+                    context_hash,
+                    card_id,
+                    evaluator_id,
+                    research_report_id,
+                    note,
+                    metadata_json,
+                    id,
+                    execute,
+                    allow_warnings,
+                    command,
+                },
+            )?;
+            let exit_code = report.child_exit_code;
+            print_runtime_adoption_wrap(&report, &format)?;
+            if exit_code != 0 {
+                std::process::exit(exit_code);
+            }
+            Ok(())
+        }
         Phase3AdoptionCommands::CheckRecord {
             track,
             signal,
@@ -2916,6 +3592,116 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
     }
 }
 
+struct RuntimeAdoptionWrapArgs {
+    surface: String,
+    outcome: String,
+    query: Option<String>,
+    context_hash: Option<String>,
+    card_id: Option<String>,
+    evaluator_id: Option<String>,
+    research_report_id: Option<String>,
+    note: Option<String>,
+    metadata_json: Option<String>,
+    id: Option<String>,
+    execute: bool,
+    allow_warnings: bool,
+    command: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct RuntimeAdoptionWrapReport {
+    writes: bool,
+    execute: bool,
+    surface: String,
+    outcome: String,
+    child_exit_code: i32,
+    child_stdout: String,
+    child_stderr: String,
+    capture: RuntimeAdoptionCaptureReport,
+}
+
+fn phase3_adoption_wrap_command(
+    db: &Database,
+    args: RuntimeAdoptionWrapArgs,
+) -> Result<RuntimeAdoptionWrapReport> {
+    let (program, argv) = args
+        .command
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("child command is required after `--`"))?;
+    let output = ProcessCommand::new(program)
+        .args(argv)
+        .output()
+        .with_context(|| format!("failed to execute child command `{program}`"))?;
+    let child_exit_code = output.status.code().unwrap_or(1);
+    let outcome = match args.outcome.as_str() {
+        "auto" => {
+            if child_exit_code == 0 {
+                "accepted".to_string()
+            } else {
+                "rejected".to_string()
+            }
+        }
+        other => other.to_string(),
+    };
+    let metadata = args
+        .metadata_json
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .context("failed to parse --metadata-json")?;
+    let record_input = capture_runtime_adoption_record_input(RuntimeAdoptionCaptureInput {
+        id: args.id,
+        surface: args.surface.clone(),
+        outcome: outcome.clone(),
+        query: args.query,
+        context_hash: args.context_hash,
+        card_id: args.card_id,
+        evaluator_id: args.evaluator_id,
+        research_report_id: args.research_report_id,
+        note: args.note,
+        metadata,
+    })
+    .map_err(anyhow::Error::msg)?;
+    let mut capture = prepare_runtime_adoption_capture(
+        args.surface.clone(),
+        outcome.clone(),
+        args.execute,
+        record_input.clone(),
+    );
+    if args.execute {
+        let track = parse_runtime_adoption_track(&record_input.track)?;
+        let signal = parse_runtime_adoption_signal(&record_input.signal)?;
+        let should_write =
+            should_write_checked_record(&capture.record_quality, args.allow_warnings);
+        let event = if should_write {
+            let event = runtime_adoption_event_from_input(record_input, track, signal);
+            db.insert_runtime_adoption_event(&event)
+                .context("failed to insert runtime adoption event")?;
+            Some(event)
+        } else {
+            None
+        };
+        capture.writes = event.is_some();
+        capture.record_checked = Some(RuntimeAdoptionCheckedRecordReport {
+            writes: event.is_some(),
+            blocked: event.is_none(),
+            record_quality: capture.record_quality.clone(),
+            event,
+        });
+    }
+
+    Ok(RuntimeAdoptionWrapReport {
+        writes: capture.writes,
+        execute: args.execute,
+        surface: args.surface,
+        outcome,
+        child_exit_code,
+        child_stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        child_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        capture,
+    })
+}
+
 fn runtime_adoption_event_from_input(
     input: RuntimeAdoptionRecordPlanInput,
     track: RuntimeAdoptionTrack,
@@ -3021,6 +3807,47 @@ fn print_runtime_adoption_capture(
                 "{}",
                 serde_json::to_string_pretty(report)
                     .context("failed to serialize runtime adoption capture report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
+    }
+}
+
+fn print_runtime_adoption_wrap(report: &RuntimeAdoptionWrapReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("execute={}", report.execute);
+            println!("surface={}", report.surface);
+            println!("outcome={}", report.outcome);
+            println!("child_exit_code={}", report.child_exit_code);
+            if !report.child_stdout.is_empty() {
+                println!("child_stdout={}", report.child_stdout);
+            }
+            if !report.child_stderr.is_empty() {
+                println!("child_stderr={}", report.child_stderr);
+            }
+            println!("quality={}", report.capture.record_quality.quality);
+            if let Some(checked) = report.capture.record_checked.as_ref() {
+                println!("blocked={}", checked.blocked);
+                if let Some(event) = checked.event.as_ref() {
+                    println!("event_id={}", event.id);
+                }
+            }
+            for error in &report.capture.record_quality.errors {
+                println!("error={error}");
+            }
+            for warning in &report.capture.record_quality.warnings {
+                println!("warning={warning}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption wrap report")?
             );
             Ok(())
         }
@@ -4721,6 +5548,456 @@ fn expand_home(path: &str) -> PathBuf {
     }
 
     PathBuf::from(path)
+}
+
+fn cowork_register_command(
+    agent_id: String,
+    tool: String,
+    cwd: PathBuf,
+    transport: String,
+    tmux_target: Option<String>,
+) -> Result<()> {
+    use mempal::cowork::bus::{self, RegisterAgentRequest};
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let record = bus::register_agent(
+        &mempal_home,
+        &cwd,
+        RegisterAgentRequest {
+            agent_id,
+            tool,
+            transport,
+            tmux_target,
+        },
+    )?;
+    println!(
+        "registered agent {} tool={} transport={}",
+        record.agent_id, record.tool, record.transport
+    );
+    if let Some(tmux_target) = record.tmux_target {
+        println!("tmux_target={tmux_target}");
+    }
+    Ok(())
+}
+
+fn cowork_send_command(
+    from: String,
+    to: Vec<String>,
+    cwd: PathBuf,
+    message: String,
+    operation: mempal::cowork::bus::SendOperation,
+    thread_id: Option<String>,
+    channel: Option<String>,
+) -> Result<()> {
+    use mempal::cowork::bus::{self, SendRequest};
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let report = bus::send(
+        &mempal_home,
+        &cwd,
+        SendRequest {
+            from,
+            targets: to,
+            message,
+            operation,
+            thread_id,
+            channel,
+        },
+    )?;
+    print_delivery_report(report.delivered);
+    Ok(())
+}
+
+fn print_delivery_report(deliveries: Vec<mempal::cowork::bus::DeliveryReport>) {
+    for delivery in deliveries {
+        let thread = delivery
+            .thread_id
+            .as_ref()
+            .map(|thread_id| format!(" thread={thread_id}"))
+            .unwrap_or_default();
+        let channel = delivery
+            .channel
+            .as_ref()
+            .map(|channel| format!(" channel={channel}"))
+            .unwrap_or_default();
+        match delivery.transport.as_str() {
+            "inbox" => println!(
+                "sent to {} message_id={} transport=inbox{}{} inbox={} bytes={}",
+                delivery.target_agent_id,
+                delivery.message_id,
+                thread,
+                channel,
+                delivery
+                    .inbox_path
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_default(),
+                delivery.inbox_size_after.unwrap_or_default()
+            ),
+            "tmux" => println!(
+                "sent to {} message_id={} transport=tmux{}{} tmux_target={}",
+                delivery.target_agent_id,
+                delivery.message_id,
+                thread,
+                channel,
+                delivery.tmux_target.unwrap_or_default()
+            ),
+            other => println!("sent to {} transport={other}", delivery.target_agent_id),
+        }
+    }
+}
+
+fn cowork_agent_drain_command(agent_id: String, cwd: PathBuf, format: String) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let messages = bus::drain_agent(&mempal_home, &cwd, &agent_id)?;
+    if messages.is_empty() {
+        return Ok(());
+    }
+    match format.as_str() {
+        "plain" => {
+            print!("{}", bus::format_agent_plain(&agent_id, &messages));
+            Ok(())
+        }
+        other => bail!("unknown format: {other}"),
+    }
+}
+
+fn cowork_agents_command(cwd: PathBuf, now: Option<String>) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let statuses = bus::list_agent_status_at(&mempal_home, &cwd, now.as_deref())?;
+    println!("Project: {}", cwd.display());
+    println!();
+    if statuses.is_empty() {
+        println!("no registered agents");
+        return Ok(());
+    }
+    for status in statuses {
+        let record = status.record;
+        println!(
+            "{}: tool={} transport={} presence={} last_seen_at={} pending={} bytes={}",
+            record.agent_id,
+            record.tool,
+            record.transport,
+            status.presence,
+            record.last_seen_at.as_deref().unwrap_or("-"),
+            status.pending_count,
+            status.pending_bytes
+        );
+        if let Some(tmux_target) = record.tmux_target {
+            println!("  tmux_target={tmux_target}");
+        }
+        for msg in status.preview {
+            println!("  from {} @ {}: {}", msg.from, msg.pushed_at, msg.content);
+        }
+    }
+    Ok(())
+}
+
+fn cowork_heartbeat_command(agent_id: String, cwd: PathBuf, seen_at: Option<String>) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let record = bus::heartbeat_agent(&mempal_home, &cwd, &agent_id, seen_at.as_deref())?;
+    println!(
+        "heartbeat agent_id={} last_seen_at={}",
+        record.agent_id,
+        record.last_seen_at.unwrap_or_default()
+    );
+    Ok(())
+}
+
+fn cowork_channel_set_command(channel: String, agents: Vec<String>, cwd: PathBuf) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let record = bus::set_channel(&mempal_home, &cwd, &channel, agents)?;
+    println!(
+        "channel {} agents={}",
+        record.channel,
+        record.agents.join(",")
+    );
+    Ok(())
+}
+
+fn cowork_channel_send_command(
+    from: String,
+    channel: String,
+    cwd: PathBuf,
+    message: String,
+    thread_id: Option<String>,
+) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let report = bus::send_channel(&mempal_home, &cwd, from, channel, message, thread_id)?;
+    print_delivery_report(report.delivered);
+    Ok(())
+}
+
+fn cowork_tmux_peek_command(agent_id: String, cwd: PathBuf, lines: usize) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let peek = bus::tmux_peek_agent(&mempal_home, &cwd, &agent_id, lines)?;
+    print!("{}", peek.content);
+    Ok(())
+}
+
+fn static_runbook_command(title: &str, content: &str, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            print!("{content}");
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "title": title,
+                    "content": content,
+                }))?
+            );
+            Ok(())
+        }
+        other => bail!("unknown format: {other}"),
+    }
+}
+
+fn cowork_doctor_command(
+    cwd: PathBuf,
+    now: Option<String>,
+    probe_tmux: bool,
+    format: String,
+) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let report = bus::doctor(&mempal_home, &cwd, now.as_deref(), probe_tmux)?;
+    match format.as_str() {
+        "plain" => {
+            print!("{}", bus::format_doctor_plain(&report));
+            Ok(())
+        }
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            Ok(())
+        }
+        other => bail!("unknown format: {other}"),
+    }
+}
+
+fn cowork_session_create_command(
+    cwd: PathBuf,
+    session_id: String,
+    title: String,
+    goal: Option<String>,
+    agents: Vec<String>,
+    channels: Vec<String>,
+    thread_id: Option<String>,
+) -> Result<()> {
+    use mempal::cowork::bus::{self, CreateSessionRequest};
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let session = bus::create_session(
+        &mempal_home,
+        &cwd,
+        CreateSessionRequest {
+            session_id,
+            title,
+            goal,
+            agents,
+            channels,
+            thread_id,
+        },
+    )?;
+    println!(
+        "session {} status={} agents={}",
+        session.session_id,
+        session.status,
+        session.agents.join(",")
+    );
+    Ok(())
+}
+
+fn cowork_sessions_command(cwd: PathBuf, format: String) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let sessions = bus::list_sessions(&mempal_home, &cwd)?;
+    match format.as_str() {
+        "plain" => {
+            print!("{}", bus::format_sessions_plain(&sessions));
+            Ok(())
+        }
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&sessions)?);
+            Ok(())
+        }
+        other => bail!("unknown format: {other}"),
+    }
+}
+
+fn cowork_session_status_command(cwd: PathBuf, session_id: String, status: String) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let session = bus::update_session_status(&mempal_home, &cwd, &session_id, &status)?;
+    println!("session {} status={}", session.session_id, session.status);
+    Ok(())
+}
+
+fn cowork_handoff_command(
+    cwd: PathBuf,
+    thread_id: Option<String>,
+    channel: Option<String>,
+    session_id: Option<String>,
+    limit: Option<usize>,
+    format: String,
+) -> Result<()> {
+    use mempal::cowork::bus::{self, HandoffFilters};
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let summary = bus::build_handoff_summary(
+        &mempal_home,
+        &cwd,
+        HandoffFilters {
+            thread_id,
+            channel,
+            session_id,
+            limit,
+        },
+    )?;
+    match format.as_str() {
+        "plain" => {
+            print!("{}", bus::format_handoff_plain(&summary));
+            Ok(())
+        }
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&summary)?);
+            Ok(())
+        }
+        other => bail!("unknown format: {other}"),
+    }
+}
+
+struct CoworkCaptureCommandArgs {
+    cwd: PathBuf,
+    summary_source: String,
+    wing: String,
+    room: Option<String>,
+    thread_id: Option<String>,
+    channel: Option<String>,
+    session_id: Option<String>,
+    note: Option<String>,
+    execute: bool,
+    format: String,
+}
+
+fn cowork_capture_command(args: CoworkCaptureCommandArgs) -> Result<()> {
+    use mempal::cowork::bus::{self, CoworkCaptureRequest};
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let db = if args.execute {
+        let config = Config::load().context("failed to load config")?;
+        Some(Database::open(&expand_home(&config.db_path)).context("failed to open database")?)
+    } else {
+        None
+    };
+    let report = bus::capture_handoff_to_memory(
+        db.as_ref(),
+        &mempal_home,
+        &args.cwd,
+        CoworkCaptureRequest {
+            summary_source: args.summary_source,
+            wing: args.wing,
+            room: args.room,
+            thread_id: args.thread_id,
+            channel: args.channel,
+            session_id: args.session_id,
+            note: args.note,
+            execute: args.execute,
+        },
+    )?;
+    match args.format.as_str() {
+        "plain" => {
+            print!("{}", bus::format_capture_plain(&report));
+            Ok(())
+        }
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            Ok(())
+        }
+        other => bail!("unknown format: {other}"),
+    }
+}
+
+fn cowork_events_command(cwd: PathBuf, limit: Option<usize>, format: String) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let events = bus::list_events(&mempal_home, &cwd, limit)?;
+    match format.as_str() {
+        "plain" => {
+            print!("{}", bus::format_events_plain(&events));
+            Ok(())
+        }
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&events)?);
+            Ok(())
+        }
+        other => bail!("unknown format: {other}"),
+    }
+}
+
+fn cowork_ack_command(agent_id: String, cwd: PathBuf, message_id: String) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let status = bus::ack_delivery(&mempal_home, &cwd, &agent_id, &message_id)?;
+    println!(
+        "acked message_id={} agent_id={} status={}",
+        status.message_id, status.target_agent_id, status.status
+    );
+    Ok(())
+}
+
+fn cowork_deliveries_command(cwd: PathBuf, agent_id: Option<String>, format: String) -> Result<()> {
+    use mempal::cowork::bus;
+    use mempal::cowork::inbox;
+
+    let mempal_home = inbox::mempal_home();
+    let deliveries = bus::list_delivery_statuses(&mempal_home, &cwd, agent_id.as_deref())?;
+    match format.as_str() {
+        "plain" => {
+            print!("{}", bus::format_delivery_statuses_plain(&deliveries));
+            Ok(())
+        }
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&deliveries)?);
+            Ok(())
+        }
+        other => bail!("unknown format: {other}"),
+    }
 }
 
 /// `mempal cowork-drain` — called by UserPromptSubmit hooks. Always exits

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -26,7 +26,10 @@ use crate::core::{
         knowledge_source_file, source_file_or_synthetic,
     },
 };
-use crate::cowork::{PeekError, PeekRequest as CoworkPeekRequest, Tool, peek_partner};
+use crate::cowork::{
+    AgentRecord, AgentStatus, BusError, DeliveryReport, InboxMessage, PeekError,
+    PeekRequest as CoworkPeekRequest, Tool, peek_partner,
+};
 use crate::embed::EmbedderFactory;
 use crate::field_taxonomy::field_taxonomy;
 use crate::ingest::{
@@ -64,8 +67,12 @@ use rmcp::{
 use serde_json::Value;
 
 use super::tools::{
-    ContextRequest, ContextResponse, CoworkPushRequest, CoworkPushResponse, DeleteRequest,
-    DeleteResponse, DuplicateWarning, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
+    ContextRequest, ContextResponse, CoworkBusAgentDto, CoworkBusCaptureDto, CoworkBusChannelDto,
+    CoworkBusDeliveryDto, CoworkBusDeliveryStatusDto, CoworkBusDoctorDto, CoworkBusEventDto,
+    CoworkBusHandoffAgentDto, CoworkBusHandoffDto, CoworkBusHandoffFiltersDto, CoworkBusMessageDto,
+    CoworkBusRequest, CoworkBusResponse, CoworkBusSessionDto, CoworkBusTmuxPeekDto,
+    CoworkBusTmuxProbeDto, CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse,
+    DuplicateWarning, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
     FieldTaxonomyResponse, IngestRequest, IngestResponse, KgRequest, KgResponse, KgStatsDto,
     KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse,
     KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
@@ -2803,6 +2810,505 @@ impl MempalMcpServer {
     }
 
     #[tool(
+        name = "mempal_cowork_bus",
+        description = "Multi-agent cowork bus for concrete agent instances in one project. \
+                       Actions: register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/handoff/capture. Uses explicit agent_id \
+                       values such as claude-main, codex-a, codex-b, per-agent inbox files, \
+                       and append-only events under ~/.mempal/cowork-bus/<project>. This is separate from legacy \
+                       mempal_cowork_push partner routing and does not infer concrete instances \
+                       from MCP client names. Most actions are file-backed runtime ops; action=capture writes \
+                       evidence only when execute=true."
+    )]
+    async fn mempal_cowork_bus(
+        &self,
+        Parameters(request): Parameters<CoworkBusRequest>,
+    ) -> std::result::Result<Json<CoworkBusResponse>, ErrorData> {
+        use crate::cowork::bus::{self, RegisterAgentRequest, SendRequest};
+
+        let mempal_home = crate::cowork::inbox::mempal_home();
+        let cwd = PathBuf::from(&request.cwd);
+        let action = request.action.as_str();
+
+        match action {
+            "register" => {
+                let agent_id = required_bus_field(request.agent_id, "agent_id", action)?;
+                let tool = required_bus_field(request.tool, "tool", action)?;
+                let record = bus::register_agent(
+                    &mempal_home,
+                    &cwd,
+                    RegisterAgentRequest {
+                        agent_id,
+                        tool,
+                        transport: request.transport.unwrap_or_else(|| "inbox".to_string()),
+                        tmux_target: request.tmux_target,
+                    },
+                )
+                .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: vec![agent_record_to_dto(record)],
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "list" => {
+                let statuses =
+                    bus::list_agent_status_at(&mempal_home, &cwd, request.now.as_deref())
+                        .map_err(bus_error_to_mcp)?
+                        .into_iter()
+                        .map(agent_status_to_dto)
+                        .collect();
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: statuses,
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "send" | "broadcast" => {
+                let from = required_bus_field(request.from, "from", action)?;
+                if request.to.is_empty() {
+                    return Err(ErrorData::invalid_params(
+                        format!("action `{action}` requires at least one `to` agent_id"),
+                        None,
+                    ));
+                }
+                if action == "send" && request.to.len() != 1 {
+                    return Err(ErrorData::invalid_params(
+                        "action `send` requires exactly one `to`; use broadcast for fanout",
+                        None,
+                    ));
+                }
+                let message = required_bus_field(request.message, "message", action)?;
+                let report = bus::send(
+                    &mempal_home,
+                    &cwd,
+                    SendRequest {
+                        from,
+                        targets: request.to,
+                        message,
+                        operation: if action == "send" {
+                            bus::SendOperation::Send
+                        } else {
+                            bus::SendOperation::Broadcast
+                        },
+                        thread_id: request.thread_id,
+                        channel: request.channel,
+                    },
+                )
+                .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: report.delivered.into_iter().map(delivery_to_dto).collect(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "drain" => {
+                let agent_id = required_bus_field(request.agent_id, "agent_id", action)?;
+                let messages = bus::drain_agent(&mempal_home, &cwd, &agent_id)
+                    .map_err(bus_error_to_mcp)?
+                    .into_iter()
+                    .map(message_to_dto)
+                    .collect();
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages,
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "events" => {
+                let events = bus::list_events(&mempal_home, &cwd, request.limit)
+                    .map_err(bus_error_to_mcp)?
+                    .into_iter()
+                    .map(event_to_dto)
+                    .collect();
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events,
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "deliveries" => {
+                let deliveries =
+                    bus::list_delivery_statuses(&mempal_home, &cwd, request.agent_id.as_deref())
+                        .map_err(bus_error_to_mcp)?
+                        .into_iter()
+                        .map(delivery_status_to_dto)
+                        .collect();
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries,
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "ack" => {
+                let agent_id = required_bus_field(request.agent_id, "agent_id", action)?;
+                let message_id = required_bus_field(request.message_id, "message_id", action)?;
+                let status = bus::ack_delivery(&mempal_home, &cwd, &agent_id, &message_id)
+                    .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: vec![delivery_status_to_dto(status)],
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "heartbeat" => {
+                let agent_id = required_bus_field(request.agent_id, "agent_id", action)?;
+                let record =
+                    bus::heartbeat_agent(&mempal_home, &cwd, &agent_id, request.seen_at.as_deref())
+                        .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: vec![agent_record_to_dto(record)],
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "channel_set" => {
+                let channel = required_bus_field(request.channel, "channel", action)?;
+                if request.agents.is_empty() {
+                    return Err(ErrorData::invalid_params(
+                        "action `channel_set` requires at least one `agents` entry",
+                        None,
+                    ));
+                }
+                let channel = bus::set_channel(&mempal_home, &cwd, &channel, request.agents)
+                    .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: vec![channel_to_dto(channel)],
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "channel_list" => {
+                let channels = bus::list_channels(&mempal_home, &cwd)
+                    .map_err(bus_error_to_mcp)?
+                    .into_iter()
+                    .map(channel_to_dto)
+                    .collect();
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels,
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "channel_send" => {
+                let from = required_bus_field(request.from, "from", action)?;
+                let channel = required_bus_field(request.channel, "channel", action)?;
+                let message = required_bus_field(request.message, "message", action)?;
+                let report = bus::send_channel(
+                    &mempal_home,
+                    &cwd,
+                    from,
+                    channel,
+                    message,
+                    request.thread_id,
+                )
+                .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: report.delivered.into_iter().map(delivery_to_dto).collect(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "tmux_peek" => {
+                let agent_id = required_bus_field(request.agent_id, "agent_id", action)?;
+                let peek = bus::tmux_peek_agent(
+                    &mempal_home,
+                    &cwd,
+                    &agent_id,
+                    request.lines.unwrap_or(80),
+                )
+                .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: Some(tmux_peek_to_dto(peek)),
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "doctor" => {
+                let report = bus::doctor(
+                    &mempal_home,
+                    &cwd,
+                    request.now.as_deref(),
+                    request.probe_tmux.unwrap_or(false),
+                )
+                .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: Some(doctor_to_dto(report)),
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "session_create" => {
+                let session_id = required_bus_field(request.session_id, "session_id", action)?;
+                let title = required_bus_field(request.title, "title", action)?;
+                if request.agents.is_empty() {
+                    return Err(ErrorData::invalid_params(
+                        "action `session_create` requires at least one `agents` entry",
+                        None,
+                    ));
+                }
+                let session = bus::create_session(
+                    &mempal_home,
+                    &cwd,
+                    bus::CreateSessionRequest {
+                        session_id,
+                        title,
+                        goal: request.goal,
+                        agents: request.agents,
+                        channels: if let Some(channel) = request.channel {
+                            vec![channel]
+                        } else {
+                            Vec::new()
+                        },
+                        thread_id: request.thread_id,
+                    },
+                )
+                .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: vec![session_to_dto(session)],
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "session_list" => {
+                let sessions = bus::list_sessions(&mempal_home, &cwd)
+                    .map_err(bus_error_to_mcp)?
+                    .into_iter()
+                    .map(session_to_dto)
+                    .collect();
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions,
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "session_status" => {
+                let session_id = required_bus_field(request.session_id, "session_id", action)?;
+                let status = required_bus_field(request.status, "status", action)?;
+                let session = bus::update_session_status(&mempal_home, &cwd, &session_id, &status)
+                    .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: vec![session_to_dto(session)],
+                    handoff: None,
+                    capture: None,
+                }))
+            }
+            "handoff" => {
+                let summary = bus::build_handoff_summary(
+                    &mempal_home,
+                    &cwd,
+                    bus::HandoffFilters {
+                        thread_id: request.thread_id,
+                        channel: request.channel,
+                        session_id: request.session_id,
+                        limit: request.limit,
+                    },
+                )
+                .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: Some(handoff_to_dto(summary)),
+                    capture: None,
+                }))
+            }
+            "capture" => {
+                let execute = request.execute.unwrap_or(false);
+                let db = if execute { Some(self.open_db()?) } else { None };
+                let report = bus::capture_handoff_to_memory(
+                    db.as_ref(),
+                    &mempal_home,
+                    &cwd,
+                    bus::CoworkCaptureRequest {
+                        summary_source: request
+                            .summary_source
+                            .unwrap_or_else(|| "handoff".to_string()),
+                        wing: request.wing.unwrap_or_else(|| "cowork-capture".to_string()),
+                        room: request.room,
+                        thread_id: request.thread_id,
+                        channel: request.channel,
+                        session_id: request.session_id,
+                        note: request.note,
+                        execute,
+                    },
+                )
+                .map_err(bus_error_to_mcp)?;
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: Vec::new(),
+                    handoff: None,
+                    capture: Some(capture_to_dto(report)),
+                }))
+            }
+            other => Err(ErrorData::invalid_params(
+                format!(
+                    "unknown action `{other}`: expected register|list|send|broadcast|drain|events|deliveries|ack|heartbeat|channel_set|channel_list|channel_send|tmux_peek|doctor|session_create|session_list|session_status|handoff|capture"
+                ),
+                None,
+            )),
+        }
+    }
+
+    #[tool(
         name = "mempal_fact_check",
         description = "Detect contradictions in text against KG triples + known entities. \
                        Returns SimilarNameConflict (similar-name typos), RelationContradiction \
@@ -2849,6 +3355,244 @@ fn current_rfc3339() -> String {
     let secs = now;
     // Reuse cowork::peek::format_rfc3339 is pub; call it to stay consistent.
     crate::cowork::peek::format_rfc3339(UNIX_EPOCH + std::time::Duration::from_secs(secs as u64))
+}
+
+fn required_bus_field(
+    value: Option<String>,
+    field: &str,
+    action: &str,
+) -> std::result::Result<String, ErrorData> {
+    value.ok_or_else(|| {
+        ErrorData::invalid_params(format!("action `{action}` requires `{field}`"), None)
+    })
+}
+
+fn bus_error_to_mcp(error: BusError) -> ErrorData {
+    match error {
+        BusError::InvalidAgentId(_)
+        | BusError::InvalidTool(_)
+        | BusError::UnsupportedTransport(_)
+        | BusError::InvalidChannel(_)
+        | BusError::InvalidThreadId(_)
+        | BusError::UnknownChannel(_)
+        | BusError::EmptyChannel(_)
+        | BusError::TmuxTargetRequired
+        | BusError::TmuxFailed(_)
+        | BusError::TmuxCaptureFailed(_)
+        | BusError::TmuxProbeFailed(_)
+        | BusError::NotTmuxAgent(_)
+        | BusError::InvalidLineCount(_)
+        | BusError::InvalidSessionId(_)
+        | BusError::EmptySession(_)
+        | BusError::UnknownSession(_)
+        | BusError::InvalidSessionStatus(_)
+        | BusError::UnsupportedCaptureSource(_)
+        | BusError::MissingCaptureDatabase
+        | BusError::InvalidTimestamp(_)
+        | BusError::UnknownSource(_)
+        | BusError::UnknownTarget(_)
+        | BusError::UnknownAgent(_)
+        | BusError::UnknownDelivery(_)
+        | BusError::DeliveryTargetMismatch { .. }
+        | BusError::CannotAckFailed(_)
+        | BusError::SelfSend(_)
+        | BusError::MessageTooLarge(_)
+        | BusError::InboxFull { .. } => ErrorData::invalid_params(error.to_string(), None),
+        BusError::LegacyInbox(_) | BusError::Io(_) | BusError::Json(_) | BusError::Db(_) => {
+            ErrorData::internal_error(error.to_string(), None)
+        }
+    }
+}
+
+fn agent_record_to_dto(record: AgentRecord) -> CoworkBusAgentDto {
+    CoworkBusAgentDto {
+        agent_id: record.agent_id,
+        tool: record.tool,
+        transport: record.transport,
+        tmux_target: record.tmux_target,
+        registered_at: record.registered_at,
+        updated_at: record.updated_at,
+        presence: if record.last_seen_at.is_some() {
+            "online".to_string()
+        } else {
+            "never_seen".to_string()
+        },
+        last_seen_at: record.last_seen_at,
+        pending_count: 0,
+        pending_bytes: 0,
+    }
+}
+
+fn agent_status_to_dto(status: AgentStatus) -> CoworkBusAgentDto {
+    CoworkBusAgentDto {
+        agent_id: status.record.agent_id,
+        tool: status.record.tool,
+        transport: status.record.transport,
+        tmux_target: status.record.tmux_target,
+        registered_at: status.record.registered_at,
+        updated_at: status.record.updated_at,
+        last_seen_at: status.record.last_seen_at,
+        presence: status.presence,
+        pending_count: status.pending_count,
+        pending_bytes: status.pending_bytes,
+    }
+}
+
+fn delivery_to_dto(delivery: DeliveryReport) -> CoworkBusDeliveryDto {
+    CoworkBusDeliveryDto {
+        message_id: delivery.message_id,
+        target_agent_id: delivery.target_agent_id,
+        transport: delivery.transport,
+        inbox_path: delivery
+            .inbox_path
+            .map(|path| path.to_string_lossy().to_string()),
+        inbox_size_after: delivery.inbox_size_after,
+        tmux_target: delivery.tmux_target,
+        thread_id: delivery.thread_id,
+        channel: delivery.channel,
+    }
+}
+
+fn delivery_status_to_dto(
+    status: crate::cowork::bus::DeliveryStatus,
+) -> CoworkBusDeliveryStatusDto {
+    CoworkBusDeliveryStatusDto {
+        message_id: status.message_id,
+        event_type: status.event_type,
+        status: status.status,
+        from: status.from,
+        target_agent_id: status.target_agent_id,
+        transport: status.transport,
+        message_preview: status.message_preview,
+        thread_id: status.thread_id,
+        channel: status.channel,
+        delivered_at: status.delivered_at,
+        updated_at: status.updated_at,
+        acked_by: status.acked_by,
+    }
+}
+
+fn message_to_dto(message: InboxMessage) -> CoworkBusMessageDto {
+    CoworkBusMessageDto {
+        pushed_at: message.pushed_at,
+        from: message.from,
+        content: message.content,
+        thread_id: message.thread_id,
+        channel: message.channel,
+    }
+}
+
+fn event_to_dto(event: crate::cowork::bus::BusEvent) -> CoworkBusEventDto {
+    CoworkBusEventDto {
+        event_id: event.event_id,
+        occurred_at: event.occurred_at,
+        event_type: event.event_type,
+        status: event.status,
+        actor_agent_id: event.actor_agent_id,
+        target_agent_ids: event.target_agent_ids,
+        transport: event.transport,
+        message_preview: event.message_preview,
+        thread_id: event.details.get("thread_id").cloned(),
+        channel: event.details.get("channel").cloned(),
+        details: event.details,
+    }
+}
+
+fn channel_to_dto(channel: crate::cowork::bus::ChannelRecord) -> CoworkBusChannelDto {
+    CoworkBusChannelDto {
+        channel: channel.channel,
+        agents: channel.agents,
+        updated_at: channel.updated_at,
+    }
+}
+
+fn tmux_peek_to_dto(peek: crate::cowork::bus::TmuxPeek) -> CoworkBusTmuxPeekDto {
+    CoworkBusTmuxPeekDto {
+        agent_id: peek.agent_id,
+        tmux_target: peek.tmux_target,
+        lines: peek.lines,
+        content: peek.content,
+    }
+}
+
+fn doctor_to_dto(report: crate::cowork::bus::DoctorReport) -> CoworkBusDoctorDto {
+    CoworkBusDoctorDto {
+        status: report.status,
+        agent_count: report.agent_count,
+        channel_count: report.channel_count,
+        session_count: report.session_count,
+        stale_agents: report.stale_agents,
+        never_seen_agents: report.never_seen_agents,
+        pending_deliveries: report.pending_deliveries,
+        warnings: report.warnings,
+        tmux: report
+            .tmux
+            .into_iter()
+            .map(|probe| CoworkBusTmuxProbeDto {
+                agent_id: probe.agent_id,
+                tmux_target: probe.tmux_target,
+                status: probe.status,
+                detail: probe.detail,
+            })
+            .collect(),
+    }
+}
+
+fn session_to_dto(session: crate::cowork::bus::TeamSession) -> CoworkBusSessionDto {
+    CoworkBusSessionDto {
+        session_id: session.session_id,
+        title: session.title,
+        goal: session.goal,
+        agents: session.agents,
+        channels: session.channels,
+        thread_id: session.thread_id,
+        status: session.status,
+        created_at: session.created_at,
+        updated_at: session.updated_at,
+    }
+}
+
+fn handoff_to_dto(summary: crate::cowork::bus::HandoffSummary) -> CoworkBusHandoffDto {
+    CoworkBusHandoffDto {
+        filters: CoworkBusHandoffFiltersDto {
+            thread_id: summary.filters.thread_id,
+            channel: summary.filters.channel,
+            session_id: summary.filters.session_id,
+            limit: summary.filters.limit,
+        },
+        sessions: summary.sessions.into_iter().map(session_to_dto).collect(),
+        agents: summary
+            .agents
+            .into_iter()
+            .map(|agent| CoworkBusHandoffAgentDto {
+                agent_id: agent.agent_id,
+                tool: agent.tool,
+                presence: agent.presence,
+                pending_count: agent.pending_count,
+            })
+            .collect(),
+        pending_deliveries: summary
+            .pending_deliveries
+            .into_iter()
+            .map(delivery_status_to_dto)
+            .collect(),
+        recent_events: summary
+            .recent_events
+            .into_iter()
+            .map(event_to_dto)
+            .collect(),
+    }
+}
+
+fn capture_to_dto(report: crate::cowork::bus::CoworkCaptureReport) -> CoworkBusCaptureDto {
+    CoworkBusCaptureDto {
+        writes: report.writes,
+        drawer_id: report.drawer_id,
+        wing: report.wing,
+        room: report.room,
+        source: report.source,
+        content: report.content,
+    }
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -6408,7 +7152,7 @@ mod tests {
     // mapping. They complement the integration tests in tests/cowork_inbox.rs,
     // which only cover the CLI and inbox layers.
 
-    use super::super::tools::CoworkPushRequest;
+    use super::super::tools::{CoworkBusRequest, CoworkPushRequest};
     use tokio::sync::Mutex as TokioMutex;
 
     // Tests below mutate $HOME env var to point mempal_home() at a tempdir.
@@ -6436,6 +7180,98 @@ mod tests {
         (mempal_home, repo, guard)
     }
 
+    async fn mcp_bus_register(server: &MempalMcpServer, repo: &Path, agent_id: &str, tool: &str) {
+        let response = server
+            .mempal_cowork_bus(Parameters(CoworkBusRequest {
+                action: "register".to_string(),
+                cwd: repo.to_string_lossy().into_owned(),
+                agent_id: Some(agent_id.to_string()),
+                tool: Some(tool.to_string()),
+                transport: None,
+                tmux_target: None,
+                from: None,
+                to: Vec::new(),
+                agents: Vec::new(),
+                message: None,
+                thread_id: None,
+                channel: None,
+                message_id: None,
+                limit: None,
+                now: None,
+                seen_at: None,
+                lines: None,
+                probe_tmux: None,
+                session_id: None,
+                title: None,
+                goal: None,
+                status: None,
+                summary_source: None,
+                wing: None,
+                room: None,
+                note: None,
+                execute: None,
+            }))
+            .await
+            .unwrap_or_else(|e| panic!("register {agent_id} failed: {e}"));
+        assert_eq!(response.0.action, "register");
+    }
+
+    fn bus_request(action: &str, repo: &Path) -> CoworkBusRequest {
+        CoworkBusRequest {
+            action: action.to_string(),
+            cwd: repo.to_string_lossy().into_owned(),
+            agent_id: None,
+            tool: None,
+            transport: None,
+            tmux_target: None,
+            from: None,
+            to: Vec::new(),
+            agents: Vec::new(),
+            message: None,
+            thread_id: None,
+            channel: None,
+            message_id: None,
+            limit: None,
+            now: None,
+            seen_at: None,
+            lines: None,
+            probe_tmux: None,
+            session_id: None,
+            title: None,
+            goal: None,
+            status: None,
+            summary_source: None,
+            wing: None,
+            room: None,
+            note: None,
+            execute: None,
+        }
+    }
+
+    fn install_fake_tmux_for_mcp(tempdir: &TempDir, exit_code: i32) -> PathBuf {
+        let bin_dir = tempdir.path().join("fake-bin");
+        std::fs::create_dir_all(&bin_dir).expect("fake bin");
+        let log_path = tempdir.path().join("tmux.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$TMUX_LOG\"\nif [ \"$1\" = \"capture-pane\" ]; then printf 'mcp pane line\\n'; fi\nexit {exit_code}\n"
+        );
+        let tmux_path = bin_dir.join("tmux");
+        std::fs::write(&tmux_path, script).expect("write fake tmux");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&tmux_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&tmux_path, perms).unwrap();
+        }
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        unsafe {
+            std::env::set_var("PATH", format!("{}:{old_path}", bin_dir.display()));
+            std::env::set_var("TMUX_LOG", &log_path);
+        }
+        log_path
+    }
+
     #[tokio::test]
     async fn test_mcp_push_without_client_info_rejects_auto_target() {
         let (tempdir, _db_path, server) = setup_server();
@@ -6459,6 +7295,542 @@ mod tests {
         assert!(
             err.to_string().contains("cannot infer"),
             "expected inference error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_register_and_list() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+        mcp_bus_register(&server, &repo, "codex-b", "codex").await;
+
+        let response = server
+            .mempal_cowork_bus(Parameters(bus_request("list", &repo)))
+            .await
+            .expect("list bus");
+        let ids: Vec<String> = response
+            .0
+            .agents
+            .iter()
+            .map(|agent| agent.agent_id.clone())
+            .collect();
+        assert_eq!(ids, vec!["claude-main", "codex-a", "codex-b"]);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_send_drains_only_target() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+        mcp_bus_register(&server, &repo, "codex-b", "codex").await;
+
+        let mut send = bus_request("send", &repo);
+        send.from = Some("claude-main".to_string());
+        send.to = vec!["codex-a".to_string()];
+        send.message = Some("review mcp bus routing".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(send))
+            .await
+            .expect("send bus message");
+        assert_eq!(response.0.delivered.len(), 1);
+        assert_eq!(response.0.delivered[0].target_agent_id, "codex-a");
+
+        let mut drain_a = bus_request("drain", &repo);
+        drain_a.agent_id = Some("codex-a".to_string());
+        let response_a = server
+            .mempal_cowork_bus(Parameters(drain_a))
+            .await
+            .expect("drain codex-a");
+        assert_eq!(response_a.0.messages.len(), 1);
+        assert_eq!(response_a.0.messages[0].content, "review mcp bus routing");
+
+        let mut drain_b = bus_request("drain", &repo);
+        drain_b.agent_id = Some("codex-b".to_string());
+        let response_b = server
+            .mempal_cowork_bus(Parameters(drain_b))
+            .await
+            .expect("drain codex-b");
+        assert!(response_b.0.messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_broadcast_fans_out() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+        mcp_bus_register(&server, &repo, "codex-b", "codex").await;
+
+        let mut broadcast = bus_request("broadcast", &repo);
+        broadcast.from = Some("claude-main".to_string());
+        broadcast.to = vec!["codex-a".to_string(), "codex-b".to_string()];
+        broadcast.message = Some("pull latest before continuing".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(broadcast))
+            .await
+            .expect("broadcast bus message");
+        assert_eq!(response.0.delivered.len(), 2);
+
+        for agent_id in ["codex-a", "codex-b"] {
+            let mut drain = bus_request("drain", &repo);
+            drain.agent_id = Some(agent_id.to_string());
+            let response = server
+                .mempal_cowork_bus(Parameters(drain))
+                .await
+                .expect("drain target");
+            assert_eq!(response.0.messages.len(), 1);
+            assert_eq!(
+                response.0.messages[0].content,
+                "pull latest before continuing"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_send_to_tmux_transport_invokes_tmux() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        let log_path = install_fake_tmux_for_mcp(&tempdir, 0);
+
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        let mut register_tmux = bus_request("register", &repo);
+        register_tmux.agent_id = Some("codex-a".to_string());
+        register_tmux.tool = Some("codex".to_string());
+        register_tmux.transport = Some("tmux".to_string());
+        register_tmux.tmux_target = Some("mempal:0.1".to_string());
+        server
+            .mempal_cowork_bus(Parameters(register_tmux))
+            .await
+            .expect("register tmux target");
+
+        let mut send = bus_request("send", &repo);
+        send.from = Some("claude-main".to_string());
+        send.to = vec!["codex-a".to_string()];
+        send.message = Some("mcp tmux hello".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(send))
+            .await
+            .expect("send to tmux target");
+        assert_eq!(response.0.delivered.len(), 1);
+        assert_eq!(response.0.delivered[0].target_agent_id, "codex-a");
+        assert_eq!(response.0.delivered[0].transport, "tmux");
+
+        let log = std::fs::read_to_string(log_path).expect("tmux log");
+        assert!(log.contains("send-keys"), "{log}");
+        assert!(log.contains("mempal:0.1"), "{log}");
+        assert!(
+            log.contains("[mempal bus from claude-main to codex-a] mcp tmux hello"),
+            "{log}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_events_lists_log() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+
+        let mut send = bus_request("send", &repo);
+        send.from = Some("claude-main".to_string());
+        send.to = vec!["codex-a".to_string()];
+        send.message = Some("event replay through mcp".to_string());
+        server
+            .mempal_cowork_bus(Parameters(send))
+            .await
+            .expect("send bus message");
+
+        let mut events = bus_request("events", &repo);
+        events.limit = Some(2);
+        let response = server
+            .mempal_cowork_bus(Parameters(events))
+            .await
+            .expect("list events");
+        assert_eq!(response.0.action, "events");
+        assert_eq!(response.0.events.len(), 2);
+        assert!(
+            response
+                .0
+                .events
+                .iter()
+                .any(|event| event.event_type == "send" && event.status == "delivered")
+        );
+        assert!(
+            !mempal_home.join("palace.db").exists(),
+            "cowork bus events must not write the db-backed memory store"
+        );
+
+        let mut drain = bus_request("drain", &repo);
+        drain.agent_id = Some("codex-a".to_string());
+        let drained = server
+            .mempal_cowork_bus(Parameters(drain))
+            .await
+            .expect("drain after event replay");
+        assert_eq!(drained.0.messages.len(), 1);
+        assert_eq!(drained.0.messages[0].content, "event replay through mcp");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_deliveries_and_ack() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+
+        let mut send = bus_request("send", &repo);
+        send.from = Some("claude-main".to_string());
+        send.to = vec!["codex-a".to_string()];
+        send.message = Some("ack through mcp".to_string());
+        let sent = server
+            .mempal_cowork_bus(Parameters(send))
+            .await
+            .expect("send bus message");
+        let message_id = sent.0.delivered[0].message_id.clone();
+
+        let mut ack = bus_request("ack", &repo);
+        ack.agent_id = Some("codex-a".to_string());
+        ack.message_id = Some(message_id.clone());
+        let acked = server
+            .mempal_cowork_bus(Parameters(ack))
+            .await
+            .expect("ack delivery");
+        assert_eq!(acked.0.deliveries.len(), 1);
+        assert_eq!(acked.0.deliveries[0].status, "acked");
+
+        let mut deliveries = bus_request("deliveries", &repo);
+        deliveries.agent_id = Some("codex-a".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(deliveries))
+            .await
+            .expect("delivery statuses");
+        assert_eq!(response.0.deliveries.len(), 1);
+        assert_eq!(response.0.deliveries[0].message_id, message_id);
+        assert_eq!(response.0.deliveries[0].status, "acked");
+        assert_eq!(
+            response.0.deliveries[0].acked_by.as_deref(),
+            Some("codex-a")
+        );
+        assert!(
+            !mempal_home.join("palace.db").exists(),
+            "cowork delivery status must not write the db-backed memory store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_heartbeat_and_presence() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+
+        let mut heartbeat = bus_request("heartbeat", &repo);
+        heartbeat.agent_id = Some("codex-a".to_string());
+        heartbeat.seen_at = Some("2026-05-25T00:00:00Z".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(heartbeat))
+            .await
+            .expect("heartbeat");
+        assert_eq!(response.0.action, "heartbeat");
+        assert_eq!(
+            response.0.agents[0].last_seen_at.as_deref(),
+            Some("2026-05-25T00:00:00Z")
+        );
+
+        let mut list = bus_request("list", &repo);
+        list.now = Some("2026-05-25T00:05:00Z".to_string());
+        let listed = server
+            .mempal_cowork_bus(Parameters(list))
+            .await
+            .expect("list presence");
+        assert_eq!(listed.0.agents[0].agent_id, "codex-a");
+        assert_eq!(listed.0.agents[0].presence, "online");
+        assert_eq!(
+            listed.0.agents[0].last_seen_at.as_deref(),
+            Some("2026-05-25T00:00:00Z")
+        );
+        assert!(
+            !mempal_home.join("palace.db").exists(),
+            "cowork presence must not write the db-backed memory store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_channel_send() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+        mcp_bus_register(&server, &repo, "codex-b", "codex").await;
+
+        let mut set = bus_request("channel_set", &repo);
+        set.channel = Some("review".to_string());
+        set.agents = vec!["codex-a".to_string(), "codex-b".to_string()];
+        let set_response = server
+            .mempal_cowork_bus(Parameters(set))
+            .await
+            .expect("set channel");
+        assert_eq!(set_response.0.channels.len(), 1);
+        assert_eq!(set_response.0.channels[0].channel, "review");
+
+        let mut send = bus_request("channel_send", &repo);
+        send.from = Some("claude-main".to_string());
+        send.channel = Some("review".to_string());
+        send.thread_id = Some("p90-review".to_string());
+        send.message = Some("mcp channel send".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(send))
+            .await
+            .expect("send channel");
+        assert_eq!(response.0.delivered.len(), 2);
+        assert!(
+            response
+                .0
+                .delivered
+                .iter()
+                .all(|delivery| delivery.channel.as_deref() == Some("review"))
+        );
+        assert!(
+            response
+                .0
+                .delivered
+                .iter()
+                .all(|delivery| delivery.thread_id.as_deref() == Some("p90-review"))
+        );
+        assert!(
+            !mempal_home.join("palace.db").exists(),
+            "cowork channels must not write the db-backed memory store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_tmux_peek() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        let log_path = install_fake_tmux_for_mcp(&tempdir, 0);
+
+        let mut register_tmux = bus_request("register", &repo);
+        register_tmux.agent_id = Some("codex-a".to_string());
+        register_tmux.tool = Some("codex".to_string());
+        register_tmux.transport = Some("tmux".to_string());
+        register_tmux.tmux_target = Some("mempal:0.1".to_string());
+        server
+            .mempal_cowork_bus(Parameters(register_tmux))
+            .await
+            .expect("register tmux target");
+
+        let mut peek = bus_request("tmux_peek", &repo);
+        peek.agent_id = Some("codex-a".to_string());
+        peek.lines = Some(20);
+        let response = server
+            .mempal_cowork_bus(Parameters(peek))
+            .await
+            .expect("tmux peek");
+        let peek = response.0.tmux_peek.expect("peek payload");
+        assert_eq!(peek.agent_id, "codex-a");
+        assert_eq!(peek.tmux_target, "mempal:0.1");
+        assert_eq!(peek.lines, 20);
+        assert!(peek.content.contains("mcp pane line"));
+        let log = std::fs::read_to_string(log_path).expect("tmux log");
+        assert!(log.contains("capture-pane"), "{log}");
+        assert!(
+            !mempal_home.join("palace.db").exists(),
+            "tmux peek must not write the db-backed memory store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_doctor() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+
+        let mut send = bus_request("send", &repo);
+        send.from = Some("claude-main".to_string());
+        send.to = vec!["codex-a".to_string()];
+        send.message = Some("doctor pending".to_string());
+        server
+            .mempal_cowork_bus(Parameters(send))
+            .await
+            .expect("send");
+
+        let response = server
+            .mempal_cowork_bus(Parameters(bus_request("doctor", &repo)))
+            .await
+            .expect("doctor");
+        let doctor = response.0.doctor.expect("doctor payload");
+        assert_eq!(doctor.pending_deliveries, 1);
+        assert_eq!(doctor.status, "warning");
+        assert!(
+            !mempal_home.join("palace.db").exists(),
+            "doctor must not write the db-backed memory store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_sessions() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+
+        let mut create = bus_request("session_create", &repo);
+        create.session_id = Some("review-1".to_string());
+        create.title = Some("Review 1".to_string());
+        create.agents = vec!["claude-main".to_string(), "codex-a".to_string()];
+        create.thread_id = Some("review-1".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(create))
+            .await
+            .expect("create session");
+        assert_eq!(response.0.sessions[0].session_id, "review-1");
+
+        let response = server
+            .mempal_cowork_bus(Parameters(bus_request("session_list", &repo)))
+            .await
+            .expect("list sessions");
+        assert_eq!(response.0.sessions.len(), 1);
+        assert_eq!(
+            response.0.sessions[0].thread_id.as_deref(),
+            Some("review-1")
+        );
+        assert!(
+            !mempal_home.join("palace.db").exists(),
+            "sessions must not write the db-backed memory store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_handoff() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+
+        let mut create = bus_request("session_create", &repo);
+        create.session_id = Some("review-1".to_string());
+        create.title = Some("Review 1".to_string());
+        create.agents = vec!["claude-main".to_string(), "codex-a".to_string()];
+        server
+            .mempal_cowork_bus(Parameters(create))
+            .await
+            .expect("create session");
+
+        let mut send = bus_request("send", &repo);
+        send.from = Some("claude-main".to_string());
+        send.to = vec!["codex-a".to_string()];
+        send.message = Some("handoff pending".to_string());
+        server
+            .mempal_cowork_bus(Parameters(send))
+            .await
+            .expect("send");
+
+        let response = server
+            .mempal_cowork_bus(Parameters(bus_request("handoff", &repo)))
+            .await
+            .expect("handoff");
+        let handoff = response.0.handoff.expect("handoff payload");
+        assert_eq!(handoff.sessions.len(), 1);
+        assert_eq!(handoff.pending_deliveries.len(), 1);
+        assert!(
+            !mempal_home.join("palace.db").exists(),
+            "handoff must not write the db-backed memory store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_capture() {
+        let (tempdir, db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+
+        let mut dry_run = bus_request("capture", &repo);
+        dry_run.summary_source = Some("handoff".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(dry_run))
+            .await
+            .expect("capture dry run");
+        let capture = response.0.capture.expect("capture payload");
+        assert!(!capture.writes);
+        assert!(!db_path.exists(), "dry-run capture must not open palace.db");
+
+        let mut execute = bus_request("capture", &repo);
+        execute.summary_source = Some("handoff".to_string());
+        execute.execute = Some(true);
+        let response = server
+            .mempal_cowork_bus(Parameters(execute))
+            .await
+            .expect("capture execute");
+        let capture = response.0.capture.expect("capture payload");
+        assert!(capture.writes);
+        let drawer_id = capture.drawer_id.expect("drawer id");
+        let db = Database::open(&db_path).expect("open db");
+        assert!(
+            db.get_drawer(&drawer_id)
+                .expect("get drawer")
+                .expect("drawer exists")
+                .content
+                .contains("Cowork Handoff Capture")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_rejects_invalid_action_and_addressing() {
+        let (tempdir, _db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+
+        let mut bad_id = bus_request("register", &repo);
+        bad_id.agent_id = Some("bad/id".to_string());
+        bad_id.tool = Some("codex".to_string());
+        let err = match server.mempal_cowork_bus(Parameters(bad_id)).await {
+            Err(error) => error,
+            Ok(_) => panic!("bad agent id must fail"),
+        };
+        assert!(err.to_string().contains("invalid agent id"));
+
+        let mut self_send = bus_request("send", &repo);
+        self_send.from = Some("codex-a".to_string());
+        self_send.to = vec!["codex-a".to_string()];
+        self_send.message = Some("self".to_string());
+        let err = match server.mempal_cowork_bus(Parameters(self_send)).await {
+            Err(error) => error,
+            Ok(_) => panic!("self-send must fail"),
+        };
+        assert!(err.to_string().contains("cannot send to self"));
+
+        let err = match server
+            .mempal_cowork_bus(Parameters(bus_request("unknown", &repo)))
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("unknown action must fail"),
+        };
+        assert!(err.to_string().contains("unknown action"));
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_cowork_bus() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_cowork_bus")
+            .expect("mempal_cowork_bus tool exists");
+        let description = tool.description.as_deref().unwrap_or_default();
+        assert!(description.contains("Multi-agent cowork bus"));
+        assert!(description.contains("agent_id"));
+        assert!(description.contains("register/list/send/broadcast/drain"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_cowork_bus"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("concrete agent_id"));
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL
+                .contains("separate from legacy mempal_cowork_push")
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1479,6 +1479,283 @@ pub struct CoworkPushResponse {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct CoworkBusRequest {
+    /// Action to execute. P85+ uses one MCP tool so agents do not need many
+    /// separate tool names for the same multi-agent bus.
+    pub action: String,
+
+    /// Absolute filesystem path of the project cwd. Internally normalized to
+    /// git repo root so all agents in one project share the same bus registry.
+    pub cwd: String,
+
+    /// Concrete target/current agent id for register/drain actions.
+    #[serde(default)]
+    pub agent_id: Option<String>,
+
+    /// Tool family/name for register action, e.g. "claude" or "codex".
+    #[serde(default)]
+    pub tool: Option<String>,
+
+    /// Transport metadata for register action. Defaults to "inbox".
+    #[serde(default)]
+    pub transport: Option<String>,
+
+    /// Optional tmux target for `transport=tmux`.
+    #[serde(default)]
+    pub tmux_target: Option<String>,
+
+    /// Concrete source agent id for send/broadcast actions.
+    #[serde(default)]
+    pub from: Option<String>,
+
+    /// Concrete target agent ids for send/broadcast actions.
+    #[serde(default)]
+    pub to: Vec<String>,
+
+    /// Concrete agent ids for channel_set action.
+    #[serde(default)]
+    pub agents: Vec<String>,
+
+    /// Message body for send/broadcast actions.
+    #[serde(default)]
+    pub message: Option<String>,
+
+    /// Optional thread id metadata for send/broadcast/channel_send actions.
+    #[serde(default)]
+    pub thread_id: Option<String>,
+
+    /// Optional channel name for send/broadcast metadata and channel actions.
+    #[serde(default)]
+    pub channel: Option<String>,
+
+    /// Delivery event id for action "ack".
+    #[serde(default)]
+    pub message_id: Option<String>,
+
+    /// Optional max number of latest events for action "events".
+    #[serde(default)]
+    pub limit: Option<usize>,
+
+    /// Optional RFC3339 timestamp for deterministic list presence checks.
+    #[serde(default)]
+    pub now: Option<String>,
+
+    /// Optional RFC3339 timestamp for action "heartbeat".
+    #[serde(default)]
+    pub seen_at: Option<String>,
+
+    /// Optional line count for action "tmux_peek".
+    #[serde(default)]
+    pub lines: Option<usize>,
+
+    /// Optional tmux reachability probe for action "doctor".
+    #[serde(default)]
+    pub probe_tmux: Option<bool>,
+
+    /// Session id for session and handoff/capture actions.
+    #[serde(default)]
+    pub session_id: Option<String>,
+
+    /// Session title for action "session_create".
+    #[serde(default)]
+    pub title: Option<String>,
+
+    /// Session goal for action "session_create".
+    #[serde(default)]
+    pub goal: Option<String>,
+
+    /// Session status for action "session_status".
+    #[serde(default)]
+    pub status: Option<String>,
+
+    /// Capture summary source for action "capture".
+    #[serde(default)]
+    pub summary_source: Option<String>,
+
+    /// Evidence wing for action "capture".
+    #[serde(default)]
+    pub wing: Option<String>,
+
+    /// Evidence room for action "capture".
+    #[serde(default)]
+    pub room: Option<String>,
+
+    /// Optional note for action "capture".
+    #[serde(default)]
+    pub note: Option<String>,
+
+    /// Explicit write switch for action "capture".
+    #[serde(default)]
+    pub execute: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusResponse {
+    pub action: String,
+    pub agents: Vec<CoworkBusAgentDto>,
+    pub delivered: Vec<CoworkBusDeliveryDto>,
+    pub messages: Vec<CoworkBusMessageDto>,
+    pub events: Vec<CoworkBusEventDto>,
+    pub deliveries: Vec<CoworkBusDeliveryStatusDto>,
+    pub channels: Vec<CoworkBusChannelDto>,
+    pub tmux_peek: Option<CoworkBusTmuxPeekDto>,
+    pub doctor: Option<CoworkBusDoctorDto>,
+    pub sessions: Vec<CoworkBusSessionDto>,
+    pub handoff: Option<CoworkBusHandoffDto>,
+    pub capture: Option<CoworkBusCaptureDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusAgentDto {
+    pub agent_id: String,
+    pub tool: String,
+    pub transport: String,
+    pub tmux_target: Option<String>,
+    pub registered_at: String,
+    pub updated_at: String,
+    pub last_seen_at: Option<String>,
+    pub presence: String,
+    pub pending_count: usize,
+    pub pending_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusDeliveryDto {
+    pub message_id: String,
+    pub target_agent_id: String,
+    pub transport: String,
+    pub inbox_path: Option<String>,
+    pub inbox_size_after: Option<u64>,
+    pub tmux_target: Option<String>,
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusMessageDto {
+    pub pushed_at: String,
+    pub from: String,
+    pub content: String,
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusEventDto {
+    pub event_id: String,
+    pub occurred_at: String,
+    pub event_type: String,
+    pub status: String,
+    pub actor_agent_id: Option<String>,
+    pub target_agent_ids: Vec<String>,
+    pub transport: Option<String>,
+    pub message_preview: Option<String>,
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+    pub details: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusDeliveryStatusDto {
+    pub message_id: String,
+    pub event_type: String,
+    pub status: String,
+    pub from: String,
+    pub target_agent_id: String,
+    pub transport: String,
+    pub message_preview: Option<String>,
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+    pub delivered_at: String,
+    pub updated_at: String,
+    pub acked_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusChannelDto {
+    pub channel: String,
+    pub agents: Vec<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusTmuxPeekDto {
+    pub agent_id: String,
+    pub tmux_target: String,
+    pub lines: usize,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusDoctorDto {
+    pub status: String,
+    pub agent_count: usize,
+    pub channel_count: usize,
+    pub session_count: usize,
+    pub stale_agents: usize,
+    pub never_seen_agents: usize,
+    pub pending_deliveries: usize,
+    pub warnings: Vec<String>,
+    pub tmux: Vec<CoworkBusTmuxProbeDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusTmuxProbeDto {
+    pub agent_id: String,
+    pub tmux_target: String,
+    pub status: String,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusSessionDto {
+    pub session_id: String,
+    pub title: String,
+    pub goal: Option<String>,
+    pub agents: Vec<String>,
+    pub channels: Vec<String>,
+    pub thread_id: Option<String>,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusHandoffDto {
+    pub filters: CoworkBusHandoffFiltersDto,
+    pub sessions: Vec<CoworkBusSessionDto>,
+    pub agents: Vec<CoworkBusHandoffAgentDto>,
+    pub pending_deliveries: Vec<CoworkBusDeliveryStatusDto>,
+    pub recent_events: Vec<CoworkBusEventDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusHandoffFiltersDto {
+    pub thread_id: Option<String>,
+    pub channel: Option<String>,
+    pub session_id: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusHandoffAgentDto {
+    pub agent_id: String,
+    pub tool: String,
+    pub presence: String,
+    pub pending_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CoworkBusCaptureDto {
+    pub writes: bool,
+    pub drawer_id: Option<String>,
+    pub wing: String,
+    pub room: Option<String>,
+    pub source: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct FactCheckRequest {
     /// Text to check for contradictions against KG triples + known entities.
     pub text: String,

--- a/tests/cognitive_brief.rs
+++ b/tests/cognitive_brief.rs
@@ -1,0 +1,323 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::Command;
+use std::thread;
+
+use mempal::core::anchor;
+use mempal::core::db::Database;
+use mempal::core::types::{
+    AnchorKind, Drawer, KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+    KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionFilter,
+    SourceType,
+};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_cli_home() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_dir = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_dir).expect("create .mempal");
+    let db = Database::open(&mempal_dir.join("palace.db")).expect("open cli db");
+    (tmp, db)
+}
+
+fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal")
+}
+
+fn vector() -> Vec<f32> {
+    vec![0.25; 384]
+}
+
+fn evidence_drawer(id: &str, content: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("brief".to_string()),
+        source_file: Some(format!("tests://brief/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 3,
+        memory_kind: MemoryKind::Evidence,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        provenance: Some(Provenance::Human),
+        statement: None,
+        tier: None,
+        status: None,
+        supporting_refs: Vec::new(),
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn knowledge_drawer(id: &str, statement: &str, content: &str, evidence_id: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("brief".to_string()),
+        source_file: Some(format!("knowledge://project/brief/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 4,
+        memory_kind: MemoryKind::Knowledge,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        provenance: None,
+        statement: Some(statement.to_string()),
+        tier: Some(KnowledgeTier::Shu),
+        status: Some(KnowledgeStatus::Promoted),
+        supporting_refs: vec![evidence_id.to_string()],
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn insert_drawer_with_vector(db: &Database, drawer: &Drawer) {
+    db.insert_drawer(drawer).expect("insert drawer");
+    db.insert_vector(&drawer.id, &vector())
+        .expect("insert vector");
+}
+
+fn insert_card_with_link(db: &Database, card_id: &str, evidence_id: &str) {
+    db.insert_knowledge_card(&KnowledgeCard {
+        id: card_id.to_string(),
+        statement: "Alice pricing card: pricing risk needs review.".to_string(),
+        content: "Alice pricing card content.".to_string(),
+        tier: KnowledgeTier::Shu,
+        status: KnowledgeStatus::Promoted,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        scope_constraints: None,
+        trigger_hints: None,
+        created_at: "1710000000".to_string(),
+        updated_at: "1710000000".to_string(),
+    })
+    .expect("insert card");
+    db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+        id: format!("link_{card_id}_{evidence_id}"),
+        card_id: card_id.to_string(),
+        evidence_drawer_id: evidence_id.to_string(),
+        role: KnowledgeEvidenceRole::Supporting,
+        note: None,
+        created_at: "1710000000".to_string(),
+    })
+    .expect("insert card link");
+}
+
+fn start_openai_embedding_stub(
+    expected_query: &str,
+    request_count: usize,
+) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding stub");
+    listener
+        .set_nonblocking(true)
+        .expect("set embedding stub nonblocking");
+    let address = listener.local_addr().expect("local addr");
+    let expected_query = expected_query.to_string();
+    let handle = thread::spawn(move || {
+        for _ in 0..request_count {
+            let (mut stream, _) = (0..50)
+                .find_map(|_| match listener.accept() {
+                    Ok(connection) => Some(connection),
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(std::time::Duration::from_millis(100));
+                        None
+                    }
+                    Err(error) => panic!("accept request: {error}"),
+                })
+                .expect("embedding stub timed out waiting for request");
+            let mut request = [0_u8; 4096];
+            let bytes_read = stream.read(&mut request).expect("read embedding request");
+            let request = String::from_utf8_lossy(&request[..bytes_read]);
+            let (_, body) = request
+                .split_once("\r\n\r\n")
+                .expect("request should contain JSON body");
+            let payload: Value = serde_json::from_str(body).expect("parse embedding request");
+            assert_eq!(payload["input"][0], expected_query);
+            let body = serde_json::to_string(&json!({
+                "data": [{ "embedding": vector() }]
+            }))
+            .expect("serialize embedding response");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write embedding response");
+        }
+    });
+    (format!("http://{address}/v1/embeddings"), handle)
+}
+
+fn write_cli_api_config(home: &Path, endpoint: &str) {
+    fs::write(
+        home.join(".mempal/config.toml"),
+        format!(
+            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+        ),
+    )
+    .expect("write config");
+}
+
+fn seed_brief_fixture(db: &Database) {
+    let evidence = evidence_drawer(
+        "brief_evidence_alice",
+        "Alice pricing meeting: three unresolved action items remain before the next call.",
+    );
+    insert_drawer_with_vector(db, &evidence);
+    let knowledge = knowledge_drawer(
+        "brief_knowledge_alice",
+        "Alice pricing has unresolved action items.",
+        "Use the Alice pricing evidence before making commitments.",
+        "brief_evidence_alice",
+    );
+    insert_drawer_with_vector(db, &knowledge);
+    insert_card_with_link(db, "brief_card_alice", "brief_evidence_alice");
+}
+
+#[test]
+fn test_cli_brief_json_includes_citations_uncertainty_and_actions() {
+    let (home, db) = setup_cli_home();
+    seed_brief_fixture(&db);
+    let query = "Alice pricing";
+    let (endpoint, handle) = start_openai_embedding_stub(query, 1);
+    write_cli_api_config(home.path(), &endpoint);
+
+    let output = run_mempal(&home, &["brief", query, "--format", "json"]);
+    assert!(
+        output.status.success(),
+        "brief failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    handle.join().expect("embedding stub");
+    let brief: Value = serde_json::from_slice(&output.stdout).expect("brief json");
+    assert_eq!(brief["query"], query);
+    assert!(
+        brief["summary"]["narrative"]
+            .as_str()
+            .unwrap()
+            .contains("cited")
+    );
+    assert!(!brief["key_facts"].as_array().unwrap().is_empty());
+    assert_eq!(
+        brief["key_facts"][0]["citation"]["drawer_id"],
+        "brief_knowledge_alice"
+    );
+    assert_eq!(
+        brief["key_facts"][0]["citation"]["source_file"],
+        "knowledge://project/brief/brief_knowledge_alice"
+    );
+    assert!(!brief["evidence"].as_array().unwrap().is_empty());
+    assert_eq!(brief["cards"][0]["card_id"], "brief_card_alice");
+    assert_eq!(
+        brief["cards"][0]["evidence_citations"][0]["evidence_drawer_id"],
+        "brief_evidence_alice"
+    );
+    assert!(brief["uncertainty"].is_array());
+    assert!(!brief["next_actions"].as_array().unwrap().is_empty());
+
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list adoption events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_brief_plain_lists_sections_and_citations() {
+    let (home, db) = setup_cli_home();
+    seed_brief_fixture(&db);
+    let query = "Alice pricing";
+    let (endpoint, handle) = start_openai_embedding_stub(query, 1);
+    write_cli_api_config(home.path(), &endpoint);
+
+    let output = run_mempal(&home, &["brief", query]);
+    assert!(
+        output.status.success(),
+        "brief failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    handle.join().expect("embedding stub");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("## Summary"));
+    assert!(stdout.contains("## Key Facts"));
+    assert!(stdout.contains("## Evidence"));
+    assert!(stdout.contains("## Uncertainty"));
+    assert!(stdout.contains("## Next Actions"));
+    assert!(stdout.contains("drawer: brief_knowledge_alice"));
+    assert!(stdout.contains("source: knowledge://project/brief/brief_knowledge_alice"));
+}
+
+#[test]
+fn test_cli_brief_no_evidence_reports_uncertainty() {
+    let (home, _db) = setup_cli_home();
+    let query = "Unknown account";
+    let (endpoint, handle) = start_openai_embedding_stub(query, 1);
+    write_cli_api_config(home.path(), &endpoint);
+
+    let output = run_mempal(&home, &["brief", query, "--format", "json"]);
+    assert!(
+        output.status.success(),
+        "brief failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    handle.join().expect("embedding stub");
+    let brief: Value = serde_json::from_slice(&output.stdout).expect("brief json");
+    assert_eq!(brief["evidence"].as_array().unwrap().len(), 0);
+    assert!(
+        brief["uncertainty"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["kind"] == "no_evidence")
+    );
+    assert!(
+        brief["next_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item.as_str().unwrap().contains("Ingest"))
+    );
+}
+
+#[test]
+fn test_cli_brief_rejects_invalid_format() {
+    let (home, _db) = setup_cli_home();
+    let output = run_mempal(&home, &["brief", "Alice pricing", "--format", "yaml"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported brief format"));
+}

--- a/tests/cowork_bus.rs
+++ b/tests/cowork_bus.rs
@@ -1,0 +1,1909 @@
+//! Integration tests for P84 multi-agent cowork bus.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_repo(tmp: &TempDir, name: &str) -> PathBuf {
+    let repo = tmp.path().join(name);
+    fs::create_dir_all(repo.join(".git")).expect("create fake git repo");
+    repo
+}
+
+fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal")
+}
+
+fn run_mempal_with_env(
+    home: &TempDir,
+    args: &[&str],
+    envs: &[(&str, String)],
+) -> std::process::Output {
+    let mut command = Command::new(mempal_bin());
+    command.args(args).env("HOME", home.path());
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().expect("run mempal")
+}
+
+fn install_fake_tmux(home: &TempDir, exit_code: i32) -> (String, PathBuf) {
+    let bin_dir = home.path().join("fake-bin");
+    fs::create_dir_all(&bin_dir).expect("create fake bin");
+    let log_path = home.path().join("tmux.log");
+    let script = format!("#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$TMUX_LOG\"\nexit {exit_code}\n");
+    let tmux_path = bin_dir.join("tmux");
+    fs::write(&tmux_path, script).expect("write fake tmux");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&tmux_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&tmux_path, perms).unwrap();
+    }
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{old_path}", bin_dir.display());
+    (path, log_path)
+}
+
+fn install_fake_tmux_capture(home: &TempDir) -> (String, PathBuf) {
+    let bin_dir = home.path().join("fake-capture-bin");
+    fs::create_dir_all(&bin_dir).expect("create fake bin");
+    let log_path = home.path().join("tmux-capture.log");
+    let script = "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$TMUX_LOG\"\nif [ \"$1\" = \"capture-pane\" ]; then printf 'pane line 1\\npane line 2\\n'; fi\nexit 0\n";
+    let tmux_path = bin_dir.join("tmux");
+    fs::write(&tmux_path, script).expect("write fake tmux");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&tmux_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&tmux_path, perms).unwrap();
+    }
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{old_path}", bin_dir.display());
+    (path, log_path)
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn assert_success(output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output)
+    );
+}
+
+fn message_id_from_send(output: &std::process::Output) -> String {
+    stdout(output)
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix("message_id="))
+        .expect("message_id in send output")
+        .to_string()
+}
+
+fn register(home: &TempDir, repo: &Path, agent_id: &str, tool: &str) {
+    let output = run_mempal(
+        home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            agent_id,
+            "--tool",
+            tool,
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&output);
+}
+
+fn bus_project_dir(home: &TempDir, repo: &Path) -> PathBuf {
+    let encoded = repo.to_string_lossy().replace('/', "-");
+    home.path().join(".mempal/cowork-bus").join(encoded)
+}
+
+fn bus_events_path(home: &TempDir, repo: &Path) -> PathBuf {
+    bus_project_dir(home, repo).join("events.jsonl")
+}
+
+fn sessions_path(home: &TempDir, repo: &Path) -> PathBuf {
+    bus_project_dir(home, repo).join("sessions.json")
+}
+
+fn palace_db_path(home: &TempDir) -> PathBuf {
+    home.path().join(".mempal/palace.db")
+}
+
+fn event_lines(home: &TempDir, repo: &Path) -> Vec<String> {
+    fs::read_to_string(bus_events_path(home, repo))
+        .expect("events file")
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn failed_event_id(home: &TempDir, repo: &Path) -> String {
+    let output = run_mempal(
+        home,
+        &[
+            "cowork-events",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--format",
+            "json",
+        ],
+    );
+    assert_success(&output);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout(&output)).expect("events json");
+    parsed
+        .as_array()
+        .expect("events array")
+        .iter()
+        .find(|event| event["status"] == "failed")
+        .and_then(|event| event["event_id"].as_str())
+        .expect("failed event id")
+        .to_string()
+}
+
+#[test]
+fn test_cli_cowork_register_and_agents_list() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "multi-agent-proj");
+
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    register(&home, &repo, "codex-b", "codex");
+
+    let output = run_mempal(&home, &["cowork-agents", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("claude-main"), "{out}");
+    assert!(out.contains("codex-a"), "{out}");
+    assert!(out.contains("codex-b"), "{out}");
+    assert!(out.contains("tool=claude"), "{out}");
+    assert!(out.contains("tool=codex"), "{out}");
+    assert!(out.contains("transport=inbox"), "{out}");
+
+    let project_dir = bus_project_dir(&home, &repo);
+    assert!(
+        project_dir.join("agents.json").exists(),
+        "registry must be under cowork-bus/<encoded_project>"
+    );
+    assert!(
+        !home.path().join(".mempal/palace.db").exists(),
+        "multi-agent bus commands must not create palace.db"
+    );
+}
+
+#[test]
+fn test_cli_cowork_heartbeat_updates_presence() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "presence-proj");
+    register(&home, &repo, "codex-a", "codex");
+
+    let heartbeat = run_mempal(
+        &home,
+        &[
+            "cowork-heartbeat",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--seen-at",
+            "2026-05-25T00:00:00Z",
+        ],
+    );
+    assert_success(&heartbeat);
+    assert!(stdout(&heartbeat).contains("last_seen_at=2026-05-25T00:00:00Z"));
+
+    let agents = run_mempal(
+        &home,
+        &[
+            "cowork-agents",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--now",
+            "2026-05-25T00:05:00Z",
+        ],
+    );
+    assert_success(&agents);
+    let out = stdout(&agents);
+    assert!(out.contains("codex-a"), "{out}");
+    assert!(out.contains("presence=online"), "{out}");
+    assert!(out.contains("last_seen_at=2026-05-25T00:00:00Z"), "{out}");
+}
+
+#[test]
+fn test_cli_cowork_agents_marks_stale_presence() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "presence-stale-proj");
+    register(&home, &repo, "codex-a", "codex");
+    let heartbeat = run_mempal(
+        &home,
+        &[
+            "cowork-heartbeat",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--seen-at",
+            "2026-05-25T00:00:00Z",
+        ],
+    );
+    assert_success(&heartbeat);
+
+    let agents = run_mempal(
+        &home,
+        &[
+            "cowork-agents",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--now",
+            "2026-05-25T00:11:00Z",
+        ],
+    );
+    assert_success(&agents);
+    assert!(stdout(&agents).contains("presence=stale"));
+}
+
+#[test]
+fn test_cli_cowork_heartbeat_rejects_unknown_agent() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "presence-missing-proj");
+
+    let heartbeat = run_mempal(
+        &home,
+        &[
+            "cowork-heartbeat",
+            "--agent-id",
+            "codex-missing",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert!(!heartbeat.status.success());
+    assert!(stderr(&heartbeat).contains("unknown agent"));
+}
+
+#[test]
+fn test_cli_cowork_send_drains_only_target_agent() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "multi-agent-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    register(&home, &repo, "codex-b", "codex");
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "review P84 bus routing",
+        ],
+    );
+    assert_success(&send);
+
+    let drain_a = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain_a);
+    assert!(stdout(&drain_a).contains("review P84 bus routing"));
+
+    let drain_b = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-b",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain_b);
+    assert_eq!(stdout(&drain_b), "");
+
+    let drain_a_again = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain_a_again);
+    assert_eq!(stdout(&drain_a_again), "");
+}
+
+#[test]
+fn test_cli_cowork_delivery_status_pending() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "delivery-pending-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "pending delivery",
+        ],
+    );
+    assert_success(&send);
+    let message_id = message_id_from_send(&send);
+    assert!(message_id.starts_with("evt-"), "{message_id}");
+
+    let deliveries = run_mempal(
+        &home,
+        &["cowork-deliveries", "--cwd", repo.to_str().unwrap()],
+    );
+    assert_success(&deliveries);
+    let out = stdout(&deliveries);
+    assert!(out.contains(&message_id), "{out}");
+    assert!(out.contains("status=pending"), "{out}");
+    assert!(out.contains("target=codex-a"), "{out}");
+}
+
+#[test]
+fn test_cli_cowork_delivery_status_drained() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "delivery-drained-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "drain changes status",
+        ],
+    );
+    assert_success(&send);
+    let message_id = message_id_from_send(&send);
+    let drain = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain);
+
+    let deliveries = run_mempal(
+        &home,
+        &[
+            "cowork-deliveries",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--agent-id",
+            "codex-a",
+        ],
+    );
+    assert_success(&deliveries);
+    let out = stdout(&deliveries);
+    assert!(out.contains(&message_id), "{out}");
+    assert!(out.contains("status=drained"), "{out}");
+}
+
+#[test]
+fn test_cli_cowork_ack_marks_delivery_acked() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "delivery-acked-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "ack without drain",
+        ],
+    );
+    assert_success(&send);
+    let message_id = message_id_from_send(&send);
+
+    let ack = run_mempal(
+        &home,
+        &[
+            "cowork-ack",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message-id",
+            &message_id,
+        ],
+    );
+    assert_success(&ack);
+    assert!(stdout(&ack).contains("status=acked"));
+
+    let deliveries = run_mempal(
+        &home,
+        &[
+            "cowork-deliveries",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--agent-id",
+            "codex-a",
+        ],
+    );
+    assert_success(&deliveries);
+    assert!(stdout(&deliveries).contains("status=acked"));
+
+    let drain = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain);
+    assert!(stdout(&drain).contains("ack without drain"));
+}
+
+#[test]
+fn test_cli_cowork_send_with_thread_metadata() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "thread-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "threaded message",
+            "--thread-id",
+            "p90-review",
+        ],
+    );
+    assert_success(&send);
+
+    let drain = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain);
+    assert!(stdout(&drain).contains("thread=p90-review"));
+
+    let events = run_mempal(&home, &["cowork-events", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&events);
+    assert!(stdout(&events).contains("thread_id=p90-review"));
+}
+
+#[test]
+fn test_cli_cowork_channel_send_fans_out() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "channel-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    register(&home, &repo, "codex-b", "codex");
+
+    let set = run_mempal(
+        &home,
+        &[
+            "cowork-channel-set",
+            "--channel",
+            "review",
+            "--agent",
+            "codex-a",
+            "--agent",
+            "codex-b",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&set);
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-channel-send",
+            "--from",
+            "claude-main",
+            "--channel",
+            "review",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "review channel update",
+            "--thread-id",
+            "p90-review",
+        ],
+    );
+    assert_success(&send);
+
+    for agent_id in ["codex-a", "codex-b"] {
+        let drain = run_mempal(
+            &home,
+            &[
+                "cowork-agent-drain",
+                "--agent-id",
+                agent_id,
+                "--cwd",
+                repo.to_str().unwrap(),
+            ],
+        );
+        assert_success(&drain);
+        let out = stdout(&drain);
+        assert!(out.contains("review channel update"), "{out}");
+        assert!(out.contains("thread=p90-review"), "{out}");
+        assert!(out.contains("channel=review"), "{out}");
+    }
+
+    let deliveries = run_mempal(
+        &home,
+        &[
+            "cowork-deliveries",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--agent-id",
+            "codex-a",
+        ],
+    );
+    assert_success(&deliveries);
+    assert!(stdout(&deliveries).contains("channel=review"));
+}
+
+#[test]
+fn test_cli_cowork_channel_set_replaces_members() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "channel-replace-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    register(&home, &repo, "codex-b", "codex");
+
+    let set_initial = run_mempal(
+        &home,
+        &[
+            "cowork-channel-set",
+            "--channel",
+            "review",
+            "--agent",
+            "codex-a",
+            "--agent",
+            "codex-b",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&set_initial);
+    let set_replacement = run_mempal(
+        &home,
+        &[
+            "cowork-channel-set",
+            "--channel",
+            "review",
+            "--agent",
+            "codex-b",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&set_replacement);
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-channel-send",
+            "--from",
+            "claude-main",
+            "--channel",
+            "review",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "only b should see this",
+        ],
+    );
+    assert_success(&send);
+
+    let drain_a = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain_a);
+    assert_eq!(stdout(&drain_a), "");
+
+    let drain_b = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-b",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain_b);
+    assert!(stdout(&drain_b).contains("only b should see this"));
+}
+
+#[test]
+fn test_cli_cowork_channel_send_rejects_unknown_channel() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "channel-missing-proj");
+    register(&home, &repo, "claude-main", "claude");
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-channel-send",
+            "--from",
+            "claude-main",
+            "--channel",
+            "missing",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "nope",
+        ],
+    );
+    assert!(!send.status.success());
+    assert!(stderr(&send).contains("unknown channel"));
+}
+
+#[test]
+fn test_cli_cowork_events_records_register_send_drain() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "events-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "record this handoff",
+        ],
+    );
+    assert_success(&send);
+
+    let drain = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain);
+
+    let events = run_mempal(&home, &["cowork-events", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&events);
+    let out = stdout(&events);
+    assert!(out.contains("evt-"), "{out}");
+    assert!(out.contains("type=register"), "{out}");
+    assert!(out.contains("type=send"), "{out}");
+    assert!(out.contains("type=drain"), "{out}");
+    assert!(out.contains("status=registered"), "{out}");
+    assert!(out.contains("status=delivered"), "{out}");
+    assert!(out.contains("status=drained"), "{out}");
+    assert!(out.contains("actor=claude-main"), "{out}");
+    assert!(out.contains("targets=codex-a"), "{out}");
+    assert!(
+        bus_events_path(&home, &repo).exists(),
+        "events.jsonl must exist under the project bus directory"
+    );
+}
+
+#[test]
+fn test_cli_cowork_events_json_is_machine_readable() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "events-json-proj");
+    register(&home, &repo, "claude-main", "claude");
+
+    let events = run_mempal(
+        &home,
+        &[
+            "cowork-events",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--format",
+            "json",
+        ],
+    );
+    assert_success(&events);
+    assert_eq!(stderr(&events), "");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout(&events)).expect("json events");
+    let array = parsed.as_array().expect("events array");
+    assert_eq!(array.len(), 1);
+    assert_eq!(array[0]["event_type"], "register");
+    assert_eq!(array[0]["status"], "registered");
+}
+
+#[test]
+fn test_cli_cowork_events_file_output_is_append_only() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "events-append-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    let before = event_lines(&home, &repo);
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "append one event",
+        ],
+    );
+    assert_success(&send);
+
+    let after = event_lines(&home, &repo);
+    assert_eq!(after.len(), before.len() + 1);
+    assert_eq!(&after[..before.len()], before.as_slice());
+    assert!(after.last().unwrap().contains("\"event_type\":\"send\""));
+}
+
+#[test]
+fn test_cli_cowork_events_limit_returns_latest() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "events-limit-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "latest one",
+        ],
+    );
+    assert_success(&send);
+    let drain = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain);
+
+    let events = run_mempal(
+        &home,
+        &[
+            "cowork-events",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--limit",
+            "2",
+        ],
+    );
+    assert_success(&events);
+    let out = stdout(&events);
+    let lines: Vec<_> = out.lines().collect();
+    assert_eq!(lines.len(), 2, "{out}");
+    assert!(out.contains("type=send"), "{out}");
+    assert!(out.contains("type=drain"), "{out}");
+    assert!(!out.contains("type=register"), "{out}");
+}
+
+#[test]
+fn test_cli_cowork_broadcast_fans_out_to_each_agent() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "multi-agent-proj");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    register(&home, &repo, "codex-b", "codex");
+
+    let broadcast = run_mempal(
+        &home,
+        &[
+            "cowork-broadcast",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--to",
+            "codex-b",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "main changed, pull before continuing",
+        ],
+    );
+    assert_success(&broadcast);
+
+    for agent_id in ["codex-a", "codex-b"] {
+        let drain = run_mempal(
+            &home,
+            &[
+                "cowork-agent-drain",
+                "--agent-id",
+                agent_id,
+                "--cwd",
+                repo.to_str().unwrap(),
+            ],
+        );
+        assert_success(&drain);
+        assert!(stdout(&drain).contains("main changed, pull before continuing"));
+    }
+}
+
+#[test]
+fn test_cli_cowork_bus_rejects_invalid_addressing() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "multi-agent-proj");
+    register(&home, &repo, "codex-a", "codex");
+
+    let bad_id = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "bad/id",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert!(!bad_id.status.success());
+    assert!(stderr(&bad_id).contains("invalid agent id"));
+
+    let self_send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "codex-a",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "self",
+        ],
+    );
+    assert!(!self_send.status.success());
+    assert!(stderr(&self_send).contains("cannot send to self"));
+
+    let missing_target = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "codex-a",
+            "--to",
+            "codex-missing",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "missing",
+        ],
+    );
+    assert!(!missing_target.status.success());
+    assert!(stderr(&missing_target).contains("unknown target agent"));
+}
+
+#[test]
+fn test_legacy_cowork_status_still_lists_tool_inboxes() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "legacy-proj");
+
+    let output = run_mempal(&home, &["cowork-status", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("claude inbox"), "{out}");
+    assert!(out.contains("codex inbox"), "{out}");
+    assert!(
+        !home.path().join(".mempal/cowork-bus").exists(),
+        "legacy status must not require bus registry"
+    );
+}
+
+#[test]
+fn test_cli_cowork_send_to_tmux_transport_invokes_tmux() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "tmux-proj");
+    let (path, log_path) = install_fake_tmux(&home, 0);
+    register(&home, &repo, "claude-main", "claude");
+
+    let register_tmux = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+            "--tmux-target",
+            "mempal:0.1",
+        ],
+    );
+    assert_success(&register_tmux);
+
+    let send = run_mempal_with_env(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "tmux hello",
+        ],
+        &[("PATH", path), ("TMUX_LOG", log_path.display().to_string())],
+    );
+    assert_success(&send);
+
+    let log = fs::read_to_string(&log_path).expect("tmux log");
+    assert!(log.contains("send-keys"), "{log}");
+    assert!(log.contains("-t"), "{log}");
+    assert!(log.contains("mempal:0.1"), "{log}");
+    assert!(
+        log.contains("[mempal bus from claude-main to codex-a] tmux hello"),
+        "{log}"
+    );
+    assert!(log.contains("Enter"), "{log}");
+
+    let drain = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain);
+    assert_eq!(stdout(&drain), "");
+}
+
+#[test]
+fn test_cli_cowork_register_tmux_requires_target() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "tmux-proj");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+        ],
+    );
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("tmux_target is required"));
+}
+
+#[test]
+fn test_cli_cowork_tmux_failure_does_not_write_inbox() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "tmux-proj");
+    let (path, log_path) = install_fake_tmux(&home, 42);
+    register(&home, &repo, "claude-main", "claude");
+    let register_tmux = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+            "--tmux-target",
+            "mempal:0.1",
+        ],
+    );
+    assert_success(&register_tmux);
+
+    let send = run_mempal_with_env(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "tmux should fail",
+        ],
+        &[("PATH", path), ("TMUX_LOG", log_path.display().to_string())],
+    );
+    assert!(!send.status.success());
+    assert!(stderr(&send).contains("tmux delivery failed"));
+
+    let drain = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain);
+    assert_eq!(stdout(&drain), "");
+}
+
+#[test]
+fn test_cli_cowork_tmux_peek_captures_pane() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "tmux-peek-proj");
+    let (path, log_path) = install_fake_tmux_capture(&home);
+    let register_tmux = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+            "--tmux-target",
+            "mempal:0.1",
+        ],
+    );
+    assert_success(&register_tmux);
+
+    let peek = run_mempal_with_env(
+        &home,
+        &[
+            "cowork-tmux-peek",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--lines",
+            "20",
+        ],
+        &[("PATH", path), ("TMUX_LOG", log_path.display().to_string())],
+    );
+    assert_success(&peek);
+    assert_eq!(stderr(&peek), "");
+    assert!(stdout(&peek).contains("pane line 1"));
+    let log = fs::read_to_string(&log_path).expect("tmux log");
+    assert!(log.contains("capture-pane"), "{log}");
+    assert!(log.contains("-t"), "{log}");
+    assert!(log.contains("mempal:0.1"), "{log}");
+    assert!(log.contains("-p"), "{log}");
+    assert!(log.contains("-S"), "{log}");
+    assert!(log.contains("-20"), "{log}");
+}
+
+#[test]
+fn test_cli_cowork_tmux_peek_rejects_inbox_agent() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "tmux-peek-inbox-proj");
+    register(&home, &repo, "codex-a", "codex");
+
+    let peek = run_mempal(
+        &home,
+        &[
+            "cowork-tmux-peek",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert!(!peek.status.success());
+    assert!(stderr(&peek).contains("not registered with transport=tmux"));
+}
+
+#[test]
+fn test_cli_cowork_tmux_peek_has_no_bus_side_effects() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "tmux-peek-side-effect-proj");
+    let (path, log_path) = install_fake_tmux_capture(&home);
+    let register_tmux = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+            "--tmux-target",
+            "mempal:0.1",
+        ],
+    );
+    assert_success(&register_tmux);
+    let before = fs::read_to_string(bus_events_path(&home, &repo)).expect("events before");
+
+    let peek = run_mempal_with_env(
+        &home,
+        &[
+            "cowork-tmux-peek",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+        &[("PATH", path), ("TMUX_LOG", log_path.display().to_string())],
+    );
+    assert_success(&peek);
+    let after = fs::read_to_string(bus_events_path(&home, &repo)).expect("events after");
+    assert_eq!(after, before);
+    assert!(!home.path().join(".mempal/palace.db").exists());
+}
+
+#[test]
+fn test_cli_cowork_tmux_peek_does_not_write_file_output() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "tmux-peek-no-file-proj");
+    let (path, log_path) = install_fake_tmux_capture(&home);
+    let register_tmux = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+            "--tmux-target",
+            "mempal:0.1",
+        ],
+    );
+    assert_success(&register_tmux);
+    let before_files = fs::read_dir(bus_project_dir(&home, &repo))
+        .expect("bus dir")
+        .count();
+
+    let peek = run_mempal_with_env(
+        &home,
+        &[
+            "cowork-tmux-peek",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+        &[("PATH", path), ("TMUX_LOG", log_path.display().to_string())],
+    );
+    assert_success(&peek);
+    let after_files = fs::read_dir(bus_project_dir(&home, &repo))
+        .expect("bus dir")
+        .count();
+    assert_eq!(after_files, before_files);
+}
+
+#[test]
+fn test_cli_cowork_events_records_tmux_failure() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "events-tmux-proj");
+    let (path, log_path) = install_fake_tmux(&home, 42);
+    register(&home, &repo, "claude-main", "claude");
+    let register_tmux = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+            "--tmux-target",
+            "mempal:0.1",
+        ],
+    );
+    assert_success(&register_tmux);
+
+    let send = run_mempal_with_env(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "tmux should fail and log",
+        ],
+        &[("PATH", path), ("TMUX_LOG", log_path.display().to_string())],
+    );
+    assert!(!send.status.success());
+    assert!(stderr(&send).contains("tmux delivery failed"));
+
+    let events = run_mempal(&home, &["cowork-events", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&events);
+    let out = stdout(&events);
+    assert!(out.contains("type=send"), "{out}");
+    assert!(out.contains("status=failed"), "{out}");
+    assert!(out.contains("transport=tmux"), "{out}");
+    assert!(out.contains("targets=codex-a"), "{out}");
+
+    let drain = run_mempal(
+        &home,
+        &[
+            "cowork-agent-drain",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+        ],
+    );
+    assert_success(&drain);
+    assert_eq!(stdout(&drain), "");
+}
+
+#[test]
+fn test_cli_cowork_failed_delivery_cannot_be_acked() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "delivery-failed-proj");
+    let (path, log_path) = install_fake_tmux(&home, 42);
+    register(&home, &repo, "claude-main", "claude");
+    let register_tmux = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+            "--tmux-target",
+            "mempal:0.1",
+        ],
+    );
+    assert_success(&register_tmux);
+
+    let send = run_mempal_with_env(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "failed status",
+        ],
+        &[("PATH", path), ("TMUX_LOG", log_path.display().to_string())],
+    );
+    assert!(!send.status.success());
+    let message_id = failed_event_id(&home, &repo);
+
+    let deliveries = run_mempal(
+        &home,
+        &[
+            "cowork-deliveries",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--agent-id",
+            "codex-a",
+        ],
+    );
+    assert_success(&deliveries);
+    let out = stdout(&deliveries);
+    assert!(out.contains(&message_id), "{out}");
+    assert!(out.contains("status=failed"), "{out}");
+
+    let ack = run_mempal(
+        &home,
+        &[
+            "cowork-ack",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message-id",
+            &message_id,
+        ],
+    );
+    assert!(!ack.status.success());
+    assert!(stderr(&ack).contains("cannot ack failed delivery"));
+}
+
+#[test]
+fn test_cli_cowork_runbook_plain() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["cowork-runbook", "--format", "plain"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("cowork-register"), "{out}");
+    assert!(out.contains("cowork-channel-send"), "{out}");
+    assert!(out.contains("cowork-tmux-peek"), "{out}");
+    assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn test_cli_cowork_runbook_json() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["cowork-runbook", "--format", "json"]);
+    assert_success(&output);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("runbook json");
+    assert!(
+        value["title"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Multi-Agent Cowork Runbook")
+    );
+    assert!(
+        value["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("cowork-deliveries")
+    );
+}
+
+#[test]
+fn test_cli_cowork_runbook_rejects_invalid_format() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["cowork-runbook", "--format", "yaml"]);
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("unknown format"));
+    assert!(!home.path().join(".mempal").exists());
+}
+
+#[test]
+fn test_cli_cowork_doctor_empty_registry() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "doctor-empty");
+    let output = run_mempal(&home, &["cowork-doctor", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("status=warning"), "{out}");
+    assert!(out.contains("no registered agents"), "{out}");
+    assert!(!bus_events_path(&home, &repo).exists());
+}
+
+#[test]
+fn test_cli_cowork_doctor_reports_stale_and_pending() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "doctor-stale");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    let heartbeat = run_mempal(
+        &home,
+        &[
+            "cowork-heartbeat",
+            "--agent-id",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--seen-at",
+            "2026-05-25T00:00:00Z",
+        ],
+    );
+    assert_success(&heartbeat);
+    let send = run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "pending doctor",
+        ],
+    );
+    assert_success(&send);
+
+    let output = run_mempal(
+        &home,
+        &[
+            "cowork-doctor",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--now",
+            "2026-05-25T00:20:00Z",
+        ],
+    );
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("stale_agents=1"), "{out}");
+    assert!(out.contains("pending_deliveries=1"), "{out}");
+    assert!(out.contains("status=warning"), "{out}");
+}
+
+#[test]
+fn test_cli_cowork_doctor_json_tmux_probe() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "doctor-tmux");
+    let (path, log_path) = install_fake_tmux(&home, 0);
+    let register_tmux = run_mempal(
+        &home,
+        &[
+            "cowork-register",
+            "--agent-id",
+            "codex-a",
+            "--tool",
+            "codex",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--transport",
+            "tmux",
+            "--tmux-target",
+            "mempal:0.1",
+        ],
+    );
+    assert_success(&register_tmux);
+    let output = run_mempal_with_env(
+        &home,
+        &[
+            "cowork-doctor",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--probe-tmux",
+            "--format",
+            "json",
+        ],
+        &[("PATH", path), ("TMUX_LOG", log_path.display().to_string())],
+    );
+    assert_success(&output);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("doctor json");
+    assert_eq!(value["tmux"][0]["status"], "ok");
+    let log = fs::read_to_string(log_path).expect("tmux log");
+    assert!(log.contains("has-session"), "{log}");
+    assert!(log.contains("-t"), "{log}");
+    assert!(log.contains("mempal:0.1"), "{log}");
+}
+
+#[test]
+fn test_cli_cowork_session_create_and_list() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "session-create");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    let create = run_mempal(
+        &home,
+        &[
+            "cowork-session-create",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+            "--title",
+            "Review 1",
+            "--agent",
+            "claude-main",
+            "--agent",
+            "codex-a",
+        ],
+    );
+    assert_success(&create);
+    let list = run_mempal(&home, &["cowork-sessions", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&list);
+    assert!(stdout(&list).contains("review-1"));
+    assert!(sessions_path(&home, &repo).exists());
+}
+
+#[test]
+fn test_cli_cowork_session_rejects_unknown_agent() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "session-reject");
+    register(&home, &repo, "claude-main", "claude");
+    let create = run_mempal(
+        &home,
+        &[
+            "cowork-session-create",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+            "--title",
+            "Review 1",
+            "--agent",
+            "claude-main",
+            "--agent",
+            "codex-missing",
+        ],
+    );
+    assert!(!create.status.success());
+    assert!(stderr(&create).contains("unknown agent"));
+    assert!(!sessions_path(&home, &repo).exists());
+}
+
+#[test]
+fn test_cli_cowork_session_status_update() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "session-status");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    let create = run_mempal(
+        &home,
+        &[
+            "cowork-session-create",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+            "--title",
+            "Review 1",
+            "--agent",
+            "claude-main",
+            "--agent",
+            "codex-a",
+        ],
+    );
+    assert_success(&create);
+    let update = run_mempal(
+        &home,
+        &[
+            "cowork-session-status",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+            "--status",
+            "paused",
+        ],
+    );
+    assert_success(&update);
+    let list = run_mempal(
+        &home,
+        &[
+            "cowork-sessions",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--format",
+            "json",
+        ],
+    );
+    assert_success(&list);
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).expect("sessions json");
+    assert_eq!(value[0]["status"], "paused");
+    let events = run_mempal(&home, &["cowork-events", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&events);
+    assert!(stdout(&events).contains("session_status"));
+}
+
+#[test]
+fn test_cli_cowork_handoff_plain() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "handoff-plain");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    assert_success(&run_mempal(
+        &home,
+        &[
+            "cowork-session-create",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+            "--title",
+            "Review 1",
+            "--agent",
+            "claude-main",
+            "--agent",
+            "codex-a",
+        ],
+    ));
+    assert_success(&run_mempal(
+        &home,
+        &[
+            "cowork-send",
+            "--from",
+            "claude-main",
+            "--to",
+            "codex-a",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--message",
+            "handoff pending",
+        ],
+    ));
+    let handoff = run_mempal(&home, &["cowork-handoff", "--cwd", repo.to_str().unwrap()]);
+    assert_success(&handoff);
+    let out = stdout(&handoff);
+    assert!(out.contains("Active sessions"), "{out}");
+    assert!(out.contains("review-1"), "{out}");
+    assert!(out.contains("Pending deliveries"), "{out}");
+}
+
+#[test]
+fn test_cli_cowork_handoff_filters_thread() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "handoff-thread");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    for (thread, message) in [("thread-a", "message a"), ("thread-b", "message b")] {
+        assert_success(&run_mempal(
+            &home,
+            &[
+                "cowork-send",
+                "--from",
+                "claude-main",
+                "--to",
+                "codex-a",
+                "--cwd",
+                repo.to_str().unwrap(),
+                "--thread-id",
+                thread,
+                "--message",
+                message,
+            ],
+        ));
+    }
+    let handoff = run_mempal(
+        &home,
+        &[
+            "cowork-handoff",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--thread-id",
+            "thread-a",
+            "--format",
+            "json",
+        ],
+    );
+    assert_success(&handoff);
+    let out = stdout(&handoff);
+    assert!(out.contains("thread-a"), "{out}");
+    assert!(!out.contains("thread-b"), "{out}");
+}
+
+#[test]
+fn test_cli_cowork_handoff_rejects_invalid_format() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "handoff-invalid");
+    register(&home, &repo, "claude-main", "claude");
+    let before = fs::read_to_string(bus_events_path(&home, &repo)).expect("events");
+    let handoff = run_mempal(
+        &home,
+        &[
+            "cowork-handoff",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--format",
+            "yaml",
+        ],
+    );
+    assert!(!handoff.status.success());
+    let after = fs::read_to_string(bus_events_path(&home, &repo)).expect("events");
+    assert_eq!(before, after);
+}
+
+#[test]
+fn test_cli_cowork_capture_dry_run_no_write() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "capture-dry-run");
+    register(&home, &repo, "claude-main", "claude");
+    let capture = run_mempal(
+        &home,
+        &[
+            "cowork-capture",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--summary-source",
+            "handoff",
+            "--format",
+            "json",
+        ],
+    );
+    assert_success(&capture);
+    let value: serde_json::Value = serde_json::from_slice(&capture.stdout).expect("capture json");
+    assert_eq!(value["writes"], false);
+    assert!(!palace_db_path(&home).exists());
+}
+
+#[test]
+fn test_cli_cowork_capture_execute_writes_evidence() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "capture-execute");
+    register(&home, &repo, "claude-main", "claude");
+    let capture = run_mempal(
+        &home,
+        &[
+            "cowork-capture",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--summary-source",
+            "handoff",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert_success(&capture);
+    let value: serde_json::Value = serde_json::from_slice(&capture.stdout).expect("capture json");
+    assert_eq!(value["writes"], true);
+    let drawer_id = value["drawer_id"].as_str().expect("drawer id");
+    let db = mempal::core::db::Database::open(&palace_db_path(&home)).expect("open db");
+    let drawer = db
+        .get_drawer(drawer_id)
+        .expect("get drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.wing, "cowork-capture");
+    assert!(drawer.content.contains("Cowork Handoff Capture"));
+}
+
+#[test]
+fn test_cli_cowork_capture_rejects_unknown_source() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "capture-unknown");
+    let capture = run_mempal(
+        &home,
+        &[
+            "cowork-capture",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--summary-source",
+            "tmux",
+        ],
+    );
+    assert!(!capture.status.success());
+    assert!(stderr(&capture).contains("unsupported cowork capture summary source"));
+}
+
+#[test]
+fn test_cli_maintenance_runbook_plain() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["maintenance-runbook", "--format", "plain"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("research-ingest-plan"), "{out}");
+    assert!(out.contains("knowledge distill"), "{out}");
+    assert!(out.contains("cowork-capture"), "{out}");
+}
+
+#[test]
+fn test_cli_maintenance_runbook_json() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["maintenance-runbook", "--format", "json"]);
+    assert_success(&output);
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("maintenance json");
+    assert!(
+        value["title"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Maintenance Runbook")
+    );
+    assert!(
+        value["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("runtime adoption")
+    );
+}
+
+#[test]
+fn test_cli_maintenance_runbook_rejects_invalid_format() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["maintenance-runbook", "--format", "yaml"]);
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("unknown format"));
+    assert!(!home.path().join(".mempal").exists());
+}

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -1362,6 +1362,175 @@ fn test_cli_phase3_adoption_capture_rejects_unknown_surface() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_wrap_dry_run_executes_child_without_writing() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "wrap",
+            "--surface",
+            "runtime-context",
+            "--query",
+            "context pack",
+            "--format",
+            "json",
+            "--",
+            "sh",
+            "-c",
+            "printf wrapper-child; exit 0",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "wrap dry-run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("wrap json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["execute"], false);
+    assert_eq!(report["child_exit_code"], 0);
+    assert_eq!(report["child_stdout"], "wrapper-child");
+    assert_eq!(report["outcome"], "accepted");
+    assert_eq!(report["capture"]["record_quality"]["quality"], "ready");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events")
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_cli_phase3_adoption_wrap_execute_writes_ready_event() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "wrap",
+            "--surface",
+            "runtime-context",
+            "--query",
+            "context pack",
+            "--note",
+            "wrapper helped",
+            "--execute",
+            "--format",
+            "json",
+            "--",
+            "sh",
+            "-c",
+            "exit 0",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "wrap execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("wrap json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["capture"]["record_checked"]["blocked"], false);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].signal, RuntimeAdoptionSignal::Accepted);
+}
+
+#[test]
+fn test_cli_phase3_adoption_wrap_failure_maps_rejected_and_exits_nonzero() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "wrap",
+            "--surface",
+            "runtime-context",
+            "--format",
+            "json",
+            "--",
+            "sh",
+            "-c",
+            "exit 7",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(7));
+    let report: Value = serde_json::from_slice(&output.stdout).expect("wrap json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["child_exit_code"], 7);
+    assert_eq!(report["outcome"], "rejected");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events")
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_cli_phase3_adoption_wrap_blocks_warning_by_default() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "wrap",
+            "--surface",
+            "card-context",
+            "--execute",
+            "--format",
+            "json",
+            "--",
+            "sh",
+            "-c",
+            "exit 0",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "wrap warning should return blocked JSON: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("wrap json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["capture"]["record_quality"]["quality"], "warning");
+    assert_eq!(report["capture"]["record_checked"]["blocked"], true);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events")
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_cli_phase3_adoption_wrap_rejects_missing_child_command() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "adoption", "wrap", "--surface", "runtime-context"],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("required") || stderr.contains("command"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_cli_phase3_adoption_check_record_json_accepts_supported_event() {
     let home = setup_cli_home();
     let output = run_mempal(


### PR DESCRIPTION
## Summary

- Adds P82-P97 specs and matching implementation plans, keeping the numbered-P spec completeness invariant intact.
- Adds opt-in runtime adoption wrapping, deterministic cognitive briefs, multi-agent cowork bus capabilities, tmux transport/peek, delivery events, presence, sessions, handoff summaries, and explicit cowork-to-evidence capture.
- Updates MIND-MODEL, AGENTS, CLAUDE, MCP protocol/tool surfaces, and runbooks for cowork and maintenance operations.

## Validation

- `agent-spec parse/lint` for P92-P97
- `cargo fmt -- --check`
- `git diff --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test --test cowork_bus`
- `cargo test --lib test_mcp_cowork_bus_`
- `cargo test`
- `cargo check --features rest`
- `cargo clippy --features rest -- -D warnings`