### PR TITLE
fix(ingest): strip Codex runtime preamble and bump normalize version (P115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p112-session-peek.spec.md` | 完成 | P112 explicit MCP session peek：新增 `mempal_session_peek` 显式按 `tool + cwd` 只读读取本地 Claude/Codex session，支持同工具/跨项目场景，同时保持 `mempal_peek_partner` self-peek 保护不变 |
 | `specs/p113-public-workspace-crates.spec.md` | 完成 | P113 public multi-crate workspace split：保留 root `mempal` CLI 包，同时新增公开可发布的 `mempal-embed` / `mempal-search-core` / `mempal-agent-memory` / `mempal-mcp-protocol` workspace crates，并通过 legacy facade path 兼容现有 API |
 | `specs/p114-coarse-workspace-split.spec.md` | 完成 | P114 coarse workspace split：新增公开可发布的 `mempal-store-sqlite` / `mempal-runtime` / `mempal-mcp-server` 三个粗粒度 crate，把 SQLite storage、runtime workflows、MCP server wiring 从 root 拆出，同时保留 root CLI 和 legacy facade paths |
+| `specs/p115-codex-preamble-noise-strip.spec.md` | 完成 | P115 Codex runtime preamble strip：`strip_codex_rollout_noise` 剥离 `<INSTRUCTIONS>` / `<user_instructions>` / `<environment_context>` / `<recommended_plugins>` / `<turn_aborted>` wrapper 块（GitHub #10）；`CURRENT_NORMALIZE_VERSION` 2→3 让 `reindex --stale` 重拾 PR #7 前的旧 source；`is_codex_jsonl` 要求至少一条 `event_msg`/`response_item` |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -288,6 +289,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-07-07-p112-session-peek.md` — P112 explicit MCP session peek（已完成）
 - `docs/plans/2026-07-08-p113-public-workspace-crates.md` — P113 public multi-crate workspace split（已完成）
 - `docs/plans/2026-07-09-p114-coarse-workspace-split.md` — P114 coarse workspace split（已完成）
+- `docs/plans/2026-07-26-p115-codex-preamble-noise-strip.md` — P115 Codex runtime preamble strip + normalize version bump（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p112-session-peek.spec.md` | 完成 | P112 explicit MCP session peek：新增 `mempal_session_peek` 显式按 `tool + cwd` 只读读取本地 Claude/Codex session，支持同工具/跨项目场景，同时保持 `mempal_peek_partner` self-peek 保护不变 |
 | `specs/p113-public-workspace-crates.spec.md` | 完成 | P113 public multi-crate workspace split：保留 root `mempal` CLI 包，同时新增公开可发布的 `mempal-embed` / `mempal-search-core` / `mempal-agent-memory` / `mempal-mcp-protocol` workspace crates，并通过 legacy facade path 兼容现有 API |
 | `specs/p114-coarse-workspace-split.spec.md` | 完成 | P114 coarse workspace split：新增公开可发布的 `mempal-store-sqlite` / `mempal-runtime` / `mempal-mcp-server` 三个粗粒度 crate，把 SQLite storage、runtime workflows、MCP server wiring 从 root 拆出，同时保留 root CLI 和 legacy facade paths |
+| `specs/p115-codex-preamble-noise-strip.spec.md` | 完成 | P115 Codex runtime preamble strip：`strip_codex_rollout_noise` 剥离 `<INSTRUCTIONS>` / `<user_instructions>` / `<environment_context>` / `<recommended_plugins>` / `<turn_aborted>` wrapper 块（GitHub #10）；`CURRENT_NORMALIZE_VERSION` 2→3 让 `reindex --stale` 重拾 PR #7 前的旧 source；`is_codex_jsonl` 要求至少一条 `event_msg`/`response_item` |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -286,6 +287,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-07-07-p112-session-peek.md` — P112 explicit MCP session peek（已完成）
 - `docs/plans/2026-07-08-p113-public-workspace-crates.md` — P113 public multi-crate workspace split（已完成）
 - `docs/plans/2026-07-09-p114-coarse-workspace-split.md` — P114 coarse workspace split（已完成）
+- `docs/plans/2026-07-26-p115-codex-preamble-noise-strip.md` — P115 Codex runtime preamble strip + normalize version bump（已完成）
 
 ### Spec 使用方式
 

--- a/crates/mempal-mcp-server/src/server.rs
+++ b/crates/mempal-mcp-server/src/server.rs
@@ -5029,8 +5029,7 @@ mod tests {
                 tool.name
             );
             if let Some(output_schema) = &tool.output_schema {
-                let output =
-                    serde_json::to_string(output_schema).expect("serialize output schema");
+                let output = serde_json::to_string(output_schema).expect("serialize output schema");
                 assert!(
                     !output.contains("\"uint"),
                     "tool {} output schema contains unsigned integer format: {output}",

--- a/crates/mempal-runtime/src/ingest/detect.rs
+++ b/crates/mempal-runtime/src/ingest/detect.rs
@@ -31,7 +31,7 @@ pub fn detect_format(content: &str) -> Format {
 
 fn is_codex_jsonl(content: &str) -> bool {
     let mut has_session_meta = false;
-    let mut has_activity = false;
+    let mut has_message_record = false;
 
     for line in content.lines().map(str::trim).filter(|l| !l.is_empty()) {
         let Ok(value) = serde_json::from_str::<Value>(line) else {
@@ -39,15 +39,15 @@ fn is_codex_jsonl(content: &str) -> bool {
         };
         match value.get("type").and_then(Value::as_str) {
             Some("session_meta") => has_session_meta = true,
-            Some("event_msg" | "response_item" | "turn_context" | "compacted") => {
-                has_activity = true
-            }
-            Some(_) => {} // tolerate newer rollout record types
+            Some("event_msg" | "response_item") => has_message_record = true,
+            // Tolerate turn_context/compacted and newer rollout record types,
+            // but they are not evidence of a Codex rollout on their own.
+            Some(_) => {}
             None => return false,
         }
     }
 
-    has_session_meta && has_activity
+    has_session_meta && has_message_record
 }
 
 fn is_slack_json(content: &str) -> bool {
@@ -142,6 +142,17 @@ pub(crate) fn extract_content_text(value: &Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{Format, detect_format};
+
+    #[test]
+    fn rejects_codex_rollout_without_message_records() {
+        // session_meta plus non-message records only: turn_context/compacted
+        // are tolerated context, not sufficient evidence of a Codex rollout.
+        let content = r#"{"timestamp":"2026-07-26T10:00:00.000Z","type":"session_meta","payload":{"cwd":"/tmp/project"}}
+{"timestamp":"2026-07-26T10:00:00.100Z","type":"turn_context","payload":{"cwd":"/tmp/project"}}
+{"timestamp":"2026-07-26T10:00:00.200Z","type":"compacted","payload":{"summary":"trimmed"}}"#;
+
+        assert_eq!(detect_format(content), Format::PlainText);
+    }
 
     #[test]
     fn detects_current_codex_rollout_with_turn_context_and_compacted() {

--- a/crates/mempal-runtime/src/ingest/noise.rs
+++ b/crates/mempal-runtime/src/ingest/noise.rs
@@ -1,25 +1,55 @@
 use serde_json::Value;
 
-const SYSTEM_REMINDER_OPEN: &str = "<system-reminder>";
-const SYSTEM_REMINDER_CLOSE: &str = "</system-reminder>";
+const SYSTEM_REMINDER_TAG: &str = "system-reminder";
+
+/// Codex runtime preamble wrappers injected as user/developer messages
+/// (issue #10): AGENTS.md instructions, environment context, plugin
+/// recommendations, and turn-abort markers.
+const CODEX_WRAPPER_TAGS: &[&str] = &[
+    "INSTRUCTIONS",
+    "user_instructions",
+    "environment_context",
+    "recommended_plugins",
+    "turn_aborted",
+];
+
+struct MarkerPair {
+    open: String,
+    close: String,
+}
+
+impl MarkerPair {
+    fn for_tag(tag: &str) -> Self {
+        Self {
+            open: format!("<{tag}>"),
+            close: format!("</{tag}>"),
+        }
+    }
+}
 
 pub fn strip_claude_jsonl_noise(content: &str) -> String {
-    let without_system_reminders = strip_system_reminders(content);
+    let markers = [MarkerPair::for_tag(SYSTEM_REMINDER_TAG)];
+    let without_system_reminders = strip_marker_blocks(content, &markers);
     strip_noise_lines(&without_system_reminders, true)
 }
 
 pub fn strip_codex_rollout_noise(content: &str) -> String {
-    strip_noise_lines(content, false)
+    let markers: Vec<MarkerPair> = CODEX_WRAPPER_TAGS
+        .iter()
+        .map(|tag| MarkerPair::for_tag(tag))
+        .collect();
+    let without_wrappers = strip_marker_blocks(content, &markers);
+    strip_noise_lines(&without_wrappers, false)
 }
 
-fn strip_system_reminders(content: &str) -> String {
+fn strip_marker_blocks(content: &str, markers: &[MarkerPair]) -> String {
     let mut output = String::with_capacity(content.len());
     let mut in_code_block = false;
-    let mut skipping_reminder = false;
+    let mut skipping: Option<usize> = None;
 
     for line in content.split_inclusive('\n') {
         let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
-        if !skipping_reminder && is_code_fence(line_without_newline) {
+        if skipping.is_none() && is_code_fence(line_without_newline) {
             in_code_block = !in_code_block;
             output.push_str(line);
             continue;
@@ -29,38 +59,50 @@ fn strip_system_reminders(content: &str) -> String {
             continue;
         }
 
-        output.push_str(&strip_system_reminders_from_line(
-            line,
-            &mut skipping_reminder,
-        ));
+        output.push_str(&strip_marker_blocks_from_line(line, markers, &mut skipping));
     }
 
     output
 }
 
-fn strip_system_reminders_from_line(line: &str, skipping_reminder: &mut bool) -> String {
+fn strip_marker_blocks_from_line(
+    line: &str,
+    markers: &[MarkerPair],
+    skipping: &mut Option<usize>,
+) -> String {
     let mut output = String::new();
     let mut remaining = line;
 
     loop {
-        if *skipping_reminder {
-            let Some(end) = remaining.find(SYSTEM_REMINDER_CLOSE) else {
+        if let Some(active) = *skipping {
+            let close = markers[active].close.as_str();
+            let Some(end) = remaining.find(close) else {
                 return output;
             };
-            remaining = &remaining[end + SYSTEM_REMINDER_CLOSE.len()..];
-            *skipping_reminder = false;
+            remaining = &remaining[end + close.len()..];
+            *skipping = None;
         }
 
-        let Some(start) = remaining.find(SYSTEM_REMINDER_OPEN) else {
+        let earliest_open = markers
+            .iter()
+            .enumerate()
+            .filter_map(|(index, marker)| {
+                remaining
+                    .find(marker.open.as_str())
+                    .map(|position| (position, index))
+            })
+            .min();
+        let Some((start, index)) = earliest_open else {
             output.push_str(remaining);
             return output;
         };
         output.push_str(&remaining[..start]);
-        let after_open = &remaining[start + SYSTEM_REMINDER_OPEN.len()..];
-        if let Some(end) = after_open.find(SYSTEM_REMINDER_CLOSE) {
-            remaining = &after_open[end + SYSTEM_REMINDER_CLOSE.len()..];
+        let marker = &markers[index];
+        let after_open = &remaining[start + marker.open.len()..];
+        if let Some(end) = after_open.find(marker.close.as_str()) {
+            remaining = &after_open[end + marker.close.len()..];
         } else {
-            *skipping_reminder = true;
+            *skipping = Some(index);
             return output;
         }
     }

--- a/crates/mempal-runtime/src/ingest/normalize.rs
+++ b/crates/mempal-runtime/src/ingest/normalize.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use super::detect::{Format, extract_content_text, extract_message_text};
 use super::noise::{strip_claude_jsonl_noise, strip_codex_rollout_noise};
 
-pub const CURRENT_NORMALIZE_VERSION: u32 = 2;
+pub const CURRENT_NORMALIZE_VERSION: u32 = 3;
 
 pub type Result<T> = std::result::Result<T, NormalizeError>;
 
@@ -320,6 +320,19 @@ mod tests {
 
         let normalized = normalize_codex_jsonl(content, true).expect("normalize codex");
         assert_eq!(normalized.content, "> first line\nsecond line\nanswer");
+    }
+
+    #[test]
+    fn codex_normalize_drops_runtime_preamble_user_messages() {
+        // Issue #10: Codex injects runtime preamble as role=user messages;
+        // wrapper-only messages must not become transcript lines.
+        let content = r#"{"timestamp":"2026-07-26T10:00:00.000Z","type":"session_meta","payload":{"cwd":"/tmp/project"}}
+{"timestamp":"2026-07-26T10:00:00.100Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<user_instructions>\nAGENTS.md content\n</user_instructions>"}]}}
+{"timestamp":"2026-07-26T10:00:00.200Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>\nfix the bug"}]}}
+{"timestamp":"2026-07-26T10:00:00.300Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}"#;
+
+        let normalized = normalize_codex_jsonl(content, true).expect("normalize codex");
+        assert_eq!(normalized.content, "> fix the bug\ndone");
     }
 
     #[test]

--- a/docs/plans/2026-07-26-p115-codex-preamble-noise-strip.md
+++ b/docs/plans/2026-07-26-p115-codex-preamble-noise-strip.md
@@ -1,0 +1,39 @@
+# P115 实现计划 — Codex runtime preamble strip + normalize version bump
+
+日期：2026-07-26
+Spec：`specs/p115-codex-preamble-noise-strip.spec.md`
+背景：PR #7 / #84 / #85 合并后的收尾，含 GitHub issue #10 的修复。
+
+## 步骤
+
+1. **RED（先写失败测试）**
+   - `tests/noise_strip.rs`：
+     - `<user_instructions>` / `<environment_context>` / `<recommended_plugins>`
+       / `<INSTRUCTIONS>` / `<turn_aborted>` 块被整体剥离，块外文本保留；
+     - 纯 wrapper 的 user message 在 codex normalize 后不产生 transcript 行；
+     - 代码围栏内的 wrapper 标签不剥离。
+   - `crates/mempal-runtime/src/ingest/normalize.rs`：钉死
+     `CURRENT_NORMALIZE_VERSION == 3`（PR #7 + P115 共同改变了归一化输出，
+     `reindex --stale` 依赖版本号发现旧 source）。
+   - `crates/mempal-runtime/src/ingest/detect.rs`：`session_meta` +
+     `turn_context`-only 文件不判为 Codex；补 `event_msg`/`response_item`
+     后判为 Codex。
+
+2. **GREEN（最小实现）**
+   - `noise.rs`：把 system-reminder 的成对标签剥离机制泛化为 marker-pair
+     列表；`strip_codex_rollout_noise` 使用上述 5 个 wrapper 标签对 +
+     既有 session marker 规则。
+   - `normalize.rs`：`CURRENT_NORMALIZE_VERSION = 3`。
+   - `detect.rs`：`is_codex_jsonl` 要求至少一条 `event_msg` 或
+     `response_item`；`turn_context`/`compacted`/未知 type 容忍但不作数。
+
+3. **验证**：workspace `cargo test`、`cargo clippy`、`cargo fmt --check`。
+
+4. **收尾**：更新 `AGENTS.md` / `CLAUDE.md` 的 spec 与 plan inventory；
+   commit；`mempal_ingest` 存决策记录；报告 issue triage 结论
+   （#1/#2/#3/#4/#9/#11 已修可关闭，#10 由本 P 修复，#81 为 feature 提案
+   另立 P）。
+
+## 状态
+
+已完成。

--- a/specs/p115-codex-preamble-noise-strip.spec.md
+++ b/specs/p115-codex-preamble-noise-strip.spec.md
@@ -1,0 +1,79 @@
+spec: task
+name: "P115: Codex runtime preamble strip + normalize version bump"
+inherits: project
+tags: [ingest, normalize, noise, codex, detect]
+estimate: 0.5d
+---
+
+## Intent
+
+P115 is the post-merge hardening pass for PR #7 (Codex rollout ingest, merged
+as 2fe3ce8) and the fix for GitHub issue #10 (Codex runtime preamble pollutes
+imported memory). Three gaps remain after the PR #7 merge:
+
+1. Current Codex rollouts inject runtime preamble as `role=user` messages
+   (`<user_instructions>` carrying AGENTS.md, `<environment_context>`,
+   `<recommended_plugins>`, legacy `<INSTRUCTIONS>`), which the new
+   `response_item` normalize path stores verbatim — issue #10 persists.
+2. PR #7 changed normalization output (Codex `response_item` preference and the
+   shared `extract_content_text` block-text extraction used by the
+   Claude-export and ChatGPT paths) without bumping
+   `CURRENT_NORMALIZE_VERSION`, so `reindex --stale` cannot find sources
+   normalized under the old rules.
+3. Detection (`is_codex_jsonl`) now accepts a file containing only
+   `session_meta` plus a `turn_context`/`compacted` record — zero messages —
+   and any third-party JSONL with a `session_meta`-typed line can be
+   misrouted to the Codex path.
+
+## Decisions
+
+- Strip Codex runtime wrapper blocks in `strip_codex_rollout_noise` for the
+  evidence-based tag set: `<INSTRUCTIONS>`, `<user_instructions>`,
+  `<environment_context>`, `<recommended_plugins>`, `<turn_aborted>`.
+  Block strip is paired-tag removal (open through matching close), code-fence
+  aware, reusing the existing system-reminder strip machinery generalized to
+  arbitrary marker pairs.
+- A user message that consists entirely of wrapper blocks strips to empty and
+  is dropped by the existing empty-message filtering; no separate
+  message-level skip list.
+- Bump `CURRENT_NORMALIZE_VERSION` from 2 to 3 exactly once for the combined
+  PR #7 + P115 normalization change, so one `mempal reindex --stale` pass
+  re-normalizes previously ingested Claude/Codex/ChatGPT sources.
+- Tighten `is_codex_jsonl`: a file is Codex JSONL only if it has
+  `session_meta` AND at least one message-bearing record type (`event_msg` or
+  `response_item`). `turn_context`, `compacted`, and unknown typed records
+  stay tolerated but are not sufficient evidence on their own.
+- Do not change the legacy `event_msg` fallback ordering, chunking, drawer
+  identity, schema version, or any MCP tool contract in P115.
+
+## Boundaries
+
+### Allowed Changes
+- crates/mempal-runtime/src/ingest/noise.rs
+- crates/mempal-runtime/src/ingest/normalize.rs
+- crates/mempal-runtime/src/ingest/detect.rs
+- tests/noise_strip.rs
+- specs/p115-codex-preamble-noise-strip.spec.md
+- docs/plans/2026-07-26-p115-codex-preamble-noise-strip.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not add a schema migration, database table, or database column.
+- Do not rewrite, delete, or re-embed existing drawers (re-normalization only
+  happens through the explicit `reindex --stale` flow).
+- Do not change drawer identity hashing, search ranking, or MCP response
+  shapes.
+- Do not strip wrapper tags that appear inside fenced code blocks.
+
+## Acceptance
+
+- `strip_codex_rollout_noise` removes each listed wrapper block, including
+  multi-line blocks, and preserves surrounding real text.
+- A Codex rollout whose only user-message content is a wrapper block produces
+  no transcript line for that message.
+- `CURRENT_NORMALIZE_VERSION == 3`.
+- `detect_format` returns `PlainText` for a JSONL file with `session_meta` +
+  `turn_context` only, and `CodexJsonl` once an `event_msg` or `response_item`
+  record is present.
+- `cargo test` (workspace), `cargo clippy`, `cargo fmt --check` pass.

--- a/specs/p115-codex-preamble-noise-strip.spec.md
+++ b/specs/p115-codex-preamble-noise-strip.spec.md
@@ -72,7 +72,8 @@ Rule: wrapper-strip  Codex runtime preamble wrappers never enter memory
 
 Scenario: each wrapper tag block is stripped with surrounding text kept
   Test:
-    Filter: cargo test --test noise_strip test_codex_all_wrapper_tags_stripped
+    Package: mempal
+    Filter: test_codex_all_wrapper_tags_stripped
   Given content wrapping boilerplate in each of INSTRUCTIONS, user_instructions, environment_context, recommended_plugins, and turn_aborted tags
   When strip_codex_rollout_noise runs
   Then the wrapper block and its payload are removed
@@ -80,7 +81,8 @@ Scenario: each wrapper tag block is stripped with surrounding text kept
 
 Scenario: multi-line wrapper blocks strip while real text survives
   Test:
-    Filter: cargo test --test noise_strip test_codex_runtime_preamble_wrappers_stripped
+    Package: mempal
+    Filter: test_codex_runtime_preamble_wrappers_stripped
   Given a user_instructions block, real request text, and an environment_context block
   When strip_codex_rollout_noise runs
   Then both wrapper blocks are removed entirely
@@ -88,21 +90,24 @@ Scenario: multi-line wrapper blocks strip while real text survives
 
 Scenario: wrapper-only content strips to blank
   Test:
-    Filter: cargo test --test noise_strip test_codex_wrapper_only_message_strips_to_blank
+    Package: mempal
+    Filter: test_codex_wrapper_only_message_strips_to_blank
   Given content that is exactly one recommended_plugins block
   When strip_codex_rollout_noise runs
   Then the result is blank
 
 Scenario: wrapper tags inside code fences are preserved
   Test:
-    Filter: cargo test --test noise_strip test_codex_wrapper_inside_code_fence_preserved
+    Package: mempal
+    Filter: test_codex_wrapper_inside_code_fence_preserved
   Given an environment_context tag inside a fenced code block
   When strip_codex_rollout_noise runs
   Then the fenced content is preserved verbatim
 
 Scenario: preamble-only user messages produce no transcript line
   Test:
-    Filter: cargo test -p mempal-runtime --lib ingest::normalize::tests::codex_normalize_drops_runtime_preamble_user_messages
+    Package: mempal-runtime
+    Filter: ingest::normalize::tests::codex_normalize_drops_runtime_preamble_user_messages
   Given a rollout whose user messages are a user_instructions block and an environment_context block followed by real text
   When normalize_codex_jsonl runs with noise stripping
   Then only the real user text and assistant reply appear in the transcript
@@ -111,7 +116,8 @@ Rule: normalize-version  Old sources become reachable for re-normalization
 
 Scenario: the normalize version is pinned at 3
   Test:
-    Filter: cargo test --test noise_strip test_normalize_version_bump_triggers_reindex_opportunity
+    Package: mempal
+    Filter: test_normalize_version_bump_triggers_reindex_opportunity
   Given a drawer stored with normalize_version 1
   When reindex --stale runs
   Then the source is re-normalized
@@ -121,14 +127,16 @@ Rule: codex-detection  Detection needs message-bearing evidence
 
 Scenario: session_meta plus context-only records is not Codex
   Test:
-    Filter: cargo test -p mempal-runtime --lib ingest::detect::tests::rejects_codex_rollout_without_message_records
+    Package: mempal-runtime
+    Filter: ingest::detect::tests::rejects_codex_rollout_without_message_records
   Given a JSONL file with only session_meta, turn_context, and compacted records
   When detect_format runs
   Then the format is PlainText
 
 Scenario: current rollouts with new record types still detect
   Test:
-    Filter: cargo test -p mempal-runtime --lib ingest::detect::tests::detects_current_codex_rollout_with_turn_context_and_compacted
+    Package: mempal-runtime
+    Filter: ingest::detect::tests::detects_current_codex_rollout_with_turn_context_and_compacted
   Given a rollout containing session_meta, turn_context, response_item, compacted, and event_msg records
   When detect_format runs
   Then the format is CodexJsonl

--- a/specs/p115-codex-preamble-noise-strip.spec.md
+++ b/specs/p115-codex-preamble-noise-strip.spec.md
@@ -66,14 +66,69 @@ imported memory). Three gaps remain after the PR #7 merge:
   shapes.
 - Do not strip wrapper tags that appear inside fenced code blocks.
 
-## Acceptance
+## Acceptance Criteria
 
-- `strip_codex_rollout_noise` removes each listed wrapper block, including
-  multi-line blocks, and preserves surrounding real text.
-- A Codex rollout whose only user-message content is a wrapper block produces
-  no transcript line for that message.
-- `CURRENT_NORMALIZE_VERSION == 3`.
-- `detect_format` returns `PlainText` for a JSONL file with `session_meta` +
-  `turn_context` only, and `CodexJsonl` once an `event_msg` or `response_item`
-  record is present.
-- `cargo test` (workspace), `cargo clippy`, `cargo fmt --check` pass.
+Rule: wrapper-strip  Codex runtime preamble wrappers never enter memory
+
+Scenario: each wrapper tag block is stripped with surrounding text kept
+  Test:
+    Filter: cargo test --test noise_strip test_codex_all_wrapper_tags_stripped
+  Given content wrapping boilerplate in each of INSTRUCTIONS, user_instructions, environment_context, recommended_plugins, and turn_aborted tags
+  When strip_codex_rollout_noise runs
+  Then the wrapper block and its payload are removed
+  And the text before and after the block is preserved
+
+Scenario: multi-line wrapper blocks strip while real text survives
+  Test:
+    Filter: cargo test --test noise_strip test_codex_runtime_preamble_wrappers_stripped
+  Given a user_instructions block, real request text, and an environment_context block
+  When strip_codex_rollout_noise runs
+  Then both wrapper blocks are removed entirely
+  And the real request text is preserved
+
+Scenario: wrapper-only content strips to blank
+  Test:
+    Filter: cargo test --test noise_strip test_codex_wrapper_only_message_strips_to_blank
+  Given content that is exactly one recommended_plugins block
+  When strip_codex_rollout_noise runs
+  Then the result is blank
+
+Scenario: wrapper tags inside code fences are preserved
+  Test:
+    Filter: cargo test --test noise_strip test_codex_wrapper_inside_code_fence_preserved
+  Given an environment_context tag inside a fenced code block
+  When strip_codex_rollout_noise runs
+  Then the fenced content is preserved verbatim
+
+Scenario: preamble-only user messages produce no transcript line
+  Test:
+    Filter: cargo test -p mempal-runtime --lib ingest::normalize::tests::codex_normalize_drops_runtime_preamble_user_messages
+  Given a rollout whose user messages are a user_instructions block and an environment_context block followed by real text
+  When normalize_codex_jsonl runs with noise stripping
+  Then only the real user text and assistant reply appear in the transcript
+
+Rule: normalize-version  Old sources become reachable for re-normalization
+
+Scenario: the normalize version is pinned at 3
+  Test:
+    Filter: cargo test --test noise_strip test_normalize_version_bump_triggers_reindex_opportunity
+  Given a drawer stored with normalize_version 1
+  When reindex --stale runs
+  Then the source is re-normalized
+  And CURRENT_NORMALIZE_VERSION equals 3
+
+Rule: codex-detection  Detection needs message-bearing evidence
+
+Scenario: session_meta plus context-only records is not Codex
+  Test:
+    Filter: cargo test -p mempal-runtime --lib ingest::detect::tests::rejects_codex_rollout_without_message_records
+  Given a JSONL file with only session_meta, turn_context, and compacted records
+  When detect_format runs
+  Then the format is PlainText
+
+Scenario: current rollouts with new record types still detect
+  Test:
+    Filter: cargo test -p mempal-runtime --lib ingest::detect::tests::detects_current_codex_rollout_with_turn_context_and_compacted
+  Given a rollout containing session_meta, turn_context, response_item, compacted, and event_msg records
+  When detect_format runs
+  Then the format is CodexJsonl

--- a/tests/noise_strip.rs
+++ b/tests/noise_strip.rs
@@ -204,7 +204,71 @@ async fn test_normalize_version_bump_triggers_reindex_opportunity() {
         )
         .expect("read normalize_version");
     assert_eq!(version, CURRENT_NORMALIZE_VERSION);
-    assert_eq!(CURRENT_NORMALIZE_VERSION, 2);
+    // P115: PR #7 (response_item preference + shared block-text extraction)
+    // plus the codex wrapper strip changed normalize output; version 3 lets
+    // `reindex --stale` find sources normalized under the old rules.
+    assert_eq!(CURRENT_NORMALIZE_VERSION, 3);
+}
+
+#[test]
+fn test_codex_runtime_preamble_wrappers_stripped() {
+    let content = "<user_instructions>\nAGENTS.md boilerplate\n</user_instructions>\nreal request\n<environment_context>\n<cwd>/tmp/x</cwd>\n</environment_context>\nmore work";
+
+    let stripped = strip_codex_rollout_noise(content);
+
+    assert!(!stripped.contains("AGENTS.md boilerplate"), "{stripped}");
+    assert!(!stripped.contains("user_instructions"), "{stripped}");
+    assert!(!stripped.contains("environment_context"), "{stripped}");
+    assert!(!stripped.contains("<cwd>"), "{stripped}");
+    assert!(stripped.contains("real request"), "{stripped}");
+    assert!(stripped.contains("more work"), "{stripped}");
+}
+
+#[test]
+fn test_codex_all_wrapper_tags_stripped() {
+    for tag in [
+        "INSTRUCTIONS",
+        "user_instructions",
+        "environment_context",
+        "recommended_plugins",
+        "turn_aborted",
+    ] {
+        let content = format!("before\n<{tag}>\nboilerplate payload\n</{tag}>\nafter");
+
+        let stripped = strip_codex_rollout_noise(&content);
+
+        assert!(
+            !stripped.contains("boilerplate payload") && !stripped.contains(tag),
+            "wrapper <{tag}> not stripped: {stripped}"
+        );
+        assert!(stripped.contains("before"), "{stripped}");
+        assert!(stripped.contains("after"), "{stripped}");
+    }
+}
+
+#[test]
+fn test_codex_wrapper_only_message_strips_to_blank() {
+    let content = "<recommended_plugins>\nplugin list here\n</recommended_plugins>";
+
+    let stripped = strip_codex_rollout_noise(content);
+
+    assert!(
+        stripped.trim().is_empty(),
+        "wrapper-only content should strip to blank: {stripped:?}"
+    );
+}
+
+#[test]
+fn test_codex_wrapper_inside_code_fence_preserved() {
+    let content = "```xml\n<environment_context>sample</environment_context>\n```\ndone";
+
+    let stripped = strip_codex_rollout_noise(content);
+
+    assert!(
+        stripped.contains("<environment_context>sample</environment_context>"),
+        "{stripped}"
+    );
+    assert!(stripped.contains("done"), "{stripped}");
 }
 
 #[test]


### PR DESCRIPTION
## 背景

PR #7 / #84 / #85 合并后的收尾（P115），修复 GitHub issue #10。

真实数据验证：扫描本机 8 个 2026-07 的 `~/.codex/sessions` rollout，确认当前 Codex 把 runtime preamble 以 `role=user` 消息注入（实测出现 `<recommended_plugins>`、`<environment_context>`；issue #10 另报告 `<INSTRUCTIONS>` / AGENTS.md wrapper）。PR #7 合并后这些 preamble 会被 `response_item` 归一化路径原样入库，污染记忆库。

## 修改

1. **`strip_codex_rollout_noise` 剥离 Codex runtime wrapper 块**（fixes #10）
   - 标签集：`<INSTRUCTIONS>` / `<user_instructions>` / `<environment_context>` / `<recommended_plugins>` / `<turn_aborted>`
   - 实现：把 system-reminder 剥离泛化为 code-fence-aware 的 marker-pair 机制（`strip_marker_blocks`），Claude 与 Codex 路径共用
   - 纯 preamble 的 user message 剥空后由 `render_transcript` 自然丢弃，不产生 transcript 行
2. **`CURRENT_NORMALIZE_VERSION` 2 → 3**
   - PR #7 已改变归一化输出（`response_item` 优先 + 共享 `extract_content_text` 的 block-text 提取同时影响 Claude-export/ChatGPT 路径）但未 bump 版本；本次一并 bump，使 `mempal reindex --stale` 能重拾旧规则归一化的 source
3. **`is_codex_jsonl` 检测收紧**
   - 要求 `session_meta` 且至少一条 `event_msg` / `response_item`；`turn_context` / `compacted` / 未知类型容忍但不单独作为判定依据，防止零消息文件与恰好含 `session_meta` 行的第三方 JSONL 误判为 Codex
4. `cargo fmt`（修掉随 #84 合入 main 的 `server.rs:5029` 格式漂移）
5. 治理：新增 `specs/p115-codex-preamble-noise-strip.spec.md` + `docs/plans/2026-07-26-p115-codex-preamble-noise-strip.md`，同步 AGENTS.md / CLAUDE.md inventory

## 验证

- TDD：6 个新测试先行并确认 RED（wrapper 剥离 4 个、normalize preamble 丢弃、detect 收紧），实现后全绿
- `cargo test --workspace` 全部通过；`cargo clippy --workspace --all-targets` 无告警；`cargo fmt --all --check` 通过

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)