### PR TITLE
feat: add ops runtime completion surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,13 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p95-cowork-handoff-summary.spec.md` | 完成 | P95 cowork handoff summary：`cowork-handoff` / MCP `handoff` 汇总 sessions、agents、pending deliveries、recent events，支持 thread/channel/session filter |
 | `specs/p96-cowork-memory-capture.spec.md` | 完成 | P96 cowork memory capture：`cowork-capture` / MCP `capture` 显式把 handoff summary 写入 evidence drawer，默认 dry-run |
 | `specs/p97-maintenance-runbook.spec.md` | 完成 | P97 maintenance runbook：`docs/MAINTENANCE-RUNBOOK.md` + `maintenance-runbook` read-only CLI 固化 research->evidence->knowledge/card->context/adoption/cowork capture 维护流程 |
+| `specs/p98-release-install-doctor.spec.md` | 完成 | P98 release install doctor：`mempal doctor` 只读报告 binary/PATH/schema 兼容性，避免旧 binary 对新 schema 失败时无诊断 |
+| `specs/p99-mcp-runtime-doctor.spec.md` | 完成 | P99 MCP runtime doctor：`mempal_doctor` 暴露 install/schema 诊断与 MCP runtime tool/action 能力清单 |
+| `specs/p100-guided-maintenance-run.spec.md` | 完成 | P100 guided maintenance run：`mempal maintenance guided-run` 只读输出 dream/maintenance 推荐命令与状态计数 |
+| `specs/p101-cowork-session-close-capture.spec.md` | 完成 | P101 cowork session close capture：`cowork-session-close` / MCP `session_close` 关闭 session，并可显式 dry-run/execute capture |
+| `specs/p102-mcp-cognitive-brief.spec.md` | 完成 | P102 MCP cognitive brief：`mempal_brief` 向 agent runtime 暴露 deterministic citation-first brief |
+| `specs/p103-adoption-analytics.spec.md` | 完成 | P103 adoption analytics：`phase3 adoption analytics` / MCP `analytics` 按 track+feature 汇总 runtime adoption evidence |
+| `specs/p104-release-readiness-checklist.spec.md` | 完成 | P104 release readiness checklist：`mempal release-readiness` 只读检查 package/docs/spec-plan/runbook/doctor/schema 发布准备状态 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -254,6 +261,13 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-26-p95-cowork-handoff-summary.md` — P95 cowork handoff summary（已完成）
 - `docs/plans/2026-05-26-p96-cowork-memory-capture.md` — P96 cowork memory capture（已完成）
 - `docs/plans/2026-05-26-p97-maintenance-runbook.md` — P97 maintenance runbook（已完成）
+- `docs/plans/2026-05-26-p98-release-install-doctor.md` — P98 release install doctor（已完成）
+- `docs/plans/2026-05-26-p99-mcp-runtime-doctor.md` — P99 MCP runtime doctor（已完成）
+- `docs/plans/2026-05-26-p100-guided-maintenance-run.md` — P100 guided maintenance run（已完成）
+- `docs/plans/2026-05-26-p101-cowork-session-close-capture.md` — P101 cowork session close capture（已完成）
+- `docs/plans/2026-05-26-p102-mcp-cognitive-brief.md` — P102 MCP cognitive brief（已完成）
+- `docs/plans/2026-05-26-p103-adoption-analytics.md` — P103 adoption analytics（已完成）
+- `docs/plans/2026-05-26-p104-release-readiness-checklist.md` — P104 release readiness checklist（已完成）
 
 ### Spec 使用方式
 
@@ -274,13 +288,15 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，17 条规则
 
-## MCP 工具（21 个）
+## MCP 工具（23 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
+| `mempal_doctor` | release/install + MCP runtime diagnostics：报告 binary/PATH/schema 兼容性和 required MCP tool/action 能力清单（P99） |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26/P44） |
+| `mempal_brief` | deterministic citation-first cognitive brief：summary/key facts/evidence/cards/uncertainty/next actions，不调用 LLM、不写 DB（P102） |
 | `mempal_field_taxonomy` | read-only Stage-1 field taxonomy guidance：推荐 `field` 值但不限制自定义字段（P28） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_policy` | read-only Stage-1 promotion policy：列出 `dao_tian/dao_ren/shu/qi` 提升阈值（P27） |
@@ -289,7 +305,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74/P77） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/analytics/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74/P77/P103） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |
@@ -297,7 +313,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_tunnels` | 跨 Wing 链接发现 |
 | `mempal_peek_partner` | 读 partner agent 当前 session（live，不存储） |
 | `mempal_cowork_push` | 主动投递 ephemeral handoff 到 partner inbox（at-next-submit 交付） |
-| `mempal_cowork_bus` | 多 agent concrete `agent_id` 总线：register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/handoff/capture，支持 opt-in `transport=tmux`、event replay、delivery ack/status、presence、group channels、read-only tmux pane peek、诊断、session、handoff summary、显式 handoff-to-evidence capture（P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96） |
+| `mempal_cowork_bus` | 多 agent concrete `agent_id` 总线：register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/session_close/handoff/capture，支持 opt-in `transport=tmux`、event replay、delivery ack/status、presence、group channels、read-only tmux pane peek、诊断、session、handoff summary、显式 handoff-to-evidence capture（P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96/P101） |
 | `mempal_fact_check` | 离线矛盾检测（SimilarNameConflict / RelationContradiction / StaleFact）—— P9 |
 
 ## mempal 检索纪律

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,13 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p95-cowork-handoff-summary.spec.md` | 完成 | P95 cowork handoff summary：`cowork-handoff` / MCP `handoff` 汇总 sessions、agents、pending deliveries、recent events，支持 thread/channel/session filter |
 | `specs/p96-cowork-memory-capture.spec.md` | 完成 | P96 cowork memory capture：`cowork-capture` / MCP `capture` 显式把 handoff summary 写入 evidence drawer，默认 dry-run |
 | `specs/p97-maintenance-runbook.spec.md` | 完成 | P97 maintenance runbook：`docs/MAINTENANCE-RUNBOOK.md` + `maintenance-runbook` read-only CLI 固化 research->evidence->knowledge/card->context/adoption/cowork capture 维护流程 |
+| `specs/p98-release-install-doctor.spec.md` | 完成 | P98 release install doctor：`mempal doctor` 只读报告 binary/PATH/schema 兼容性，避免旧 binary 对新 schema 失败时无诊断 |
+| `specs/p99-mcp-runtime-doctor.spec.md` | 完成 | P99 MCP runtime doctor：`mempal_doctor` 暴露 install/schema 诊断与 MCP runtime tool/action 能力清单 |
+| `specs/p100-guided-maintenance-run.spec.md` | 完成 | P100 guided maintenance run：`mempal maintenance guided-run` 只读输出 dream/maintenance 推荐命令与状态计数 |
+| `specs/p101-cowork-session-close-capture.spec.md` | 完成 | P101 cowork session close capture：`cowork-session-close` / MCP `session_close` 关闭 session，并可显式 dry-run/execute capture |
+| `specs/p102-mcp-cognitive-brief.spec.md` | 完成 | P102 MCP cognitive brief：`mempal_brief` 向 agent runtime 暴露 deterministic citation-first brief |
+| `specs/p103-adoption-analytics.spec.md` | 完成 | P103 adoption analytics：`phase3 adoption analytics` / MCP `analytics` 按 track+feature 汇总 runtime adoption evidence |
+| `specs/p104-release-readiness-checklist.spec.md` | 完成 | P104 release readiness checklist：`mempal release-readiness` 只读检查 package/docs/spec-plan/runbook/doctor/schema 发布准备状态 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -252,6 +259,13 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-26-p95-cowork-handoff-summary.md` — P95 cowork handoff summary（已完成）
 - `docs/plans/2026-05-26-p96-cowork-memory-capture.md` — P96 cowork memory capture（已完成）
 - `docs/plans/2026-05-26-p97-maintenance-runbook.md` — P97 maintenance runbook（已完成）
+- `docs/plans/2026-05-26-p98-release-install-doctor.md` — P98 release install doctor（已完成）
+- `docs/plans/2026-05-26-p99-mcp-runtime-doctor.md` — P99 MCP runtime doctor（已完成）
+- `docs/plans/2026-05-26-p100-guided-maintenance-run.md` — P100 guided maintenance run（已完成）
+- `docs/plans/2026-05-26-p101-cowork-session-close-capture.md` — P101 cowork session close capture（已完成）
+- `docs/plans/2026-05-26-p102-mcp-cognitive-brief.md` — P102 MCP cognitive brief（已完成）
+- `docs/plans/2026-05-26-p103-adoption-analytics.md` — P103 adoption analytics（已完成）
+- `docs/plans/2026-05-26-p104-release-readiness-checklist.md` — P104 release readiness checklist（已完成）
 
 ### Spec 使用方式
 
@@ -272,13 +286,15 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
 - **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，17 条规则
 
-## MCP 工具（21 个）
+## MCP 工具（23 个）
 
 | 工具 | 作用 |
 |------|------|
 | `mempal_status` | 状态 + 协议 + AAAK spec |
+| `mempal_doctor` | release/install + MCP runtime diagnostics：报告 binary/PATH/schema 兼容性和 required MCP tool/action 能力清单（P99） |
 | `mempal_search` | 混合检索（BM25 + 向量 + RRF + tunnel hints）+ AAAK 结构化 signals（P7） |
 | `mempal_context` | mind-model runtime context：按 `dao_tian -> dao_ren -> shu -> qi` 组装指导性 context pack；`dao_tian_limit` 默认 1；用于辅助 workflow/skill/tool 选择但不自动执行（P15/P16/P26/P44） |
+| `mempal_brief` | deterministic citation-first cognitive brief：summary/key facts/evidence/cards/uncertainty/next actions，不调用 LLM、不写 DB（P102） |
 | `mempal_field_taxonomy` | read-only Stage-1 field taxonomy guidance：推荐 `field` 值但不限制自定义字段（P28） |
 | `mempal_knowledge_distill` | 从 existing evidence drawer refs 创建 candidate `dao_ren` / `qi` knowledge drawer（P22） |
 | `mempal_knowledge_policy` | read-only Stage-1 promotion policy：列出 `dao_tian/dao_ren/shu/qi` 提升阈值（P27） |
