### PR TITLE
Make API embedding dimensions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ backend = "onnx"
 backend = "api"
 api_endpoint = "http://localhost:11434/api/embeddings"
 api_model = "nomic-embed-text"
+dimensions = 768  # optional; defaults to 384 when omitted
 ```
 
 ## Commands
@@ -263,7 +264,7 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo fmt --all --check
 ```
 
-After changing the embedding model, re-embed existing drawers:
+After changing the embedding model or dimensions, re-embed existing drawers:
 
 ```bash
 mempal reindex

--- a/README_zh.md
+++ b/README_zh.md
@@ -57,6 +57,7 @@ backend = "onnx"
 backend = "api"
 api_endpoint = "http://localhost:11434/api/embeddings"
 api_model = "nomic-embed-text"
+dimensions = 768  # 可选；省略时默认 384
 ```
 
 ## 命令一览

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,6 +76,7 @@ db_path = "~/.mempal/palace.db"
 backend = "api"
 api_endpoint = "http://localhost:11434/api/embeddings"
 api_model = "nomic-embed-text"
+dimensions = 768  # optional; defaults to 384 when omitted
 ```
 
 Notes:

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -69,6 +69,7 @@ pub struct EmbedConfig {
     pub model: Option<String>,
     pub api_endpoint: Option<String>,
     pub api_model: Option<String>,
+    pub dimensions: Option<usize>,
 }
 
 impl Default for EmbedConfig {
@@ -78,6 +79,7 @@ impl Default for EmbedConfig {
             model: None,
             api_endpoint: None,
             api_model: None,
+            dimensions: None,
         }
     }
 }
@@ -113,4 +115,25 @@ fn default_config_path() -> PathBuf {
         .map(PathBuf::from)
         .map(|home| home.join(".mempal").join("config.toml"))
         .unwrap_or_else(|| PathBuf::from("~/.mempal/config.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    #[test]
+    fn parses_api_embedding_dimensions() {
+        let config: Config = toml::from_str(
+            r#"
+[embed]
+backend = "api"
+api_endpoint = "http://localhost:11434/api/embeddings"
+api_model = "nomic-embed-text"
+dimensions = 768
+"#,
+        )
+        .expect("parse config");
+
+        assert_eq!(config.embed.dimensions, Some(768));
+    }
 }

--- a/src/embed/factory.rs
+++ b/src/embed/factory.rs
@@ -49,7 +49,10 @@ impl EmbedderFactory for ConfiguredEmbedderFactory {
                     .clone()
                     .unwrap_or_else(|| "http://localhost:11434/api/embeddings".to_string()),
                 self.config.embed.api_model.clone(),
-                DEFAULT_API_DIMENSIONS,
+                self.config
+                    .embed
+                    .dimensions
+                    .unwrap_or(DEFAULT_API_DIMENSIONS),
             ))),
             backend => Err(EmbedError::UnsupportedBackend(backend.to_string())),
         }


### PR DESCRIPTION
## Summary

- add optional `[embed].dimensions` config for API embeddings
- keep the existing 384-dimensional default when omitted
- document `dimensions = 768` for Ollama `nomic-embed-text`
- add a config parse regression test

## Why

The API embedding backend currently assumes 384 dimensions. Ollama `nomic-embed-text` returns 768-dimensional vectors, so mempal fails with:

```text
embedding endpoint returned vectors with unexpected dimensions; expected 384, got 768
```

sqlite-vec already supports arbitrary dimensions at table creation time, so this only needs to be configurable.

## Test

```bash
cargo test --lib
```

Result: 213 passed.
