### PR TITLE
chore: release v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mempal"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "mempal-agent-memory"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "mempal-embed"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "model2vec-rs",
@@ -1584,11 +1584,11 @@ dependencies = [
 
 [[package]]
 name = "mempal-mcp-protocol"
-version = "0.9.0"
+version = "0.9.1"
 
 [[package]]
 name = "mempal-mcp-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "mempal-runtime"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1630,11 +1630,11 @@ dependencies = [
 
 [[package]]
 name = "mempal-search-core"
-version = "0.9.0"
+version = "0.9.1"
 
 [[package]]
 name = "mempal-store-sqlite"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "mempal-agent-memory",
  "mempal-search-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempal"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "Project memory for coding agents. Single binary, hybrid search, knowledge graph."
@@ -56,13 +56,13 @@ bimap = "0.6"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
 jieba-rs = "0.8"
-mempal-agent-memory = { version = "0.9.0", path = "crates/mempal-agent-memory" }
-mempal-embed = { version = "0.9.0", path = "crates/mempal-embed", default-features = false }
-mempal-mcp-server = { version = "0.9.0", path = "crates/mempal-mcp-server", default-features = false }
-mempal-mcp-protocol = { version = "0.9.0", path = "crates/mempal-mcp-protocol" }
-mempal-runtime = { version = "0.9.0", path = "crates/mempal-runtime", default-features = false }
-mempal-search-core = { version = "0.9.0", path = "crates/mempal-search-core" }
-mempal-store-sqlite = { version = "0.9.0", path = "crates/mempal-store-sqlite" }
+mempal-agent-memory = { version = "0.9.1", path = "crates/mempal-agent-memory" }
+mempal-embed = { version = "0.9.1", path = "crates/mempal-embed", default-features = false }
+mempal-mcp-server = { version = "0.9.1", path = "crates/mempal-mcp-server", default-features = false }
+mempal-mcp-protocol = { version = "0.9.1", path = "crates/mempal-mcp-protocol" }
+mempal-runtime = { version = "0.9.1", path = "crates/mempal-runtime", default-features = false }
+mempal-search-core = { version = "0.9.1", path = "crates/mempal-search-core" }
+mempal-store-sqlite = { version = "0.9.1", path = "crates/mempal-store-sqlite" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rmcp = { version = "1.3.0", features = ["server", "macros", "schemars", "transport-async-rw", "transport-io"] }
 rusqlite = { version = "0.37", features = ["bundled"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Project memory for coding agents. Single binary, `cargo install mempal`, find past decisions with citations in seconds.
 
-Latest release: **v0.9.0** (2026-07-09).
+Latest release: **v0.9.1** (2026-08-19).
 
 ## What It Does
 
@@ -28,7 +28,7 @@ Next session (any agent) → mempal search → finds the decision with source ci
 ## Quick Start
 
 ```bash
-cargo install mempal --version 0.9.0 --locked
+cargo install mempal --version 0.9.1 --locked
 
 mempal init ~/code/myapp
 mempal ingest ~/code/myapp --wing myapp
@@ -39,7 +39,7 @@ mempal wake-up
 With REST support:
 
 ```bash
-cargo install mempal --version 0.9.0 --locked --features rest
+cargo install mempal --version 0.9.1 --locked --features rest
 ```
 
 From a source checkout:

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,7 +9,7 @@
 
 Coding agent 的项目记忆工具。单二进制，`cargo install mempal`，10 秒内带出处找回历史决策。
 
-最新版本：**v0.9.0**（2026-07-09）。
+最新版本：**v0.9.1**（2026-08-19）。
 
 ## 做什么
 
@@ -28,7 +28,7 @@ Agent 写代码 → 提交 → mempal 保存决策上下文
 ## 快速开始
 
 ```bash
-cargo install mempal --version 0.9.0 --locked
+cargo install mempal --version 0.9.1 --locked
 
 mempal init ~/code/myapp
 mempal ingest ~/code/myapp --wing myapp
@@ -39,7 +39,7 @@ mempal wake-up
 启用 REST 支持：
 
 ```bash
-cargo install mempal --version 0.9.0 --locked --features rest
+cargo install mempal --version 0.9.1 --locked --features rest
 ```
 
 从源码 checkout 安装：

--- a/crates/mempal-agent-memory/Cargo.toml
+++ b/crates/mempal-agent-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempal-agent-memory"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "Reusable agent-memory domain types and anchor helpers for mempal."

--- a/crates/mempal-embed/Cargo.toml
+++ b/crates/mempal-embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempal-embed"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "Reusable embedding traits and implementations for mempal."

--- a/crates/mempal-mcp-protocol/Cargo.toml
+++ b/crates/mempal-mcp-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempal-mcp-protocol"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "Self-describing MCP memory protocol text for mempal agents."

--- a/crates/mempal-mcp-server/Cargo.toml
+++ b/crates/mempal-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempal-mcp-server"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "MCP server adapter for mempal runtime tools."
@@ -19,7 +19,7 @@ onnx = ["mempal-runtime/onnx"]
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-mempal-runtime = { version = "0.9.0", path = "../mempal-runtime", default-features = false }
+mempal-runtime = { version = "0.9.1", path = "../mempal-runtime", default-features = false }
 rmcp = { version = "1.3.0", features = ["server", "macros", "schemars", "transport-async-rw", "transport-io"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/mempal-runtime/Cargo.toml
+++ b/crates/mempal-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempal-runtime"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "Reusable mempal runtime workflows built on agent memory storage."
@@ -23,11 +23,11 @@ bimap = "0.6"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
 jieba-rs = "0.8"
-mempal-agent-memory = { version = "0.9.0", path = "../mempal-agent-memory" }
-mempal-embed = { version = "0.9.0", path = "../mempal-embed", default-features = false }
-mempal-mcp-protocol = { version = "0.9.0", path = "../mempal-mcp-protocol" }
-mempal-search-core = { version = "0.9.0", path = "../mempal-search-core" }
-mempal-store-sqlite = { version = "0.9.0", path = "../mempal-store-sqlite" }
+mempal-agent-memory = { version = "0.9.1", path = "../mempal-agent-memory" }
+mempal-embed = { version = "0.9.1", path = "../mempal-embed", default-features = false }
+mempal-mcp-protocol = { version = "0.9.1", path = "../mempal-mcp-protocol" }
+mempal-search-core = { version = "0.9.1", path = "../mempal-search-core" }
+mempal-store-sqlite = { version = "0.9.1", path = "../mempal-store-sqlite" }
 rmcp = { version = "1.3.0", features = ["schemars"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/mempal-search-core/Cargo.toml
+++ b/crates/mempal-search-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempal-search-core"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "Reusable FTS5 and RRF hybrid-search primitives for mempal."

--- a/crates/mempal-store-sqlite/Cargo.toml
+++ b/crates/mempal-store-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempal-store-sqlite"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT"
 description = "SQLite storage layer for mempal agent memory."
@@ -12,8 +12,8 @@ keywords = ["memory", "sqlite", "agents", "search"]
 categories = ["database", "development-tools"]
 
 [dependencies]
-mempal-agent-memory = { version = "0.9.0", path = "../mempal-agent-memory" }
-mempal-search-core = { version = "0.9.0", path = "../mempal-search-core" }
+mempal-agent-memory = { version = "0.9.1", path = "../mempal-agent-memory" }
+mempal-search-core = { version = "0.9.1", path = "../mempal-search-core" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,13 +24,13 @@ Before using the CLI, keep four nouns straight:
 Install the latest released CLI from crates.io:
 
 ```bash
-cargo install mempal --version 0.9.0 --locked
+cargo install mempal --version 0.9.1 --locked
 ```
 
 Install with REST support:
 
 ```bash
-cargo install mempal --version 0.9.0 --locked --features rest
+cargo install mempal --version 0.9.1 --locked --features rest
 ```
 
 For development without installation:


### PR DESCRIPTION
## Release scope

- ship P115 Codex runtime preamble stripping and normalize version 3
- ship P116 cowork pair delivery receipts
- ship P117 atomic, collision-safe, knowledge-reference-safe reindex replacement
- publish the root CLI plus all seven reusable workspace crates at 0.9.1
- update English and Chinese installation documentation

## Verification

- cargo metadata --locked: all eight mempal packages report 0.9.1
- cargo check --workspace --all-targets --all-features --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- cargo build --workspace --release --all-features --locked
- cargo package --workspace --locked
- cargo run --quiet --locked -- release-readiness --format json: ready, no warnings

## Known packaging note

Cargo reports the pre-existing yanked core2 0.4.0 lockfile warning while packaging runtime-dependent crates. Packaging and isolated verification complete successfully; no dependency versions change in this patch release.