@@ -287,7 +303,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74/P77） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/analytics/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74/P77/P103） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |
@@ -295,7 +311,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_tunnels` | 跨 Wing 链接发现 |
 | `mempal_peek_partner` | 读 partner agent 当前 session（live，不存储） |
 | `mempal_cowork_push` | 主动投递 ephemeral handoff 到 partner inbox（at-next-submit 交付） |
-| `mempal_cowork_bus` | 多 agent concrete `agent_id` 总线：register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/handoff/capture，支持 opt-in `transport=tmux`、event replay、delivery ack/status、presence、group channels、read-only tmux pane peek、诊断、session、handoff summary、显式 handoff-to-evidence capture（P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96） |
+| `mempal_cowork_bus` | 多 agent concrete `agent_id` 总线：register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/session_close/handoff/capture，支持 opt-in `transport=tmux`、event replay、delivery ack/status、presence、group channels、read-only tmux pane peek、诊断、session、handoff summary、显式 handoff-to-evidence capture（P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96/P101） |
 | `mempal_fact_check` | 离线矛盾检测（SimilarNameConflict / RelationContradiction / StaleFact）—— P9 |
 
 ## mempal 检索纪律

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -2066,6 +2066,107 @@ knowledge distill, card lifecycle gates, context adoption, runtime adoption
 review, rollback, cowork handoff, and explicit cowork capture. It is a
 checklist for dream-cycle style maintenance, not a daemon or scheduler.
 
+## Release Install Doctor
+
+P98 adds a read-only operator diagnostic:
+
+```bash
+mempal doctor --format plain
+mempal doctor --format json
+```
+
+Doctor runs before normal database open/migration. It reports current binary
+version, supported schema version, configured database path, direct SQLite
+`PRAGMA user_version`, current executable path, the first `mempal` found on
+`PATH`, warnings, and recommendations. This is specifically for the failure
+mode where a long-lived MCP client or shell resolves an old binary against a
+newer `palace.db` schema.
+
+P99 exposes the same runtime diagnostic through MCP:
+
+```text
+mempal_doctor
+```
+
+The MCP response adds required server tool/action expectations so an agent can
+tell whether its connected server advertises `mempal_context`, `mempal_brief`,
+`mempal_phase3`, and `mempal_cowork_bus`.
+
+## Guided Maintenance Run
+
+P100 turns the static runbook into a deterministic dry-run command:
+
+```bash
+mempal maintenance guided-run --format plain
+mempal maintenance guided-run --format json
+```
+
+The command is read-only (`writes=false`). It reports current drawer, knowledge
+card, and runtime adoption event counts when a database exists, then emits an
+ordered operator checklist for research validation, research evidence ingest,
+knowledge distill, card lifecycle gate, context review, adoption review,
+rollback review, cowork doctor, handoff, and explicit cowork capture. It never
+executes the generated commands.
+
+## Session Close Capture
+
+P101 closes the loop for concrete multi-agent sessions:
+
+```bash
+mempal cowork-session-close --cwd "$PWD" --session-id p101-review
+mempal cowork-session-close --cwd "$PWD" --session-id p101-review --capture --execute --format json
+```
+
+The MCP equivalent is `mempal_cowork_bus action=session_close`. Closing a
+session updates the runtime session status to `closed` and appends the existing
+session-status event. It does not write durable memory unless capture is
+explicitly requested and `execute=true`; dry-run capture returns the handoff
+payload without creating `palace.db`.
+
+## MCP Cognitive Brief
+
+P102 exposes the deterministic P83 brief to agent runtimes:
+
+```text
+mempal_brief
+```
+
+The tool accepts query, field, domain, cwd, max_items, and dao_tian_limit. It
+returns the same citation-first shape as CLI brief: summary, key facts,
+evidence, cards, entities, unresolved items, uncertainty, and next actions. It
+does not call an LLM and does not write adoption evidence.
+
+## Adoption Analytics
+
+P103 adds a compact analytics view over runtime adoption events:
+
+```bash
+mempal phase3 adoption analytics --format plain
+mempal phase3 adoption analytics --format json
+```
+
+MCP exposes the same report as `mempal_phase3 action=analytics`. Analytics is
+read-only and groups events by `track` and `feature`, reporting used, accepted,
+rejected, miss, rollback, contradiction, and neutral counts plus a
+deterministic recommendation. This is the operator-facing bridge from raw
+adoption evidence to default-change planning, without itself changing any
+default or lifecycle state.
+
+## Release Readiness
+
+P104 adds the release checklist:
+
+```bash
+mempal release-readiness --format plain
+mempal release-readiness --format json
+```
+
+The checklist is read-only (`writes=false`) and checks Cargo package metadata,
+README presence, P98-P104 spec/plan inventory, runbooks, doctor availability,
+and current schema support. It recommends concrete verification commands such
+as `mempal doctor --format json`, `cargo test`, `cargo clippy -- -D warnings`,
+and `cargo package`, but it does not run them automatically.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/plans/2026-05-26-p100-guided-maintenance-run.md
+++ b/docs/plans/2026-05-26-p100-guided-maintenance-run.md
@@ -1,0 +1,21 @@
+# P100 Guided Maintenance Run
+
+Spec: `specs/p100-guided-maintenance-run.spec.md`
+
+## Tasks
+
+- [x] Define the P100 task contract and implementation plan.
+- [x] Add `maintenance guided-run --format plain|json`.
+- [x] Build deterministic state counters and command suggestions.
+- [x] Add integration tests for JSON, plain, and invalid format.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL inventory.
+
+## Verification
+
+```bash
+agent-spec parse specs/p100-guided-maintenance-run.spec.md
+agent-spec lint specs/p100-guided-maintenance-run.spec.md --min-score 0.7
+cargo test --test ops_runtime test_cli_maintenance_guided_run_json
+cargo test --test ops_runtime test_cli_maintenance_guided_run_plain
+cargo test --test ops_runtime test_cli_maintenance_guided_run_rejects_invalid_format
+```

--- a/docs/plans/2026-05-26-p101-cowork-session-close-capture.md
+++ b/docs/plans/2026-05-26-p101-cowork-session-close-capture.md
@@ -1,0 +1,21 @@
+# P101 Cowork Session Close Capture
+
+Spec: `specs/p101-cowork-session-close-capture.spec.md`
+
+## Tasks
+
+- [x] Define the P101 task contract and implementation plan.
+- [x] Add CLI `cowork-session-close`.
+- [x] Add MCP action `session_close`.
+- [x] Reuse P96 handoff capture for optional evidence write.
+- [x] Add CLI/MCP tests and update docs inventory.
+
+## Verification
+
+```bash
+agent-spec parse specs/p101-cowork-session-close-capture.spec.md
+agent-spec lint specs/p101-cowork-session-close-capture.spec.md --min-score 0.7
+cargo test --test cowork_bus test_cli_cowork_session_close_no_capture
+cargo test --test cowork_bus test_cli_cowork_session_close_capture_execute
+cargo test --lib test_mcp_cowork_bus_session_close
+```

--- a/docs/plans/2026-05-26-p102-mcp-cognitive-brief.md
+++ b/docs/plans/2026-05-26-p102-mcp-cognitive-brief.md
@@ -1,0 +1,21 @@
+# P102 MCP Cognitive Brief
+
+Spec: `specs/p102-mcp-cognitive-brief.spec.md`
+
+## Tasks
+
+- [x] Define the P102 task contract and implementation plan.
+- [x] Add MCP request/response DTOs for cognitive briefs.
+- [x] Add `mempal_brief` MCP tool using existing brief core.
+- [x] Add MCP behavior, validation, and registry/protocol tests.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL inventory.
+
+## Verification
+
+```bash
+agent-spec parse specs/p102-mcp-cognitive-brief.spec.md
+agent-spec lint specs/p102-mcp-cognitive-brief.spec.md --min-score 0.7
+cargo test --lib test_mcp_brief_returns_cognitive_brief
+cargo test --lib test_mcp_brief_rejects_max_items_zero
+cargo test --lib test_mcp_tool_registry_and_protocol_include_mempal_brief
+```

--- a/docs/plans/2026-05-26-p103-adoption-analytics.md
+++ b/docs/plans/2026-05-26-p103-adoption-analytics.md
@@ -1,0 +1,21 @@
+# P103 Adoption Analytics
+
+Spec: `specs/p103-adoption-analytics.spec.md`
+
+## Tasks
+
+- [x] Define the P103 task contract and implementation plan.
+- [x] Add analytics report model over runtime adoption events.
+- [x] Add CLI `phase3 adoption analytics`.
+- [x] Add MCP `mempal_phase3 action=analytics`.
+- [x] Add CLI/MCP tests and docs inventory updates.
+
+## Verification
+
+```bash
+agent-spec parse specs/p103-adoption-analytics.spec.md
+agent-spec lint specs/p103-adoption-analytics.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_analytics_json
+cargo test --test phase3_runtime test_cli_phase3_adoption_analytics_plain
+cargo test --lib test_mcp_phase3_adoption_analytics_action
+```

--- a/docs/plans/2026-05-26-p104-release-readiness-checklist.md
+++ b/docs/plans/2026-05-26-p104-release-readiness-checklist.md
@@ -1,0 +1,21 @@
+# P104 Release Readiness Checklist
+
+Spec: `specs/p104-release-readiness-checklist.spec.md`
+
+## Tasks
+
+- [x] Define the P104 task contract and implementation plan.
+- [x] Add CLI `release-readiness --format plain|json`.
+- [x] Add deterministic checklist for metadata, docs, specs/plans, doctor, and schema.
+- [x] Add integration tests for JSON, plain, and invalid format.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL inventory through P104.
+
+## Verification
+
+```bash
+agent-spec parse specs/p104-release-readiness-checklist.spec.md
+agent-spec lint specs/p104-release-readiness-checklist.spec.md --min-score 0.7
+cargo test --test ops_runtime test_cli_release_readiness_json
+cargo test --test ops_runtime test_cli_release_readiness_plain
+cargo test --test ops_runtime test_cli_release_readiness_rejects_invalid_format
+```

--- a/docs/plans/2026-05-26-p98-release-install-doctor.md
+++ b/docs/plans/2026-05-26-p98-release-install-doctor.md
@@ -1,0 +1,21 @@
+# P98 Release Install Doctor
+
+Spec: `specs/p98-release-install-doctor.spec.md`
+
+## Tasks
+
+- [x] Define the P98 task contract and implementation plan.
+- [x] Add read-only doctor core model for binary, PATH, and DB schema checks.
+- [x] Add CLI `doctor --format plain|json` before normal DB open.
+- [x] Add deterministic integration tests for schema/path, missing DB, and bad format.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL inventory.
+
+## Verification
+
+```bash
+agent-spec parse specs/p98-release-install-doctor.spec.md
+agent-spec lint specs/p98-release-install-doctor.spec.md --min-score 0.7
+cargo test --test ops_runtime test_cli_doctor_json_reports_schema_and_path
+cargo test --test ops_runtime test_cli_doctor_plain_no_db_is_read_only
+cargo test --test ops_runtime test_cli_doctor_rejects_invalid_format
+```

--- a/docs/plans/2026-05-26-p99-mcp-runtime-doctor.md
+++ b/docs/plans/2026-05-26-p99-mcp-runtime-doctor.md
@@ -1,0 +1,21 @@
+# P99 MCP Runtime Doctor
+
+Spec: `specs/p99-mcp-runtime-doctor.spec.md`
+
+## Tasks
+
+- [x] Define the P99 task contract and implementation plan.
+- [x] Add MCP request/response DTOs for doctor diagnostics.
+- [x] Add `mempal_doctor` server tool backed by P98 doctor core.
+- [x] Add MCP registry/protocol tests.
+- [x] Update AGENTS / CLAUDE / MIND-MODEL inventory.
+
+## Verification
+
+```bash
+agent-spec parse specs/p99-mcp-runtime-doctor.spec.md
+agent-spec lint specs/p99-mcp-runtime-doctor.spec.md --min-score 0.7
+cargo test --lib test_mcp_tool_registry_includes_mempal_doctor
+cargo test --lib test_mcp_doctor_reports_runtime_tools
+cargo test --lib test_mcp_tool_registry_and_protocol_include_mempal_doctor
+```

--- a/specs/p100-guided-maintenance-run.spec.md
+++ b/specs/p100-guided-maintenance-run.spec.md
@@ -1,0 +1,75 @@
+spec: task
+name: "P100: guided maintenance run"
+inherits: project
+tags: [maintenance, guided-run, self-evolution, phase-5]
+---
+
+## Intent
+
+P100 turns the static maintenance runbook into a deterministic guided dry-run.
+The command should inspect current memory/runtime state and emit the next
+recommended maintenance commands, while preserving the existing rule that
+maintenance is not autonomous and does not grant promotion authority.
+
+## Decisions
+
+- Add CLI `mempal maintenance guided-run --format plain|json`.
+- The guided run is read-only and returns `writes=false`.
+- The report includes ordered steps for research validation, research ingest,
+  knowledge distill, card lifecycle, context/adoption review, rollback review,
+  cowork doctor, handoff, and cowork capture.
+- The report includes current state counters when available: drawer count,
+  runtime adoption event count, and card count.
+- Guided run never executes generated commands.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p100-guided-maintenance-run.spec.md
+- docs/plans/2026-05-26-p100-guided-maintenance-run.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/main.rs
+- tests/ops_runtime.rs
+
+### Forbidden
+- Do not add a daemon, timer, hook, or background worker.
+- Do not execute research, promotion, rollback, or capture commands.
+- Do not mutate DB state.
+
+## Acceptance Criteria
+
+Scenario: CLI guided run JSON returns ordered commands
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_maintenance_guided_run_json
+    Targets: `mempal maintenance guided-run`.
+  Given an initialized temp mempal DB
+  When `mempal maintenance guided-run --format json` runs
+  Then JSON reports `writes=false`
+  And JSON includes steps for `research-validate-plan`
+  And JSON includes steps for `adoption review`
+  And JSON includes steps for `cowork-doctor`
+
+Scenario: CLI guided run plain output is operator-readable
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_maintenance_guided_run_plain
+    Targets: plain report.
+  When `mempal maintenance guided-run --format plain` runs
+  Then stdout contains `Guided Maintenance Run`
+  And stdout contains `mempal phase3 adoption review`
+  And stdout contains `mempal cowork-capture`
+
+Scenario: CLI guided run rejects unsupported format
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_maintenance_guided_run_rejects_invalid_format
+    Targets: format validation.
+  When `mempal maintenance guided-run --format yaml` runs
+  Then the command fails
+  And stderr mentions `unsupported maintenance guided-run format`
+
+## Out of Scope
+
+- Automatic maintenance execution.
+- Autonomous promotion/demotion.
+- Scheduling.

--- a/specs/p101-cowork-session-close-capture.spec.md
+++ b/specs/p101-cowork-session-close-capture.spec.md
@@ -1,0 +1,77 @@
+spec: task
+name: "P101: cowork session close capture"
+inherits: project
+tags: [cowork, session, handoff, capture, mcp, phase-5]
+---
+
+## Intent
+
+P101 reduces multi-agent shutdown friction by adding an explicit session close
+flow. Closing a session updates runtime session state and can optionally bridge
+the deterministic handoff summary into durable evidence through the existing
+P96 capture path.
+
+## Decisions
+
+- Add CLI `mempal cowork-session-close --cwd <repo> --session-id <id>`.
+- Add optional `--capture` and `--execute` flags; capture defaults to dry-run.
+- Add MCP action `mempal_cowork_bus action=session_close`.
+- Closing sets session status to `closed` and appends the existing runtime
+  session-status event.
+- Capture writes durable memory only when both `capture=true` and
+  `execute=true` are supplied.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p101-cowork-session-close-capture.spec.md
+- docs/plans/2026-05-26-p101-cowork-session-close-capture.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/cowork/bus.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/cowork_bus.rs
+
+### Forbidden
+- Do not capture raw tmux pane text.
+- Do not automatically capture without an explicit capture flag.
+- Do not promote knowledge or create cards.
+- Do not alter legacy `mempal_cowork_push`.
+
+## Acceptance Criteria
+
+Scenario: CLI closes a session without writing memory
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_session_close_no_capture
+    Targets: `cowork-session-close`.
+  Given a runtime session exists
+  When `mempal cowork-session-close --session-id review-1` runs
+  Then `cowork-sessions --format json` reports status `closed`
+  And no `palace.db` file is created
+
+Scenario: CLI close capture execute writes evidence
+  Test:
+    Filter: cargo test --test cowork_bus test_cli_cowork_session_close_capture_execute
+    Targets: close + capture bridge.
+  Given a runtime session exists
+  When `cowork-session-close --capture --execute --format json` runs
+  Then JSON includes `capture.writes=true`
+  And the returned drawer is in wing `cowork-capture`
+
+Scenario: MCP session_close mirrors CLI close and dry-run capture
+  Test:
+    Filter: test_mcp_cowork_bus_session_close
+    Targets: `mempal_cowork_bus action=session_close`.
+  Given a runtime session exists
+  When MCP action `session_close` runs with `capture=true` and `execute=false`
+  Then the response includes a closed session
+  And the capture payload reports `writes=false`
+
+## Out of Scope
+
+- Automatic session expiration.
+- Closing all sessions.
+- Background capture.

--- a/specs/p102-mcp-cognitive-brief.spec.md
+++ b/specs/p102-mcp-cognitive-brief.spec.md
@@ -1,0 +1,69 @@
+spec: task
+name: "P102: MCP cognitive brief"
+inherits: project
+tags: [brief, mcp, cognition, phase-5]
+---
+
+## Intent
+
+P102 exposes the deterministic P83 cognitive brief to agent runtimes. Agents
+should be able to request a citation-first brief before starting work without
+falling back to raw search or ad hoc context assembly.
+
+## Decisions
+
+- Add MCP tool `mempal_brief`.
+- The tool accepts query, field, domain, cwd, max_items, and dao_tian_limit.
+- The tool uses the existing deterministic brief assembly path.
+- The response includes summary, key facts, evidence, cards, entities,
+  unresolved items, uncertainty, and next actions.
+- The tool is read-only and does not write runtime adoption evidence.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p102-mcp-cognitive-brief.spec.md
+- docs/plans/2026-05-26-p102-mcp-cognitive-brief.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- src/core/protocol.rs
+
+### Forbidden
+- Do not call an LLM.
+- Do not write DB rows, adoption events, cards, or audit logs.
+- Do not replace `mempal_search` or `mempal_context`.
+
+## Acceptance Criteria
+
+Scenario: MCP brief returns citation-first sections
+  Test:
+    Filter: test_mcp_brief_returns_cognitive_brief
+    Targets: `mempal_brief`.
+  Given a test DB with cited evidence and knowledge
+  When `mempal_brief` runs
+  Then the response includes a summary
+  And it includes at least one key fact or evidence item
+  And returned items include drawer/source citations
+
+Scenario: MCP brief rejects invalid max_items
+  Test:
+    Filter: test_mcp_brief_rejects_max_items_zero
+    Targets: request validation.
+  When `mempal_brief` runs with `max_items=0`
+  Then it returns invalid params
+
+Scenario: MCP registry and protocol mention mempal_brief
+  Test:
+    Filter: test_mcp_tool_registry_and_protocol_include_mempal_brief
+    Targets: tool registry and protocol.
+  When inspecting MCP tools and memory protocol
+  Then `mempal_brief` is advertised
+
+## Out of Scope
+
+- LLM synthesis.
+- Adoption capture.
+- CLI brief changes.

--- a/specs/p103-adoption-analytics.spec.md
+++ b/specs/p103-adoption-analytics.spec.md
@@ -1,0 +1,73 @@
+spec: task
+name: "P103: adoption analytics"
+inherits: project
+tags: [phase3, adoption, analytics, phase-5]
+---
+
+## Intent
+
+P103 adds an operator-facing analytics surface over runtime adoption evidence.
+The system has many explicit adoption signals; operators need a compact way to
+see which surfaces are useful, risky, or missing evidence before changing
+defaults or workflows.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption analytics --format plain|json`.
+- Add MCP action `mempal_phase3 action=analytics`.
+- Analytics groups events by `track` and `feature`.
+- Each group reports total, accepted, rejected, misses, rollbacks,
+  contradictions, and a deterministic recommendation.
+- Analytics is read-only and does not write adoption events.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p103-adoption-analytics.spec.md
+- docs/plans/2026-05-26-p103-adoption-analytics.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not change promotion gates.
+- Do not change card context defaults.
+- Do not mutate runtime adoption events.
+
+## Acceptance Criteria
+
+Scenario: CLI analytics groups accepted and rejected evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_analytics_json
+    Targets: `phase3 adoption analytics`.
+  Given runtime adoption events exist for two features
+  When `mempal phase3 adoption analytics --format json` runs
+  Then JSON reports `writes=false`
+  And contains grouped feature analytics
+  And contains deterministic recommendations
+
+Scenario: CLI analytics plain output is compact
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_analytics_plain
+    Targets: plain output.
+  When `phase3 adoption analytics --format plain` runs
+  Then stdout contains `adoption analytics`
+  And stdout includes feature-level counts
+
+Scenario: MCP analytics mirrors CLI report shape
+  Test:
+    Filter: test_mcp_phase3_adoption_analytics_action
+    Targets: `mempal_phase3 action=analytics`.
+  When MCP action `analytics` runs
+  Then the response includes an analytics report
+  And no DB mutations occur
+
+## Out of Scope
+
+- Graph rendering.
+- Threshold tuning.
+- Automatic default changes.

--- a/specs/p104-release-readiness-checklist.spec.md
+++ b/specs/p104-release-readiness-checklist.spec.md
@@ -1,0 +1,73 @@
+spec: task
+name: "P104: release readiness checklist"
+inherits: project
+tags: [release, readiness, checklist, phase-5]
+---
+
+## Intent
+
+P104 adds a deterministic release readiness checklist for real-world use. After
+P82-P103 the project has many runtime surfaces; release operators need a single
+read-only command that checks documentation, specs/plans, install diagnostics,
+and package metadata before publishing or recommending an install.
+
+## Decisions
+
+- Add CLI `mempal release-readiness --format plain|json`.
+- The checklist reports `ready`, `writes=false`, individual checks, warnings,
+  and recommended commands.
+- Checks include Cargo package metadata, README presence, P98-P104 spec/plan
+  inventory, runbooks, doctor availability, and current DB schema support.
+- The command is read-only and does not run `cargo package`.
+- P104 updates AGENTS / CLAUDE inventory through P104.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p104-release-readiness-checklist.spec.md
+- docs/plans/2026-05-26-p104-release-readiness-checklist.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/main.rs
+- tests/ops_runtime.rs
+
+### Forbidden
+- Do not publish to crates.io.
+- Do not run network operations.
+- Do not create or modify DB state.
+
+## Acceptance Criteria
+
+Scenario: CLI release readiness JSON reports required checks
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_release_readiness_json
+    Targets: `release-readiness`.
+  When `mempal release-readiness --format json` runs from the repo root
+  Then JSON reports `writes=false`
+  And includes checks for `cargo-metadata`
+  And includes checks for `spec-plan-inventory`
+  And includes recommended verification commands
+
+Scenario: CLI release readiness plain output is actionable
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_release_readiness_plain
+    Targets: plain output.
+  When `mempal release-readiness --format plain` runs
+  Then stdout contains `Release Readiness`
+  And stdout contains `cargo package`
+  And stdout contains `mempal doctor`
+
+Scenario: CLI release readiness rejects unsupported format
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_release_readiness_rejects_invalid_format
+    Targets: format validation.
+  When `mempal release-readiness --format yaml` runs
+  Then the command fails
+  And stderr mentions `unsupported release-readiness format`
+
+## Out of Scope
+
+- Publishing.
+- GitHub release creation.
+- Running package builds automatically.

--- a/specs/p98-release-install-doctor.spec.md
+++ b/specs/p98-release-install-doctor.spec.md
@@ -1,0 +1,82 @@
+spec: task
+name: "P98: release install doctor"
+inherits: project
+tags: [doctor, release, install, schema, phase-5]
+---
+
+## Intent
+
+P98 adds an operator-facing release/install diagnostic surface. The immediate
+problem is that a user or agent can run an older `mempal` binary against a newer
+schema v9 database and see confusing failures. The doctor should explain binary,
+PATH, and database schema compatibility without migrating or mutating state.
+
+## Decisions
+
+- Add CLI `mempal doctor --format plain|json`.
+- Doctor runs before normal `Database::open` so it can report DB compatibility
+  instead of failing on schema mismatch.
+- Doctor reads SQLite `PRAGMA user_version` directly when `palace.db` exists.
+- Doctor reports current binary version, supported schema version, configured
+  DB path, DB schema version, current executable path, first `mempal` on PATH,
+  warnings, and recommendations.
+- Doctor is read-only and never creates `palace.db` or config files.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p98-release-install-doctor.spec.md
+- docs/plans/2026-05-26-p98-release-install-doctor.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/doctor.rs
+- src/lib.rs
+- src/main.rs
+- tests/ops_runtime.rs
+
+### Forbidden
+- Do not run `cargo install` from doctor.
+- Do not migrate or create the database from doctor.
+- Do not require network access.
+- Do not remove support for existing `status`.
+
+## Acceptance Criteria
+
+Scenario: CLI doctor reports schema and install path diagnostics
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_doctor_json_reports_schema_and_path
+    Targets: `src/main.rs` `mempal doctor`.
+  Given a temp HOME with an existing schema v9 `palace.db`
+  And PATH resolves `mempal` to a different executable path
+  When `mempal doctor --format json` runs
+  Then JSON includes `current_version`
+  And JSON includes `supported_schema_version=9`
+  And JSON includes `db_schema_version=9`
+  And JSON includes a warning containing `PATH`
+
+Scenario: CLI doctor is read-only without an existing database
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_doctor_plain_no_db_is_read_only
+    Targets: read-only missing-db behavior.
+  Given a temp HOME without `.mempal/palace.db`
+  When `mempal doctor --format plain` runs
+  Then the command succeeds
+  And stdout reports `db_exists=false`
+  And no `palace.db` file is created
+
+Scenario: CLI doctor rejects unsupported format without side effects
+  Test:
+    Filter: cargo test --test ops_runtime test_cli_doctor_rejects_invalid_format
+    Targets: format validation.
+  Given a temp HOME without `.mempal/palace.db`
+  When `mempal doctor --format yaml` runs
+  Then the command fails
+  And stderr mentions `unsupported doctor format`
+  And no `palace.db` file is created
+
+## Out of Scope
+
+- Self-upgrade or install execution.
+- GitHub release lookup.
+- MCP runtime diagnostics; P99 covers the MCP surface.

--- a/specs/p99-mcp-runtime-doctor.spec.md
+++ b/specs/p99-mcp-runtime-doctor.spec.md
@@ -1,0 +1,74 @@
+spec: task
+name: "P99: MCP runtime doctor"
+inherits: project
+tags: [doctor, mcp, runtime, phase-5]
+---
+
+## Intent
+
+P99 exposes the P98 diagnostic surface to agent runtimes. Agents need a direct
+MCP call that confirms the server they are connected to knows the current
+tooling surface, especially after installing a newer binary where old MCP
+processes may still be running.
+
+## Decisions
+
+- Add MCP tool `mempal_doctor`.
+- `mempal_doctor` returns P98 release/install diagnostics plus MCP tool/action
+  expectations for the current server.
+- The MCP response includes whether required tools are advertised:
+  `mempal_context`, `mempal_brief`, `mempal_phase3`, and `mempal_cowork_bus`.
+- The response includes expected `mempal_cowork_bus` and `mempal_phase3`
+  actions as static capability metadata.
+- The tool is read-only and does not open the DB through migration paths.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p99-mcp-runtime-doctor.spec.md
+- docs/plans/2026-05-26-p99-mcp-runtime-doctor.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/doctor.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- src/core/protocol.rs
+
+### Forbidden
+- Do not restart MCP clients or server processes.
+- Do not install hooks or modify user config.
+- Do not infer client-side tool visibility beyond the server's advertised tools.
+
+## Acceptance Criteria
+
+Scenario: MCP doctor is registered and documented
+  Test:
+    Filter: test_mcp_tool_registry_includes_mempal_doctor
+    Targets: `src/mcp/server.rs` tool registry.
+  When listing MCP tools
+  Then `mempal_doctor` is present
+  And its description mentions MCP runtime diagnostics
+
+Scenario: MCP doctor reports required server tools
+  Test:
+    Filter: test_mcp_doctor_reports_runtime_tools
+    Targets: `mempal_doctor`.
+  Given a test MCP server
+  When `mempal_doctor` runs
+  Then the response reports `mempal_context`
+  And the response reports `mempal_phase3`
+  And the response reports `mempal_cowork_bus`
+
+Scenario: Protocol advertises mempal_doctor
+  Test:
+    Filter: test_mcp_tool_registry_and_protocol_include_mempal_doctor
+    Targets: `src/core/protocol.rs`.
+  When inspecting the memory protocol
+  Then it mentions `mempal_doctor`
+
+## Out of Scope
+
+- Client process restart automation.
+- Remote MCP client introspection.
+- GitHub or network diagnostics.

--- a/src/adoption_analytics.rs
+++ b/src/adoption_analytics.rs
@@ -1,0 +1,99 @@
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::core::types::{RuntimeAdoptionEvent, RuntimeAdoptionSignal, RuntimeAdoptionTrack};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeAdoptionAnalyticsReport {
+    pub writes: bool,
+    pub total_events: usize,
+    pub groups: Vec<RuntimeAdoptionAnalyticsGroup>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeAdoptionAnalyticsGroup {
+    pub track: String,
+    pub feature: String,
+    pub total: usize,
+    pub used: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub misses: usize,
+    pub rollbacks: usize,
+    pub contradictions: usize,
+    pub neutral: usize,
+    pub recommendation: String,
+}
+
+pub fn build_runtime_adoption_analytics(
+    events: &[RuntimeAdoptionEvent],
+) -> RuntimeAdoptionAnalyticsReport {
+    let mut groups = BTreeMap::<(String, String), RuntimeAdoptionAnalyticsGroup>::new();
+    for event in events {
+        let track = runtime_adoption_track_slug(&event.track).to_string();
+        let feature = event.feature.clone();
+        let group = groups.entry((track.clone(), feature.clone())).or_insert(
+            RuntimeAdoptionAnalyticsGroup {
+                track,
+                feature,
+                total: 0,
+                used: 0,
+                accepted: 0,
+                rejected: 0,
+                misses: 0,
+                rollbacks: 0,
+                contradictions: 0,
+                neutral: 0,
+                recommendation: String::new(),
+            },
+        );
+        group.total += 1;
+        match event.signal {
+            RuntimeAdoptionSignal::Used => group.used += 1,
+            RuntimeAdoptionSignal::Accepted => group.accepted += 1,
+            RuntimeAdoptionSignal::Rejected => group.rejected += 1,
+            RuntimeAdoptionSignal::Miss => group.misses += 1,
+            RuntimeAdoptionSignal::Rollback => group.rollbacks += 1,
+            RuntimeAdoptionSignal::Contradiction => group.contradictions += 1,
+            RuntimeAdoptionSignal::Neutral => group.neutral += 1,
+        }
+    }
+
+    let mut groups = groups.into_values().collect::<Vec<_>>();
+    for group in &mut groups {
+        group.recommendation = recommendation_for(group).to_string();
+    }
+
+    RuntimeAdoptionAnalyticsReport {
+        writes: false,
+        total_events: events.len(),
+        groups,
+    }
+}
+
+fn recommendation_for(group: &RuntimeAdoptionAnalyticsGroup) -> &'static str {
+    if group.rollbacks > 0 || group.contradictions > 0 {
+        return "review_before_default_change";
+    }
+    if group.misses > group.accepted {
+        return "investigate_misses";
+    }
+    if group.rejected > group.accepted {
+        return "observe_or_rollback";
+    }
+    if group.accepted >= 3 && group.rejected <= group.accepted {
+        return "candidate_for_workflow_hardening";
+    }
+    "observe_more_evidence"
+}
+
+fn runtime_adoption_track_slug(track: &RuntimeAdoptionTrack) -> &'static str {
+    match track {
+        RuntimeAdoptionTrack::RuntimeAdoption => "runtime_adoption",
+        RuntimeAdoptionTrack::CardContext => "card_context",
+        RuntimeAdoptionTrack::CardEmbedding => "card_embedding",
+        RuntimeAdoptionTrack::Evaluator => "evaluator",
+        RuntimeAdoptionTrack::ResearchAdapter => "research_adapter",
+    }
+}

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -18,7 +18,7 @@ use super::types::{
 };
 use super::utils::{build_tunnel_id, current_timestamp, format_tunnel_endpoint};
 
-const CURRENT_SCHEMA_VERSION: u32 = 9;
+pub const CURRENT_SCHEMA_VERSION: u32 = 9;
 const DRAWER_SELECT_COLUMNS: &str = r#"
     id,
     content,

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -73,7 +73,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    mempal_search to verify project facts, past decisions, and citations.
    Do not use wake-up as a substitute for mempal_context when you need typed
    dao/shu/qi guidance; wake-up preserves a refresh-oriented L0/L1 shape.
-   Use CLI `mempal brief <query>` when a human or agent needs a compact
+   Use CLI `mempal brief <query>` or MCP `mempal_brief` when a human or agent needs a compact
    citation-first cognitive report rather than raw retrieval: it organizes key
    facts, evidence, cards, unresolved cues, uncertainty, and next actions
    without LLM synthesis or database writes.
@@ -175,7 +175,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    action=heartbeat to update explicit last-seen presence, and
    action=channel_set/channel_list/channel_send to manage named group
    channels. Use action=doctor for read-only diagnostics, session_create/
-   session_list/session_status for runtime team sessions, action=handoff for
+   session_list/session_status/session_close for runtime team sessions, action=handoff for
    deterministic handoff summaries, and action=capture only when you
    explicitly want to lift a handoff summary into evidence memory.
    Each target has an independent inbox under the project bus, so
@@ -242,7 +242,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/analytics/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=instrumentation_policy before building live tool instrumentation:
@@ -286,6 +286,8 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    warning records require allow_warnings=true, and invalid records are blocked.
    Use action=review to summarize accumulated evidence by track, feature, and
    signal before proposing stronger defaults; review is read-only and advisory.
+   Use action=analytics for compact grouped counts and deterministic
+   recommendations by track and feature; analytics is read-only.
    Use action=readiness with candidate=card-context-default to inspect whether
    card-aware context is eligible for a future default-on spec; readiness is
    read-only and does not enable the default.
@@ -302,14 +304,16 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
+  mempal_doctor        — release/install and MCP runtime diagnostics
   mempal_search        — semantic search with wing/room filters, citation-bearing
   mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi; evidence/cards opt-in)
+  mempal_brief         — citation-first cognitive brief with summary/facts/evidence/cards/uncertainty
   mempal_field_taxonomy — read-only recommended mind-model field values
   mempal_knowledge_distill — create candidate knowledge from evidence refs
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/analytics/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication
@@ -320,7 +324,7 @@ TOOLS:
   mempal_tunnels       — discover cross-wing room links
   mempal_peek_partner  — read partner agent's live session (Claude ↔ Codex), pure read
   mempal_cowork_push   — send a short handoff message to partner agent (P8)
-  mempal_cowork_bus    — concrete agent_id multi-agent bus register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/handoff/capture, with opt-in transport=tmux, event replay, delivery ack/status, presence, group channels, read-only tmux pane peek, diagnostics, sessions, handoff summaries, and explicit handoff-to-evidence capture (P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96)
+  mempal_cowork_bus    — concrete agent_id multi-agent bus register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/session_close/handoff/capture, with opt-in transport=tmux, event replay, delivery ack/status, presence, group channels, read-only tmux pane peek, diagnostics, sessions, handoff summaries, and explicit handoff-to-evidence capture (P85/P86/P87/P88/P89/P90/P91/P93/P94/P95/P96/P101)
   mempal_fact_check    — offline contradiction detection vs KG triples + entities (P9)
 
 Key invariant: mempal stores raw text verbatim. Every search result can be

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,190 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+
+use crate::core::db::CURRENT_SCHEMA_VERSION;
+
+pub const REQUIRED_MCP_TOOLS: &[&str] = &[
+    "mempal_context",
+    "mempal_brief",
+    "mempal_phase3",
+    "mempal_cowork_bus",
+];
+
+pub const PHASE3_ACTIONS: &[&str] = &[
+    "guidance",
+    "instrumentation_policy",
+    "prepare_record",
+    "capture",
+    "evaluator_advise",
+    "default_proposal",
+    "rollback_control",
+    "check_record",
+    "record_checked",
+    "review",
+    "readiness",
+    "analytics",
+    "record",
+    "list",
+    "stats",
+    "gate",
+    "research_validate_plan",
+    "research_ingest_plan",
+];
+
+pub const COWORK_BUS_ACTIONS: &[&str] = &[
+    "register",
+    "list",
+    "send",
+    "broadcast",
+    "drain",
+    "events",
+    "deliveries",
+    "ack",
+    "heartbeat",
+    "channel_set",
+    "channel_list",
+    "channel_send",
+    "tmux_peek",
+    "doctor",
+    "session_create",
+    "session_list",
+    "session_status",
+    "session_close",
+    "handoff",
+    "capture",
+];
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorReport {
+    pub current_version: String,
+    pub supported_schema_version: u32,
+    pub db: DoctorDbReport,
+    pub install: DoctorInstallReport,
+    pub warnings: Vec<String>,
+    pub recommendations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorDbReport {
+    pub path: String,
+    pub exists: bool,
+    pub schema_version: Option<u32>,
+    pub compatible: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorInstallReport {
+    pub current_exe: Option<String>,
+    pub path_mempal: Option<String>,
+    pub path_matches_current_exe: Option<bool>,
+}
+
+pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
+    let db = inspect_db(db_path);
+    let install = inspect_install();
+    let mut warnings = Vec::new();
+    let mut recommendations = vec![
+        "Run `mempal doctor --format json` after installing or upgrading mempal.".to_string(),
+        "If PATH points at an older binary, restart the MCP client after updating PATH."
+            .to_string(),
+    ];
+
+    if db.exists && !db.compatible {
+        warnings.push(format!(
+            "database schema is not compatible with this binary: found {:?}, supported {}",
+            db.schema_version, CURRENT_SCHEMA_VERSION
+        ));
+        recommendations
+            .push("Install a mempal binary that supports this palace.db schema.".to_string());
+    }
+    if let Some(error) = db.error.as_deref() {
+        warnings.push(format!("database schema could not be inspected: {error}"));
+    }
+    if install.path_matches_current_exe == Some(false) {
+        warnings
+            .push("PATH resolves mempal to a different executable than this process".to_string());
+        recommendations
+            .push("Check `which mempal` and restart long-lived MCP clients.".to_string());
+    }
+    if install.path_mempal.is_none() {
+        warnings.push("PATH does not contain a mempal executable".to_string());
+    }
+
+    DoctorReport {
+        current_version: env!("CARGO_PKG_VERSION").to_string(),
+        supported_schema_version: CURRENT_SCHEMA_VERSION,
+        db,
+        install,
+        warnings,
+        recommendations,
+    }
+}
+
+fn inspect_db(db_path: &Path) -> DoctorDbReport {
+    if !db_path.exists() {
+        return DoctorDbReport {
+            path: db_path.display().to_string(),
+            exists: false,
+            schema_version: None,
+            compatible: true,
+            error: None,
+        };
+    }
+
+    match read_schema_version_read_only(db_path) {
+        Ok(schema_version) => DoctorDbReport {
+            path: db_path.display().to_string(),
+            exists: true,
+            schema_version: Some(schema_version),
+            compatible: schema_version <= CURRENT_SCHEMA_VERSION,
+            error: None,
+        },
+        Err(error) => DoctorDbReport {
+            path: db_path.display().to_string(),
+            exists: true,
+            schema_version: None,
+            compatible: false,
+            error: Some(error),
+        },
+    }
+}
+
+fn read_schema_version_read_only(db_path: &Path) -> Result<u32, String> {
+    let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|error| error.to_string())?;
+    conn.pragma_query_value(None, "user_version", |row| row.get::<_, u32>(0))
+        .map_err(|error| error.to_string())
+}
+
+fn inspect_install() -> DoctorInstallReport {
+    let current_exe = env::current_exe().ok();
+    let path_mempal = find_path_executable("mempal");
+    let path_matches_current_exe = match (current_exe.as_ref(), path_mempal.as_ref()) {
+        (Some(current), Some(path_mempal)) => Some(paths_match(current, path_mempal)),
+        (_, Some(_)) => None,
+        _ => None,
+    };
+
+    DoctorInstallReport {
+        current_exe: current_exe.map(|path| path.display().to_string()),
+        path_mempal: path_mempal.map(|path| path.display().to_string()),
+        path_matches_current_exe,
+    }
+}
+
+fn find_path_executable(name: &str) -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|candidate| candidate.is_file())
+}
+
+fn paths_match(left: &Path, right: &Path) -> bool {
+    let left = left.canonicalize().unwrap_or_else(|_| left.to_path_buf());
+    let right = right.canonicalize().unwrap_or_else(|_| right.to_path_buf());
+    left == right
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 #![warn(clippy::all)]
 
 pub mod aaak;
+pub mod adoption_analytics;
 #[cfg(feature = "rest")]
 pub mod api;
 pub mod brief;
 pub mod context;
 pub mod core;
 pub mod cowork;
+pub mod doctor;
 pub mod embed;
 pub mod factcheck;
 pub mod field_taxonomy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::env;
+use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -10,6 +11,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use mempal::aaak::{AaakCodec, AaakMeta};
+use mempal::adoption_analytics::{
+    RuntimeAdoptionAnalyticsReport, build_runtime_adoption_analytics,
+};
 #[cfg(feature = "rest")]
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
 use mempal::brief::{BriefRequest, CognitiveBrief, assemble_brief};
@@ -17,7 +21,7 @@ use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
     anchor,
     config::Config,
-    db::Database,
+    db::{CURRENT_SCHEMA_VERSION, Database},
     phase3::{
         CardContextDefaultProposalReport, CardContextRollbackControlReport, EvaluatorAdviceInput,
         EvaluatorAdviceReport, Phase3ReadinessReport, ResearchIngestPlanReport,
@@ -42,6 +46,7 @@ use mempal::core::{
     },
     utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
 };
+use mempal::doctor::{DoctorReport, build_doctor_report};
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
 use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
 use mempal::ingest::{
@@ -87,6 +92,10 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    Doctor {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     Init {
         dir: PathBuf,
         #[arg(long)]
@@ -457,6 +466,19 @@ enum Commands {
         #[arg(long)]
         status: String,
     },
+    /// Close a runtime team session and optionally capture its handoff summary.
+    CoworkSessionClose {
+        #[arg(long)]
+        cwd: PathBuf,
+        #[arg(long)]
+        session_id: String,
+        #[arg(long)]
+        capture: bool,
+        #[arg(long)]
+        execute: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     /// Build a deterministic multi-agent handoff summary.
     CoworkHandoff {
         #[arg(long)]
@@ -497,6 +519,22 @@ enum Commands {
     },
     /// Print the governed maintenance runbook.
     MaintenanceRunbook {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Maintenance {
+        #[command(subcommand)]
+        command: MaintenanceCommands,
+    },
+    ReleaseReadiness {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum MaintenanceCommands {
+    GuidedRun {
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -1054,6 +1092,10 @@ enum Phase3AdoptionCommands {
         #[arg(long, default_value = "plain")]
         format: String,
     },
+    Analytics {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     Record {
         #[arg(long)]
         track: String,
@@ -1165,6 +1207,17 @@ async fn run() -> Result<()> {
     // or config to exist. Dispatch them BEFORE Config::load / Database::open
     // so a missing mempal_home never breaks the hook path.
     match cli.command {
+        Commands::Doctor { format } => {
+            return doctor_command(&format);
+        }
+        Commands::ReleaseReadiness { format } => {
+            return release_readiness_command(&format);
+        }
+        Commands::Maintenance {
+            command: MaintenanceCommands::GuidedRun { format },
+        } => {
+            return maintenance_guided_run_command(&format);
+        }
         Commands::CoworkDrain {
             target,
             cwd,
@@ -1318,6 +1371,15 @@ async fn run() -> Result<()> {
             status,
         } => {
             return cowork_session_status_command(cwd, session_id, status);
+        }
+        Commands::CoworkSessionClose {
+            cwd,
+            session_id,
+            capture,
+            execute,
+            format,
+        } => {
+            return cowork_session_close_command(cwd, session_id, capture, execute, format);
         }
         Commands::CoworkHandoff {
             cwd,
@@ -1530,9 +1592,13 @@ async fn run() -> Result<()> {
         | Commands::CoworkSessionCreate { .. }
         | Commands::CoworkSessions { .. }
         | Commands::CoworkSessionStatus { .. }
+        | Commands::CoworkSessionClose { .. }
         | Commands::CoworkHandoff { .. }
         | Commands::CoworkCapture { .. }
-        | Commands::MaintenanceRunbook { .. } => unreachable!(),
+        | Commands::MaintenanceRunbook { .. }
+        | Commands::Maintenance { .. }
+        | Commands::Doctor { .. }
+        | Commands::ReleaseReadiness { .. } => unreachable!(),
     }
 }
 
@@ -1567,6 +1633,370 @@ struct BriefCommandArgs {
     format: String,
     max_items: usize,
     dao_tian_limit: usize,
+}
+
+fn doctor_command(format: &str) -> Result<()> {
+    if !matches!(format, "plain" | "json") {
+        bail!("unsupported doctor format: {format}");
+    }
+    let (config, config_error) = match Config::load() {
+        Ok(config) => (config, None),
+        Err(error) => (Config::default(), Some(error.to_string())),
+    };
+    let mut report = build_doctor_report(&expand_home(&config.db_path));
+    if let Some(error) = config_error {
+        report.warnings.push(format!(
+            "config could not be loaded; using defaults: {error}"
+        ));
+    }
+
+    match format {
+        "plain" => print_doctor_plain(&report),
+        "json" => println!(
+            "{}",
+            serde_json::to_string_pretty(&report).context("failed to serialize doctor report")?
+        ),
+        _ => unreachable!("doctor format was validated"),
+    }
+    Ok(())
+}
+
+fn print_doctor_plain(report: &DoctorReport) {
+    println!("mempal doctor");
+    println!("current_version={}", report.current_version);
+    println!(
+        "supported_schema_version={}",
+        report.supported_schema_version
+    );
+    println!("db_path={}", report.db.path);
+    println!("db_exists={}", report.db.exists);
+    match report.db.schema_version {
+        Some(schema_version) => println!("db_schema_version={schema_version}"),
+        None => println!("db_schema_version=unknown"),
+    }
+    println!("db_compatible={}", report.db.compatible);
+    if let Some(error) = report.db.error.as_deref() {
+        println!("db_error={error}");
+    }
+    println!(
+        "current_exe={}",
+        report.install.current_exe.as_deref().unwrap_or("unknown")
+    );
+    println!(
+        "path_mempal={}",
+        report.install.path_mempal.as_deref().unwrap_or("not_found")
+    );
+    match report.install.path_matches_current_exe {
+        Some(matches) => println!("path_matches_current_exe={matches}"),
+        None => println!("path_matches_current_exe=unknown"),
+    }
+    for warning in &report.warnings {
+        println!("warning={warning}");
+    }
+    for recommendation in &report.recommendations {
+        println!("recommendation={recommendation}");
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct GuidedMaintenanceReport {
+    writes: bool,
+    drawer_count: u64,
+    runtime_adoption_event_count: u64,
+    card_count: u64,
+    steps: Vec<GuidedMaintenanceStep>,
+}
+
+#[derive(Debug, Serialize)]
+struct GuidedMaintenanceStep {
+    order: usize,
+    phase: &'static str,
+    purpose: &'static str,
+    command: &'static str,
+    writes: bool,
+}
+
+fn maintenance_guided_run_command(format: &str) -> Result<()> {
+    if !matches!(format, "plain" | "json") {
+        bail!("unsupported maintenance guided-run format: {format}");
+    }
+    let config = Config::load().unwrap_or_default();
+    let db_path = expand_home(&config.db_path);
+    let report = GuidedMaintenanceReport {
+        writes: false,
+        drawer_count: sqlite_count_if_available(&db_path, "drawers"),
+        runtime_adoption_event_count: sqlite_count_if_available(
+            &db_path,
+            "runtime_adoption_events",
+        ),
+        card_count: sqlite_count_if_available(&db_path, "knowledge_cards"),
+        steps: guided_maintenance_steps(),
+    };
+
+    match format {
+        "plain" => print_guided_maintenance_plain(&report),
+        "json" => println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .context("failed to serialize guided maintenance report")?
+        ),
+        _ => unreachable!("maintenance guided-run format was validated"),
+    }
+    Ok(())
+}
+
+fn guided_maintenance_steps() -> Vec<GuidedMaintenanceStep> {
+    vec![
+        GuidedMaintenanceStep {
+            order: 1,
+            phase: "research",
+            purpose: "Validate external research output before any ingest.",
+            command: "mempal phase3 research-validate-plan report.json --format json",
+            writes: false,
+        },
+        GuidedMaintenanceStep {
+            order: 2,
+            phase: "research",
+            purpose: "Preview evidence drawers and candidate distill suggestions.",
+            command: "mempal phase3 research-ingest-plan report.json --format json",
+            writes: false,
+        },
+        GuidedMaintenanceStep {
+            order: 3,
+            phase: "research",
+            purpose: "Explicitly ingest validated research findings as evidence only.",
+            command: "mempal phase3 research-ingest-plan report.json --execute --format json",
+            writes: true,
+        },
+        GuidedMaintenanceStep {
+            order: 4,
+            phase: "knowledge",
+            purpose: "Create candidate knowledge from explicit evidence refs.",
+            command: "mempal knowledge distill --statement ... --content ... --tier dao_ren --supporting-ref drawer_...",
+            writes: true,
+        },
+        GuidedMaintenanceStep {
+            order: 5,
+            phase: "cards",
+            purpose: "Check card lifecycle readiness before promotion.",
+            command: "mempal knowledge-card gate card_... --format json",
+            writes: false,
+        },
+        GuidedMaintenanceStep {
+            order: 6,
+            phase: "runtime",
+            purpose: "Assemble card-aware context explicitly before changing defaults.",
+            command: "mempal context \"current task\" --include-cards --format plain",
+            writes: false,
+        },
+        GuidedMaintenanceStep {
+            order: 7,
+            phase: "runtime",
+            purpose: "Review runtime adoption evidence by track and feature.",
+            command: "mempal phase3 adoption review --format json",
+            writes: false,
+        },
+        GuidedMaintenanceStep {
+            order: 8,
+            phase: "runtime",
+            purpose: "Inspect rollback evidence before keeping card context enabled.",
+            command: "mempal phase3 rollback-control card-context --format json",
+            writes: false,
+        },
+        GuidedMaintenanceStep {
+            order: 9,
+            phase: "cowork",
+            purpose: "Diagnose concrete agent bus state for the current project.",
+            command: "mempal cowork-doctor --cwd \"$PWD\" --format plain",
+            writes: false,
+        },
+        GuidedMaintenanceStep {
+            order: 10,
+            phase: "cowork",
+            purpose: "Build a deterministic handoff summary before session close.",
+            command: "mempal cowork-handoff --cwd \"$PWD\" --format plain",
+            writes: false,
+        },
+        GuidedMaintenanceStep {
+            order: 11,
+            phase: "cowork",
+            purpose: "Explicitly lift a handoff summary into evidence memory when needed.",
+            command: "mempal cowork-capture --cwd \"$PWD\" --summary-source handoff --execute --format json",
+            writes: true,
+        },
+    ]
+}
+
+fn print_guided_maintenance_plain(report: &GuidedMaintenanceReport) {
+    println!("Guided Maintenance Run");
+    println!("writes={}", report.writes);
+    println!("drawer_count={}", report.drawer_count);
+    println!(
+        "runtime_adoption_event_count={}",
+        report.runtime_adoption_event_count
+    );
+    println!("card_count={}", report.card_count);
+    for step in &report.steps {
+        println!();
+        println!("{}. {} ({})", step.order, step.phase, step.purpose);
+        println!("command: {}", step.command);
+        println!("writes={}", step.writes);
+    }
+}
+
+fn sqlite_count_if_available(db_path: &Path, table: &str) -> u64 {
+    if !db_path.exists() {
+        return 0;
+    }
+    let Ok(conn) =
+        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+    else {
+        return 0;
+    };
+    let sql = format!("SELECT COUNT(*) FROM {table}");
+    conn.query_row(&sql, [], |row| row.get::<_, i64>(0))
+        .ok()
+        .and_then(|count| u64::try_from(count).ok())
+        .unwrap_or(0)
+}
+
+#[derive(Debug, Serialize)]
+struct ReleaseReadinessReport {
+    writes: bool,
+    ready: bool,
+    supported_schema_version: u32,
+    checks: Vec<ReleaseReadinessCheck>,
+    warnings: Vec<String>,
+    recommended_commands: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReleaseReadinessCheck {
+    name: &'static str,
+    passed: bool,
+    detail: String,
+}
+
+fn release_readiness_command(format: &str) -> Result<()> {
+    if !matches!(format, "plain" | "json") {
+        bail!("unsupported release-readiness format: {format}");
+    }
+    let cwd = env::current_dir().context("failed to read current directory")?;
+    let report = build_release_readiness_report(&cwd);
+    match format {
+        "plain" => print_release_readiness_plain(&report),
+        "json" => println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .context("failed to serialize release readiness report")?
+        ),
+        _ => unreachable!("release-readiness format was validated"),
+    }
+    Ok(())
+}
+
+fn build_release_readiness_report(repo_root: &Path) -> ReleaseReadinessReport {
+    let cargo_toml = fs::read_to_string(repo_root.join("Cargo.toml")).unwrap_or_default();
+    let spec_plan_complete = (98..=104).all(|number| {
+        has_file_with_prefix(&repo_root.join("specs"), &format!("p{number}-"))
+            && has_file_name_containing(&repo_root.join("docs/plans"), &format!("p{number}"))
+    });
+    let checks = vec![
+        ReleaseReadinessCheck {
+            name: "cargo-metadata",
+            passed: cargo_toml.contains("name = \"mempal\"")
+                && cargo_toml.contains("version = ")
+                && cargo_toml.contains("readme = \"README.md\""),
+            detail: "Cargo.toml includes package name, version, and README metadata".to_string(),
+        },
+        ReleaseReadinessCheck {
+            name: "readme-docs",
+            passed: repo_root.join("README.md").is_file()
+                && repo_root.join("README_zh.md").is_file(),
+            detail: "README.md and README_zh.md are present".to_string(),
+        },
+        ReleaseReadinessCheck {
+            name: "spec-plan-inventory",
+            passed: spec_plan_complete,
+            detail: "P98-P104 each have a task spec and matching plan file".to_string(),
+        },
+        ReleaseReadinessCheck {
+            name: "runbooks",
+            passed: repo_root.join("docs/COWORK-RUNBOOK.md").is_file()
+                && repo_root.join("docs/MAINTENANCE-RUNBOOK.md").is_file(),
+            detail: "Cowork and maintenance runbooks are present".to_string(),
+        },
+        ReleaseReadinessCheck {
+            name: "doctor",
+            passed: true,
+            detail: "mempal doctor is available for install/runtime diagnostics".to_string(),
+        },
+        ReleaseReadinessCheck {
+            name: "schema-support",
+            passed: CURRENT_SCHEMA_VERSION == 9,
+            detail: format!("current supported schema version is {CURRENT_SCHEMA_VERSION}"),
+        },
+    ];
+    let warnings = checks
+        .iter()
+        .filter(|check| !check.passed)
+        .map(|check| format!("release check failed: {}", check.name))
+        .collect::<Vec<_>>();
+    let ready = warnings.is_empty();
+    ReleaseReadinessReport {
+        writes: false,
+        ready,
+        supported_schema_version: CURRENT_SCHEMA_VERSION,
+        checks,
+        warnings,
+        recommended_commands: vec![
+            "mempal doctor --format json".to_string(),
+            "cargo test".to_string(),
+            "cargo clippy -- -D warnings".to_string(),
+            "cargo package".to_string(),
+        ],
+    }
+}
+
+fn has_file_with_prefix(dir: &Path, prefix: &str) -> bool {
+    fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.ok())
+        .any(|entry| entry.file_name().to_string_lossy().starts_with(prefix))
+}
+
+fn has_file_name_containing(dir: &Path, needle: &str) -> bool {
+    fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.ok())
+        .any(|entry| entry.file_name().to_string_lossy().contains(needle))
+}
+
+fn print_release_readiness_plain(report: &ReleaseReadinessReport) {
+    println!("Release Readiness");
+    println!("writes={}", report.writes);
+    println!("ready={}", report.ready);
+    println!(
+        "supported_schema_version={}",
+        report.supported_schema_version
+    );
+    for check in &report.checks {
+        println!(
+            "check={} passed={} detail={}",
+            check.name, check.passed, check.detail
+        );
+    }
+    for warning in &report.warnings {
+        println!("warning={warning}");
+    }
+    println!("recommended_commands:");
+    for command in &report.recommended_commands {
+        println!("- {command}");
+    }
 }
 
 async fn bench_command(config: &Config, command: BenchCommands) -> Result<()> {
@@ -3589,6 +4019,13 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+        Phase3AdoptionCommands::Analytics { format } => {
+            let events = db
+                .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10_000)
+                .context("failed to list runtime adoption events")?;
+            let report = build_runtime_adoption_analytics(&events);
+            print_runtime_adoption_analytics(&report, &format)
+        }
     }
 }
 
@@ -4369,6 +4806,49 @@ fn print_runtime_adoption_stats(stats: &RuntimeAdoptionStats, format: &str) -> R
             Ok(())
         }
         other => bail!("unsupported phase3 adoption format: {other}"),
+    }
+}
+
+fn print_runtime_adoption_analytics(
+    report: &RuntimeAdoptionAnalyticsReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("adoption analytics");
+            println!("writes={}", report.writes);
+            println!("total_events={}", report.total_events);
+            if report.groups.is_empty() {
+                println!("groups=none");
+            } else {
+                for group in &report.groups {
+                    println!(
+                        "track={} feature={} total={} used={} accepted={} rejected={} misses={} rollbacks={} contradictions={} neutral={} recommendation={}",
+                        group.track,
+                        group.feature,
+                        group.total,
+                        group.used,
+                        group.accepted,
+                        group.rejected,
+                        group.misses,
+                        group.rollbacks,
+                        group.contradictions,
+                        group.neutral,
+                        group.recommendation
+                    );
+                }
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption analytics")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption analytics format: {other}"),
     }
 }
 
@@ -5859,6 +6339,70 @@ fn cowork_session_status_command(cwd: PathBuf, session_id: String, status: Strin
     let mempal_home = inbox::mempal_home();
     let session = bus::update_session_status(&mempal_home, &cwd, &session_id, &status)?;
     println!("session {} status={}", session.session_id, session.status);
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct CoworkSessionCloseReport {
+    session: mempal::cowork::bus::TeamSession,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    capture: Option<mempal::cowork::bus::CoworkCaptureReport>,
+}
+
+fn cowork_session_close_command(
+    cwd: PathBuf,
+    session_id: String,
+    capture: bool,
+    execute: bool,
+    format: String,
+) -> Result<()> {
+    use mempal::cowork::bus::{self, CoworkCaptureRequest};
+    use mempal::cowork::inbox;
+
+    if !matches!(format.as_str(), "plain" | "json") {
+        bail!("unknown format: {format}");
+    }
+    let mempal_home = inbox::mempal_home();
+    let session = bus::update_session_status(&mempal_home, &cwd, &session_id, "closed")?;
+    let capture = if capture {
+        let db = if execute {
+            let config = Config::load().context("failed to load config")?;
+            Some(Database::open(&expand_home(&config.db_path)).context("failed to open database")?)
+        } else {
+            None
+        };
+        Some(bus::capture_handoff_to_memory(
+            db.as_ref(),
+            &mempal_home,
+            &cwd,
+            CoworkCaptureRequest {
+                summary_source: "handoff".to_string(),
+                wing: "cowork-capture".to_string(),
+                room: None,
+                thread_id: None,
+                channel: None,
+                session_id: Some(session_id),
+                note: Some("Session closed through cowork-session-close.".to_string()),
+                execute,
+            },
+        )?)
+    } else {
+        None
+    };
+    let report = CoworkSessionCloseReport { session, capture };
+    match format.as_str() {
+        "plain" => {
+            println!(
+                "session {} status={}",
+                report.session.session_id, report.session.status
+            );
+            if let Some(capture) = &report.capture {
+                print!("{}", bus::format_capture_plain(capture));
+            }
+        }
+        "json" => println!("{}", serde_json::to_string_pretty(&report)?),
+        _ => unreachable!("cowork-session-close format was validated"),
+    }
     Ok(())
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8119,10 +8119,7 @@ mod tests {
             .await
             .expect("close session");
         assert_eq!(response.0.sessions[0].status, "closed");
-        assert_eq!(
-            response.0.capture.as_ref().expect("capture payload").writes,
-            false
-        );
+        assert!(!response.0.capture.as_ref().expect("capture payload").writes);
         assert!(
             !db_path.exists(),
             "dry-run session_close capture must not create palace.db"

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use crate::adoption_analytics::build_runtime_adoption_analytics;
+use crate::brief::brief_from_context;
 use crate::context::assemble_context_with_vector;
 use crate::core::{
     anchor::{self, DerivedAnchor},
@@ -30,6 +32,7 @@ use crate::cowork::{
     AgentRecord, AgentStatus, BusError, DeliveryReport, InboxMessage, PeekError,
     PeekRequest as CoworkPeekRequest, Tool, peek_partner,
 };
+use crate::doctor::{COWORK_BUS_ACTIONS, PHASE3_ACTIONS, REQUIRED_MCP_TOOLS, build_doctor_report};
 use crate::embed::EmbedderFactory;
 use crate::field_taxonomy::field_taxonomy;
 use crate::ingest::{
@@ -67,12 +70,13 @@ use rmcp::{
 use serde_json::Value;
 
 use super::tools::{
-    ContextRequest, ContextResponse, CoworkBusAgentDto, CoworkBusCaptureDto, CoworkBusChannelDto,
-    CoworkBusDeliveryDto, CoworkBusDeliveryStatusDto, CoworkBusDoctorDto, CoworkBusEventDto,
-    CoworkBusHandoffAgentDto, CoworkBusHandoffDto, CoworkBusHandoffFiltersDto, CoworkBusMessageDto,
-    CoworkBusRequest, CoworkBusResponse, CoworkBusSessionDto, CoworkBusTmuxPeekDto,
-    CoworkBusTmuxProbeDto, CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse,
-    DuplicateWarning, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
+    BriefMcpRequest, BriefMcpResponse, ContextRequest, ContextResponse, CoworkBusAgentDto,
+    CoworkBusCaptureDto, CoworkBusChannelDto, CoworkBusDeliveryDto, CoworkBusDeliveryStatusDto,
+    CoworkBusDoctorDto, CoworkBusEventDto, CoworkBusHandoffAgentDto, CoworkBusHandoffDto,
+    CoworkBusHandoffFiltersDto, CoworkBusMessageDto, CoworkBusRequest, CoworkBusResponse,
+    CoworkBusSessionDto, CoworkBusTmuxPeekDto, CoworkBusTmuxProbeDto, CoworkPushRequest,
+    CoworkPushResponse, DeleteRequest, DeleteResponse, DoctorMcpDto, DoctorRequest, DoctorResponse,
+    DoctorToolDto, DuplicateWarning, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
     FieldTaxonomyResponse, IngestRequest, IngestResponse, KgRequest, KgResponse, KgStatsDto,
     KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse,
     KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
@@ -175,6 +179,28 @@ impl MempalMcpServer {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         self.mempal_context(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn doctor_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<DoctorResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_doctor(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn brief_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<BriefMcpResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_brief(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -1061,6 +1087,102 @@ impl MempalMcpServer {
     }
 
     #[tool(
+        name = "mempal_doctor",
+        description = "MCP runtime diagnostics for mempal install/schema compatibility and server-advertised runtime tools. Read-only; does not migrate or create the database."
+    )]
+    async fn mempal_doctor(
+        &self,
+        Parameters(_request): Parameters<DoctorRequest>,
+    ) -> std::result::Result<Json<DoctorResponse>, ErrorData> {
+        let advertised_tools = self.tool_router.list_all();
+        let mcp = DoctorMcpDto {
+            required_tools: REQUIRED_MCP_TOOLS
+                .iter()
+                .map(|name| DoctorToolDto {
+                    name: (*name).to_string(),
+                    advertised: advertised_tools.iter().any(|tool| tool.name == *name),
+                })
+                .collect(),
+            phase3_actions: PHASE3_ACTIONS
+                .iter()
+                .map(|action| (*action).to_string())
+                .collect(),
+            cowork_bus_actions: COWORK_BUS_ACTIONS
+                .iter()
+                .map(|action| (*action).to_string())
+                .collect(),
+        };
+        Ok(Json(DoctorResponse::from_report(
+            build_doctor_report(&self.db_path),
+            mcp,
+        )))
+    }
+
+    #[tool(
+        name = "mempal_brief",
+        description = "Assemble a deterministic citation-first cognitive brief from memory. Returns summary, key facts, evidence, cards, unresolved items, uncertainty, and next actions without LLM synthesis or writes."
+    )]
+    async fn mempal_brief(
+        &self,
+        Parameters(request): Parameters<BriefMcpRequest>,
+    ) -> std::result::Result<Json<BriefMcpResponse>, ErrorData> {
+        let max_items = request.max_items.unwrap_or(12);
+        if max_items == 0 {
+            return Err(ErrorData::invalid_params(
+                "max_items must be greater than 0",
+                None,
+            ));
+        }
+        let domain = parse_domain(request.domain.as_deref())?.unwrap_or(MemoryDomain::Project);
+        let cwd = match request.cwd.as_deref() {
+            Some(value) if !value.trim().is_empty() => PathBuf::from(value),
+            Some(_) => {
+                return Err(ErrorData::invalid_params(
+                    "cwd must not be empty when provided",
+                    None,
+                ));
+            }
+            None => std::env::current_dir().map_err(|error| {
+                ErrorData::internal_error(
+                    format!("failed to read current directory: {error}"),
+                    None,
+                )
+            })?,
+        };
+
+        let embedder = self.embedder_factory.build().await.map_err(|error| {
+            ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
+        })?;
+        let query_vector = embedder
+            .embed(&[request.query.as_str()])
+            .await
+            .map_err(|error| ErrorData::internal_error(format!("embedding failed: {error}"), None))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| ErrorData::internal_error("embedder returned no query vector", None))?;
+        let db = self.open_db()?;
+        let context = assemble_context_with_vector(
+            &db,
+            crate::context::ContextRequest {
+                query: request.query,
+                domain,
+                field: request
+                    .field
+                    .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
+                cwd,
+                include_evidence: true,
+                include_cards: true,
+                max_items,
+                dao_tian_limit: request.dao_tian_limit.unwrap_or(1),
+            },
+            &query_vector,
+        )
+        .map_err(|error| ErrorData::internal_error(format!("brief failed: {error}"), None))?;
+        let brief = brief_from_context(context);
+        Ok(Json(BriefMcpResponse::from(brief)))
+    }
+
+    #[tool(
         name = "mempal_knowledge_distill",
         description = "Create candidate knowledge from existing evidence drawer refs. Deterministic Stage-1 distill: writes memory_kind=knowledge/status=candidate for tier dao_ren or qi, validates refs are evidence drawers, and never calls an LLM, promotes, or creates Phase-2 knowledge cards."
     )]
@@ -1379,7 +1501,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; instrumentation_policy defines opt-in live instrumentation boundaries without writing; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; rollback_control evaluates card-context rollback evidence without writing; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/analytics/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; instrumentation_policy defines opt-in live instrumentation boundaries without writing; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; rollback_control evaluates card-context rollback evidence without writing; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; analytics groups adoption evidence by track and feature without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1400,6 +1522,7 @@ impl MempalMcpServer {
                 event: None,
                 events: Vec::new(),
                 stats: None,
+                analytics: None,
                 gate: None,
                 research_plan: None,
                 research_ingest_plan: None,
@@ -1418,6 +1541,7 @@ impl MempalMcpServer {
                 event: None,
                 events: Vec::new(),
                 stats: None,
+                analytics: None,
                 gate: None,
                 research_plan: None,
                 research_ingest_plan: None,
@@ -1459,6 +1583,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1544,6 +1669,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1582,6 +1708,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1632,6 +1759,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1689,6 +1817,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1731,6 +1860,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1812,6 +1942,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1870,6 +2001,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1917,6 +2049,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -1969,6 +2102,7 @@ impl MempalMcpServer {
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -2007,6 +2141,7 @@ impl MempalMcpServer {
                         .map(RuntimeAdoptionEventDto::from)
                         .collect(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -2042,6 +2177,37 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
+                    analytics: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                    evaluator_advice: None,
+                    default_proposal: None,
+                    rollback_control: None,
+                }))
+            }
+            "analytics" => {
+                let db = self.open_db()?;
+                let events = db
+                    .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10_000)
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to list runtime adoption events: {error}"),
+                            None,
+                        )
+                    })?;
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    instrumentation_policy: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    analytics: Some(build_runtime_adoption_analytics(&events).into()),
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
@@ -2065,6 +2231,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: Some(gate),
                     research_plan: None,
                     research_ingest_plan: None,
@@ -2088,6 +2255,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: Some(validate_research_adapter_plan_value(&report)),
                     research_ingest_plan: None,
@@ -2111,6 +2279,7 @@ impl MempalMcpServer {
                     event: None,
                     events: Vec::new(),
                     stats: None,
+                    analytics: None,
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: Some(ResearchIngestPlanDto::from(
@@ -2123,7 +2292,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, rollback_control, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, rollback_control, check_record, record_checked, review, readiness, analytics, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -2812,7 +2981,7 @@ impl MempalMcpServer {
     #[tool(
         name = "mempal_cowork_bus",
         description = "Multi-agent cowork bus for concrete agent instances in one project. \
-                       Actions: register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/handoff/capture. Uses explicit agent_id \
+                       Actions: register/list/send/broadcast/drain/events/deliveries/ack/heartbeat/channel_set/channel_list/channel_send/tmux_peek/doctor/session_create/session_list/session_status/session_close/handoff/capture. Uses explicit agent_id \
                        values such as claude-main, codex-a, codex-b, per-agent inbox files, \
                        and append-only events under ~/.mempal/cowork-bus/<project>. This is separate from legacy \
                        mempal_cowork_push partner routing and does not infer concrete instances \
@@ -3236,6 +3405,51 @@ impl MempalMcpServer {
                     capture: None,
                 }))
             }
+            "session_close" => {
+                let session_id = required_bus_field(request.session_id, "session_id", action)?;
+                let session = bus::update_session_status(&mempal_home, &cwd, &session_id, "closed")
+                    .map_err(bus_error_to_mcp)?;
+                let capture = if request.capture.unwrap_or(false) {
+                    let execute = request.execute.unwrap_or(false);
+                    let db = if execute { Some(self.open_db()?) } else { None };
+                    Some(
+                        bus::capture_handoff_to_memory(
+                            db.as_ref(),
+                            &mempal_home,
+                            &cwd,
+                            bus::CoworkCaptureRequest {
+                                summary_source: request
+                                    .summary_source
+                                    .unwrap_or_else(|| "handoff".to_string()),
+                                wing: request.wing.unwrap_or_else(|| "cowork-capture".to_string()),
+                                room: request.room,
+                                thread_id: request.thread_id,
+                                channel: request.channel,
+                                session_id: Some(session_id),
+                                note: request.note,
+                                execute,
+                            },
+                        )
+                        .map_err(bus_error_to_mcp)?,
+                    )
+                } else {
+                    None
+                };
+                Ok(Json(CoworkBusResponse {
+                    action: action.to_string(),
+                    agents: Vec::new(),
+                    delivered: Vec::new(),
+                    messages: Vec::new(),
+                    events: Vec::new(),
+                    deliveries: Vec::new(),
+                    channels: Vec::new(),
+                    tmux_peek: None,
+                    doctor: None,
+                    sessions: vec![session_to_dto(session)],
+                    handoff: None,
+                    capture: capture.map(capture_to_dto),
+                }))
+            }
             "handoff" => {
                 let summary = bus::build_handoff_summary(
                     &mempal_home,
@@ -3301,7 +3515,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unknown action `{other}`: expected register|list|send|broadcast|drain|events|deliveries|ack|heartbeat|channel_set|channel_list|channel_send|tmux_peek|doctor|session_create|session_list|session_status|handoff|capture"
+                    "unknown action `{other}`: expected register|list|send|broadcast|drain|events|deliveries|ack|heartbeat|channel_set|channel_list|channel_send|tmux_peek|doctor|session_create|session_list|session_status|session_close|handoff|capture"
                 ),
                 None,
             )),
@@ -4641,6 +4855,123 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_mcp_tool_registry_includes_mempal_doctor() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let doctor_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_doctor")
+            .expect("mempal_doctor tool exists");
+        assert!(
+            doctor_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("MCP runtime diagnostics")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_doctor_reports_runtime_tools() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let response = server
+            .doctor_json_for_test(serde_json::json!({}))
+            .await
+            .expect("doctor should succeed");
+        assert!(
+            response
+                .mcp
+                .required_tools
+                .iter()
+                .any(|tool| tool.name == "mempal_context" && tool.advertised)
+        );
+        assert!(
+            response
+                .mcp
+                .required_tools
+                .iter()
+                .any(|tool| tool.name == "mempal_phase3" && tool.advertised)
+        );
+        assert!(
+            response
+                .mcp
+                .required_tools
+                .iter()
+                .any(|tool| tool.name == "mempal_cowork_bus" && tool.advertised)
+        );
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_mempal_doctor() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        assert!(tools.iter().any(|tool| tool.name == "mempal_doctor"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_doctor"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_brief_returns_cognitive_brief() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_brief_evidence",
+            "Debug evidence with unresolved action item.",
+            "mempal",
+            Some("brief"),
+            "/tmp/brief-evidence.md",
+            3,
+        );
+        insert_knowledge_drawer(
+            &db_path,
+            "drawer_brief_knowledge",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Debug by reading cited evidence first.",
+            "debug workflow",
+        );
+
+        let response = server
+            .brief_json_for_test(serde_json::json!({
+                "query": "debug",
+                "include_cards": false
+            }))
+            .await
+            .expect("brief should succeed");
+        assert!(response.summary.key_fact_count + response.summary.evidence_count > 0);
+        assert!(
+            response
+                .key_facts
+                .iter()
+                .any(|fact| !fact.citation.drawer_id.is_empty())
+                || response
+                    .evidence
+                    .iter()
+                    .any(|evidence| !evidence.citation.drawer_id.is_empty())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_brief_rejects_max_items_zero() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let error = server
+            .brief_json_for_test(serde_json::json!({
+                "query": "debug",
+                "max_items": 0
+            }))
+            .await
+            .expect_err("max_items=0 should reject");
+        assert!(error.to_string().contains("max_items"));
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_mempal_brief() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        assert!(tools.iter().any(|tool| tool.name == "mempal_brief"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_brief"));
+    }
+
     #[tokio::test]
     async fn test_mcp_field_taxonomy_lists_stage1_fields() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -5241,7 +5572,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, rollback_control, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, rollback_control, check_record, record_checked, review, readiness, analytics, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -5633,6 +5964,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_phase3_adoption_analytics_action() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            for (id, signal) in [
+                ("analytics_accept", RuntimeAdoptionSignal::Accepted),
+                ("analytics_reject", RuntimeAdoptionSignal::Rejected),
+            ] {
+                db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                    id: id.to_string(),
+                    track: RuntimeAdoptionTrack::CardContext,
+                    signal,
+                    feature: "include_cards".to_string(),
+                    query: Some("skill trigger".to_string()),
+                    context_hash: None,
+                    card_id: None,
+                    evaluator_id: None,
+                    research_report_id: None,
+                    note: Some("analytics fixture".to_string()),
+                    metadata: None,
+                    created_at: "1777710000".to_string(),
+                })
+                .expect("insert event");
+            }
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "analytics"
+            }))
+            .await
+            .expect("analytics");
+        let analytics = response.analytics.expect("analytics report");
+        assert!(!analytics.writes);
+        assert_eq!(analytics.total_events, 2);
+        assert!(
+            analytics
+                .groups
+                .iter()
+                .any(|group| group.feature == "include_cards" && group.accepted == 1)
+        );
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_phase3_readiness_card_context_default_is_read_only() {
         let (_tempdir, db_path, server) = setup_server();
         let before = {
@@ -5793,12 +6179,13 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/analytics/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=instrumentation_policy"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=analytics"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=default_proposal"));
@@ -7209,6 +7596,7 @@ mod tests {
                 wing: None,
                 room: None,
                 note: None,
+                capture: None,
                 execute: None,
             }))
             .await
@@ -7244,6 +7632,7 @@ mod tests {
             wing: None,
             room: None,
             note: None,
+            capture: None,
             execute: None,
         }
     }
@@ -7702,6 +8091,45 @@ mod tests {
         assert!(
             !mempal_home.join("palace.db").exists(),
             "sessions must not write the db-backed memory store"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_bus_session_close() {
+        let (tempdir, db_path, server) = setup_server();
+        let (mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        mcp_bus_register(&server, &repo, "claude-main", "claude").await;
+        mcp_bus_register(&server, &repo, "codex-a", "codex").await;
+
+        let mut create = bus_request("session_create", &repo);
+        create.session_id = Some("review-1".to_string());
+        create.title = Some("Review 1".to_string());
+        create.agents = vec!["claude-main".to_string(), "codex-a".to_string()];
+        server
+            .mempal_cowork_bus(Parameters(create))
+            .await
+            .expect("create session");
+
+        let mut close = bus_request("session_close", &repo);
+        close.session_id = Some("review-1".to_string());
+        close.capture = Some(true);
+        close.execute = Some(false);
+        let response = server
+            .mempal_cowork_bus(Parameters(close))
+            .await
+            .expect("close session");
+        assert_eq!(response.0.sessions[0].status, "closed");
+        assert_eq!(
+            response.0.capture.as_ref().expect("capture payload").writes,
+            false
+        );
+        assert!(
+            !db_path.exists(),
+            "dry-run session_close capture must not create palace.db"
+        );
+        assert!(
+            mempal_home.join("cowork-bus").exists(),
+            "session close should remain a cowork bus runtime operation"
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,3 +1,8 @@
+use crate::adoption_analytics::{RuntimeAdoptionAnalyticsGroup, RuntimeAdoptionAnalyticsReport};
+use crate::brief::{
+    BriefCard, BriefCitation, BriefEvidence, BriefEvidenceCitation, BriefFact, BriefSummary,
+    BriefUncertainty, BriefUnresolvedItem, CognitiveBrief,
+};
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
     Phase3ReadinessReport, ResearchCandidateInsightPlan, ResearchEvidenceDrawerPlan,
@@ -12,6 +17,7 @@ use crate::core::types::{
     MemoryDomain, MemoryKind, NeighborChunk, RouteDecision, RuntimeAdoptionEvent,
     RuntimeAdoptionSignal, RuntimeAdoptionTrack, SearchResult, TaxonomyEntry, TunnelEndpoint,
 };
+use crate::doctor::{DoctorDbReport, DoctorInstallReport, DoctorReport};
 use crate::field_taxonomy::FieldTaxonomyEntry;
 use crate::knowledge_anchor::PublishAnchorOutcome;
 use crate::knowledge_card_lifecycle::{
@@ -94,6 +100,134 @@ pub struct ContextResponse {
     pub field: String,
     pub anchors: Vec<ContextAnchorDto>,
     pub sections: Vec<ContextSectionDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, JsonSchema)]
+pub struct DoctorRequest {}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DoctorResponse {
+    pub current_version: String,
+    pub supported_schema_version: u32,
+    pub db: DoctorDbDto,
+    pub install: DoctorInstallDto,
+    pub warnings: Vec<String>,
+    pub recommendations: Vec<String>,
+    pub mcp: DoctorMcpDto,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DoctorDbDto {
+    pub path: String,
+    pub exists: bool,
+    pub schema_version: Option<u32>,
+    pub compatible: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DoctorInstallDto {
+    pub current_exe: Option<String>,
+    pub path_mempal: Option<String>,
+    pub path_matches_current_exe: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DoctorMcpDto {
+    pub required_tools: Vec<DoctorToolDto>,
+    pub phase3_actions: Vec<String>,
+    pub cowork_bus_actions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DoctorToolDto {
+    pub name: String,
+    pub advertised: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct BriefMcpRequest {
+    pub query: String,
+    pub field: Option<String>,
+    pub domain: Option<String>,
+    pub cwd: Option<String>,
+    pub max_items: Option<usize>,
+    pub dao_tian_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefMcpResponse {
+    pub query: String,
+    pub domain: String,
+    pub field: String,
+    pub summary: BriefSummaryDto,
+    pub key_facts: Vec<BriefFactDto>,
+    pub evidence: Vec<BriefEvidenceDto>,
+    pub cards: Vec<BriefCardDto>,
+    pub entities: Vec<String>,
+    pub unresolved_items: Vec<BriefUnresolvedItemDto>,
+    pub uncertainty: Vec<BriefUncertaintyDto>,
+    pub next_actions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefSummaryDto {
+    pub narrative: String,
+    pub key_fact_count: usize,
+    pub evidence_count: usize,
+    pub card_count: usize,
+    pub unresolved_count: usize,
+    pub uncertainty_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefFactDto {
+    pub text: String,
+    pub section: String,
+    pub citation: BriefCitationDto,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefEvidenceDto {
+    pub text: String,
+    pub citation: BriefCitationDto,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefCardDto {
+    pub card_id: String,
+    pub text: String,
+    pub citation: BriefCitationDto,
+    pub evidence_citations: Vec<BriefEvidenceCitationDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefUnresolvedItemDto {
+    pub text: String,
+    pub citation: BriefCitationDto,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefUncertaintyDto {
+    pub kind: String,
+    pub message: String,
+    pub citations: Vec<BriefCitationDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefCitationDto {
+    pub drawer_id: String,
+    pub source_file: String,
+    pub anchor_kind: String,
+    pub anchor_id: String,
+    pub card_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BriefEvidenceCitationDto {
+    pub evidence_drawer_id: String,
+    pub role: String,
+    pub source_file: String,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -343,7 +477,7 @@ pub struct Phase3Request {
     pub allow_warnings: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
 pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guidance: Option<RuntimeAdoptionGuidanceDto>,
@@ -366,6 +500,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stats: Option<RuntimeAdoptionStatsDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub analytics: Option<RuntimeAdoptionAnalyticsDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gate: Option<Phase3GateDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub research_plan: Option<ResearchAdapterPlanDto>,
@@ -377,6 +513,28 @@ pub struct Phase3Response {
     pub default_proposal: Option<CardContextDefaultProposalDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rollback_control: Option<CardContextRollbackControlDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionAnalyticsDto {
+    pub writes: bool,
+    pub total_events: usize,
+    pub groups: Vec<RuntimeAdoptionAnalyticsGroupDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionAnalyticsGroupDto {
+    pub track: String,
+    pub feature: String,
+    pub total: usize,
+    pub used: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub misses: usize,
+    pub rollbacks: usize,
+    pub contradictions: usize,
+    pub neutral: usize,
+    pub recommendation: String,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -866,6 +1024,34 @@ impl From<ResearchCandidateInsightPlan> for ResearchCandidateInsightPlanDto {
             statement: plan.statement,
             supporting_refs: plan.supporting_refs,
             suggested_command: plan.suggested_command,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionAnalyticsReport> for RuntimeAdoptionAnalyticsDto {
+    fn from(report: RuntimeAdoptionAnalyticsReport) -> Self {
+        Self {
+            writes: report.writes,
+            total_events: report.total_events,
+            groups: report.groups.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<RuntimeAdoptionAnalyticsGroup> for RuntimeAdoptionAnalyticsGroupDto {
+    fn from(group: RuntimeAdoptionAnalyticsGroup) -> Self {
+        Self {
+            track: group.track,
+            feature: group.feature,
+            total: group.total,
+            used: group.used,
+            accepted: group.accepted,
+            rejected: group.rejected,
+            misses: group.misses,
+            rollbacks: group.rollbacks,
+            contradictions: group.contradictions,
+            neutral: group.neutral,
+            recommendation: group.recommendation,
         }
     }
 }
@@ -1584,7 +1770,11 @@ pub struct CoworkBusRequest {
     #[serde(default)]
     pub note: Option<String>,
 
-    /// Explicit write switch for action "capture".
+    /// Explicit capture switch for action "session_close".
+    #[serde(default)]
+    pub capture: Option<bool>,
+
+    /// Explicit write switch for action "capture" and "session_close".
     #[serde(default)]
     pub execute: Option<bool>,
 }
@@ -1835,6 +2025,148 @@ impl From<ContextPack> for ContextResponse {
                 .into_iter()
                 .map(ContextSectionDto::from)
                 .collect(),
+        }
+    }
+}
+
+impl DoctorResponse {
+    pub fn from_report(report: DoctorReport, mcp: DoctorMcpDto) -> Self {
+        Self {
+            current_version: report.current_version,
+            supported_schema_version: report.supported_schema_version,
+            db: report.db.into(),
+            install: report.install.into(),
+            warnings: report.warnings,
+            recommendations: report.recommendations,
+            mcp,
+        }
+    }
+}
+
+impl From<DoctorDbReport> for DoctorDbDto {
+    fn from(report: DoctorDbReport) -> Self {
+        Self {
+            path: report.path,
+            exists: report.exists,
+            schema_version: report.schema_version,
+            compatible: report.compatible,
+            error: report.error,
+        }
+    }
+}
+
+impl From<DoctorInstallReport> for DoctorInstallDto {
+    fn from(report: DoctorInstallReport) -> Self {
+        Self {
+            current_exe: report.current_exe,
+            path_mempal: report.path_mempal,
+            path_matches_current_exe: report.path_matches_current_exe,
+        }
+    }
+}
+
+impl From<CognitiveBrief> for BriefMcpResponse {
+    fn from(brief: CognitiveBrief) -> Self {
+        Self {
+            query: brief.query,
+            domain: domain_slug(&brief.domain).to_string(),
+            field: brief.field,
+            summary: brief.summary.into(),
+            key_facts: brief.key_facts.into_iter().map(Into::into).collect(),
+            evidence: brief.evidence.into_iter().map(Into::into).collect(),
+            cards: brief.cards.into_iter().map(Into::into).collect(),
+            entities: brief.entities,
+            unresolved_items: brief.unresolved_items.into_iter().map(Into::into).collect(),
+            uncertainty: brief.uncertainty.into_iter().map(Into::into).collect(),
+            next_actions: brief.next_actions,
+        }
+    }
+}
+
+impl From<BriefSummary> for BriefSummaryDto {
+    fn from(summary: BriefSummary) -> Self {
+        Self {
+            narrative: summary.narrative,
+            key_fact_count: summary.key_fact_count,
+            evidence_count: summary.evidence_count,
+            card_count: summary.card_count,
+            unresolved_count: summary.unresolved_count,
+            uncertainty_count: summary.uncertainty_count,
+        }
+    }
+}
+
+impl From<BriefFact> for BriefFactDto {
+    fn from(fact: BriefFact) -> Self {
+        Self {
+            text: fact.text,
+            section: fact.section,
+            citation: fact.citation.into(),
+        }
+    }
+}
+
+impl From<BriefEvidence> for BriefEvidenceDto {
+    fn from(evidence: BriefEvidence) -> Self {
+        Self {
+            text: evidence.text,
+            citation: evidence.citation.into(),
+        }
+    }
+}
+
+impl From<BriefCard> for BriefCardDto {
+    fn from(card: BriefCard) -> Self {
+        Self {
+            card_id: card.card_id,
+            text: card.text,
+            citation: card.citation.into(),
+            evidence_citations: card
+                .evidence_citations
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        }
+    }
+}
+
+impl From<BriefUnresolvedItem> for BriefUnresolvedItemDto {
+    fn from(item: BriefUnresolvedItem) -> Self {
+        Self {
+            text: item.text,
+            citation: item.citation.into(),
+        }
+    }
+}
+
+impl From<BriefUncertainty> for BriefUncertaintyDto {
+    fn from(uncertainty: BriefUncertainty) -> Self {
+        Self {
+            kind: uncertainty.kind,
+            message: uncertainty.message,
+            citations: uncertainty.citations.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<BriefCitation> for BriefCitationDto {
+    fn from(citation: BriefCitation) -> Self {
+        Self {
+            drawer_id: citation.drawer_id,
+            source_file: citation.source_file,
+            anchor_kind: anchor_kind_slug(&citation.anchor_kind).to_string(),
+            anchor_id: citation.anchor_id,
+            card_id: citation.card_id,
+        }
+    }
+}
+
+impl From<BriefEvidenceCitation> for BriefEvidenceCitationDto {
+    fn from(citation: BriefEvidenceCitation) -> Self {
+        Self {
+            evidence_drawer_id: citation.evidence_drawer_id,
+            role: knowledge_evidence_role_slug(&citation.role).to_string(),
+            source_file: citation.source_file,
         }
     }
 }

--- a/tests/cowork_bus.rs
+++ b/tests/cowork_bus.rs
@@ -1689,6 +1689,106 @@ fn test_cli_cowork_session_status_update() {
 }
 
 #[test]
+fn test_cli_cowork_session_close_no_capture() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "session-close");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    assert_success(&run_mempal(
+        &home,
+        &[
+            "cowork-session-create",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+            "--title",
+            "Review 1",
+            "--agent",
+            "claude-main",
+            "--agent",
+            "codex-a",
+        ],
+    ));
+
+    let close = run_mempal(
+        &home,
+        &[
+            "cowork-session-close",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+        ],
+    );
+    assert_success(&close);
+    let list = run_mempal(
+        &home,
+        &[
+            "cowork-sessions",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--format",
+            "json",
+        ],
+    );
+    assert_success(&list);
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).expect("sessions json");
+    assert_eq!(value[0]["status"], "closed");
+    assert!(!palace_db_path(&home).exists());
+}
+
+#[test]
+fn test_cli_cowork_session_close_capture_execute() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "session-close-capture");
+    register(&home, &repo, "claude-main", "claude");
+    register(&home, &repo, "codex-a", "codex");
+    assert_success(&run_mempal(
+        &home,
+        &[
+            "cowork-session-create",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+            "--title",
+            "Review 1",
+            "--agent",
+            "claude-main",
+            "--agent",
+            "codex-a",
+        ],
+    ));
+
+    let close = run_mempal(
+        &home,
+        &[
+            "cowork-session-close",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--session-id",
+            "review-1",
+            "--capture",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert_success(&close);
+    let value: serde_json::Value = serde_json::from_slice(&close.stdout).expect("close json");
+    assert_eq!(value["session"]["status"], "closed");
+    assert_eq!(value["capture"]["writes"], true);
+    let drawer_id = value["capture"]["drawer_id"].as_str().expect("drawer id");
+    let db = mempal::core::db::Database::open(&palace_db_path(&home)).expect("open db");
+    let drawer = db
+        .get_drawer(drawer_id)
+        .expect("get drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.wing, "cowork-capture");
+}
+
+#[test]
 fn test_cli_cowork_handoff_plain() {
     let home = TempDir::new().expect("home");
     let repo = setup_repo(&home, "handoff-plain");

--- a/tests/ops_runtime.rs
+++ b/tests/ops_runtime.rs
@@ -1,0 +1,224 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use mempal::core::db::Database;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal")
+}
+
+fn run_mempal_with_path(home: &TempDir, args: &[&str], path_value: &str) -> std::process::Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home.path())
+        .env("PATH", path_value)
+        .output()
+        .expect("run mempal")
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn assert_success(output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output)
+    );
+}
+
+fn palace_db_path(home: &TempDir) -> PathBuf {
+    home.path().join(".mempal/palace.db")
+}
+
+fn install_fake_path_mempal(home: &TempDir) -> String {
+    let bin_dir = home.path().join("fake-bin");
+    fs::create_dir_all(&bin_dir).expect("create fake bin");
+    let fake = bin_dir.join("mempal");
+    fs::write(&fake, "#!/bin/sh\nprintf 'mempal 0.0.0\\n'\n").expect("write fake mempal");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&fake).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake, perms).unwrap();
+    }
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{old_path}", bin_dir.display())
+}
+
+#[test]
+fn test_cli_doctor_json_reports_schema_and_path() {
+    let home = TempDir::new().expect("home");
+    fs::create_dir_all(home.path().join(".mempal")).expect("create mempal home");
+    let db = Database::open(&palace_db_path(&home)).expect("open db");
+    assert_eq!(db.schema_version().expect("schema"), 9);
+    drop(db);
+    let path_value = install_fake_path_mempal(&home);
+
+    let output = run_mempal_with_path(&home, &["doctor", "--format", "json"], &path_value);
+    assert_success(&output);
+    let value: Value = serde_json::from_str(&stdout(&output)).expect("doctor json");
+    assert_eq!(
+        value["current_version"].as_str(),
+        Some(env!("CARGO_PKG_VERSION"))
+    );
+    assert_eq!(value["supported_schema_version"], 9);
+    assert_eq!(value["db"]["exists"], true);
+    assert_eq!(value["db"]["schema_version"], 9);
+    assert_eq!(value["install"]["path_matches_current_exe"], false);
+    assert!(
+        value["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .any(|warning| warning.as_str().unwrap_or_default().contains("PATH"))
+    );
+}
+
+#[test]
+fn test_cli_doctor_plain_no_db_is_read_only() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["doctor", "--format", "plain"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("db_exists=false"), "{out}");
+    assert!(!palace_db_path(&home).exists());
+}
+
+#[test]
+fn test_cli_doctor_rejects_invalid_format() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["doctor", "--format", "yaml"]);
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("unsupported doctor format"));
+    assert!(!palace_db_path(&home).exists());
+}
+
+#[test]
+fn test_cli_maintenance_guided_run_json() {
+    let home = TempDir::new().expect("home");
+    fs::create_dir_all(home.path().join(".mempal")).expect("create mempal home");
+    Database::open(&palace_db_path(&home)).expect("open db");
+
+    let output = run_mempal(&home, &["maintenance", "guided-run", "--format", "json"]);
+    assert_success(&output);
+    let value: Value = serde_json::from_str(&stdout(&output)).expect("guided run json");
+    assert_eq!(value["writes"], false);
+    let commands = value["steps"]
+        .as_array()
+        .expect("steps")
+        .iter()
+        .filter_map(|step| step["command"].as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(commands.contains("research-validate-plan"), "{commands}");
+    assert!(commands.contains("adoption review"), "{commands}");
+    assert!(commands.contains("cowork-doctor"), "{commands}");
+}
+
+#[test]
+fn test_cli_maintenance_guided_run_plain() {
+    let home = TempDir::new().expect("home");
+    fs::create_dir_all(home.path().join(".mempal")).expect("create mempal home");
+    Database::open(&palace_db_path(&home)).expect("open db");
+
+    let output = run_mempal(&home, &["maintenance", "guided-run", "--format", "plain"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("Guided Maintenance Run"), "{out}");
+    assert!(out.contains("mempal phase3 adoption review"), "{out}");
+    assert!(out.contains("mempal cowork-capture"), "{out}");
+}
+
+#[test]
+fn test_cli_maintenance_guided_run_rejects_invalid_format() {
+    let home = TempDir::new().expect("home");
+    fs::create_dir_all(home.path().join(".mempal")).expect("create mempal home");
+    Database::open(&palace_db_path(&home)).expect("open db");
+
+    let output = run_mempal(&home, &["maintenance", "guided-run", "--format", "yaml"]);
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("unsupported maintenance guided-run format"));
+}
+
+#[test]
+fn test_cli_release_readiness_json() {
+    let home = TempDir::new().expect("home");
+    let output = Command::new(mempal_bin())
+        .args(["release-readiness", "--format", "json"])
+        .env("HOME", home.path())
+        .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")))
+        .output()
+        .expect("run mempal");
+    assert_success(&output);
+    let value: Value = serde_json::from_str(&stdout(&output)).expect("release readiness json");
+    assert_eq!(value["writes"], false);
+    let check_names = value["checks"]
+        .as_array()
+        .expect("checks")
+        .iter()
+        .filter_map(|check| check["name"].as_str())
+        .collect::<Vec<_>>();
+    assert!(check_names.contains(&"cargo-metadata"), "{check_names:?}");
+    assert!(
+        check_names.contains(&"spec-plan-inventory"),
+        "{check_names:?}"
+    );
+    assert!(
+        value["recommended_commands"]
+            .as_array()
+            .expect("commands")
+            .iter()
+            .any(|command| command
+                .as_str()
+                .unwrap_or_default()
+                .contains("cargo package"))
+    );
+}
+
+#[test]
+fn test_cli_release_readiness_plain() {
+    let home = TempDir::new().expect("home");
+    let output = Command::new(mempal_bin())
+        .args(["release-readiness", "--format", "plain"])
+        .env("HOME", home.path())
+        .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")))
+        .output()
+        .expect("run mempal");
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("Release Readiness"), "{out}");
+    assert!(out.contains("cargo package"), "{out}");
+    assert!(out.contains("mempal doctor"), "{out}");
+}
+
+#[test]
+fn test_cli_release_readiness_rejects_invalid_format() {
+    let home = TempDir::new().expect("home");
+    let output = Command::new(mempal_bin())
+        .args(["release-readiness", "--format", "yaml"])
+        .env("HOME", home.path())
+        .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")))
+        .output()
+        .expect("run mempal");
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("unsupported release-readiness format"));
+}

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -173,9 +173,10 @@ fn start_openai_embedding_stub(query: &str) -> (String, thread::JoinHandle<()>) 
                 Err(error) => panic!("accept request: {error}"),
             })
             .expect("embedding stub timed out waiting for request");
-        let mut request = [0_u8; 4096];
-        let bytes_read = stream.read(&mut request).expect("read embedding request");
-        let request = String::from_utf8_lossy(&request[..bytes_read]);
+        stream
+            .set_nonblocking(false)
+            .expect("set embedding request stream blocking");
+        let request = read_http_request(&mut stream);
         let (_, body) = request
             .split_once("\r\n\r\n")
             .expect("request should contain JSON body");
@@ -195,6 +196,44 @@ fn start_openai_embedding_stub(query: &str) -> (String, thread::JoinHandle<()>) 
             .expect("write embedding response");
     });
     (format!("http://{address}/v1/embeddings"), handle)
+}
+
+fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    let header_end = loop {
+        let bytes_read = stream.read(&mut chunk).expect("read embedding request");
+        assert!(
+            bytes_read > 0,
+            "embedding request closed before headers were complete"
+        );
+        request.extend_from_slice(&chunk[..bytes_read]);
+        if let Some(index) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+            break index + 4;
+        }
+    };
+    let headers = String::from_utf8_lossy(&request[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .expect("embedding request content-length");
+    let expected_len = header_end + content_length;
+    while request.len() < expected_len {
+        let bytes_read = stream
+            .read(&mut chunk)
+            .expect("read embedding request body");
+        assert!(
+            bytes_read > 0,
+            "embedding request closed before body was complete"
+        );
+        request.extend_from_slice(&chunk[..bytes_read]);
+    }
+    String::from_utf8_lossy(&request[..expected_len]).into_owned()
 }
 
 fn write_cli_api_config(home: &TempDir, endpoint: &str) {
@@ -2469,4 +2508,75 @@ fn test_cli_phase3_research_ingest_plan_rejects_invalid_format() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unsupported phase3 research ingest format"));
+}
+
+#[test]
+fn test_cli_phase3_adoption_analytics_json() {
+    let home = setup_cli_home();
+    record_card_context_acceptance(&home, "analytics_accept_1");
+    record_card_context_acceptance(&home, "analytics_accept_2");
+    let rejected = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record",
+            "--id",
+            "analytics_reject_1",
+            "--track",
+            "card_context",
+            "--signal",
+            "rejected",
+            "--feature",
+            "include_cards",
+            "--query",
+            "skill trigger context",
+        ],
+    );
+    assert!(rejected.status.success());
+
+    let output = run_mempal(
+        &home,
+        &["phase3", "adoption", "analytics", "--format", "json"],
+    );
+    assert!(
+        output.status.success(),
+        "analytics failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("analytics json");
+    assert_eq!(report["writes"], false);
+    let groups = report["groups"].as_array().expect("groups");
+    let include_cards = groups
+        .iter()
+        .find(|group| group["feature"] == "include_cards")
+        .expect("include_cards group");
+    assert_eq!(include_cards["accepted"], 2);
+    assert_eq!(include_cards["rejected"], 1);
+    assert!(
+        include_cards["recommendation"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("observe")
+    );
+}
+
+#[test]
+fn test_cli_phase3_adoption_analytics_plain() {
+    let home = setup_cli_home();
+    record_card_context_acceptance(&home, "analytics_plain_accept");
+
+    let output = run_mempal(
+        &home,
+        &["phase3", "adoption", "analytics", "--format", "plain"],
+    );
+    assert!(
+        output.status.success(),
+        "analytics failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("adoption analytics"), "{out}");
+    assert!(out.contains("include_cards"), "{out}");
+    assert!(out.contains("accepted=1"), "{out}");
 }


### PR DESCRIPTION
## Summary
- Add P98-P104 operational/runtime completion surface: doctor, MCP doctor, guided maintenance run, cowork session close capture, MCP cognitive brief, adoption analytics, and release readiness.
- Add matching P98-P104 specs/plans and update AGENTS.md, CLAUDE.md, and MIND-MODEL-DESIGN documentation.
- Stabilize the Phase-3 embedding test stub by reading HTTP request bodies by Content-Length after restoring accepted sockets to blocking mode.

## Validation
- cargo fmt -- --check
- git diff --check
- cargo test
- cargo clippy -- -D warnings
- cargo run -- release-readiness --format json