### PR TITLE
fix(ingest): atomic reindex replace + honest dry-run report (P117)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p114-coarse-workspace-split.spec.md` | 完成 | P114 coarse workspace split：新增公开可发布的 `mempal-store-sqlite` / `mempal-runtime` / `mempal-mcp-server` 三个粗粒度 crate，把 SQLite storage、runtime workflows、MCP server wiring 从 root 拆出，同时保留 root CLI 和 legacy facade paths |
 | `specs/p115-codex-preamble-noise-strip.spec.md` | 完成 | P115 Codex runtime preamble strip：`strip_codex_rollout_noise` 剥离 `<INSTRUCTIONS>` / `<user_instructions>` / `<environment_context>` / `<recommended_plugins>` / `<turn_aborted>` wrapper 块（GitHub #10）；`CURRENT_NORMALIZE_VERSION` 2→3 让 `reindex --stale` 重拾 PR #7 前的旧 source；`is_codex_jsonl` 要求至少一条 `event_msg`/`response_item` |
 | `specs/p116-cowork-pair-delivery-receipts.spec.md` | 完成 | P116 cowork pair-push delivery receipts：pair 通道每条 push 基于确定性 base 生成唯一 `message_id`（`CoworkPushResponse` 返回），push/drain 写有界 receipts event log，`mempal cowork-receipts` / `cowork-status` 汇总 pending/drained/lost，`cowork-drain --hook-runtime` 记录注入 runtime（GitHub #81） |
-| `specs/p117-reindex-atomic-replace.spec.md` | 完成 | P117 atomic reindex replace：source 替换重排为 embed 先行 + 单事务 delete/insert（embed/insert 失败不再丢旧数据），`reindex --stale --dry-run` 补 missing-source 扫描成为真实可行性报告；file-less source（MCP 直录）保持不可重归一化 |
+| `specs/p117-reindex-atomic-replace.spec.md` | 完成 | P117 atomic reindex replace：embed 先行并验证向量基数，delete/insert 单事务且 closure/COMMIT/ID 冲突失败均回滚；dry-run/real-run 报告并跳过 missing-source 与 Stage-1/Phase-2 knowledge 引用保护的 source，避免 evidence refs 悬空；file-less source 保持不可重归一化 |
 
 ### 当前 Spec（草稿，未实现）
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p114-coarse-workspace-split.spec.md` | 完成 | P114 coarse workspace split：新增公开可发布的 `mempal-store-sqlite` / `mempal-runtime` / `mempal-mcp-server` 三个粗粒度 crate，把 SQLite storage、runtime workflows、MCP server wiring 从 root 拆出，同时保留 root CLI 和 legacy facade paths |
 | `specs/p115-codex-preamble-noise-strip.spec.md` | 完成 | P115 Codex runtime preamble strip：`strip_codex_rollout_noise` 剥离 `<INSTRUCTIONS>` / `<user_instructions>` / `<environment_context>` / `<recommended_plugins>` / `<turn_aborted>` wrapper 块（GitHub #10）；`CURRENT_NORMALIZE_VERSION` 2→3 让 `reindex --stale` 重拾 PR #7 前的旧 source；`is_codex_jsonl` 要求至少一条 `event_msg`/`response_item` |
 | `specs/p116-cowork-pair-delivery-receipts.spec.md` | 完成 | P116 cowork pair-push delivery receipts：pair 通道每条 push 基于确定性 base 生成唯一 `message_id`（`CoworkPushResponse` 返回），push/drain 写有界 receipts event log，`mempal cowork-receipts` / `cowork-status` 汇总 pending/drained/lost，`cowork-drain --hook-runtime` 记录注入 runtime（GitHub #81） |
+| `specs/p117-reindex-atomic-replace.spec.md` | 完成 | P117 atomic reindex replace：source 替换重排为 embed 先行 + 单事务 delete/insert（embed/insert 失败不再丢旧数据），`reindex --stale --dry-run` 补 missing-source 扫描成为真实可行性报告；file-less source（MCP 直录）保持不可重归一化 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -292,6 +293,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-07-09-p114-coarse-workspace-split.md` — P114 coarse workspace split（已完成）
 - `docs/plans/2026-07-26-p115-codex-preamble-noise-strip.md` — P115 Codex runtime preamble strip + normalize version bump（已完成）
 - `docs/plans/2026-07-26-p116-cowork-pair-delivery-receipts.md` — P116 cowork pair-push delivery receipts（已完成）
+- `docs/plans/2026-08-18-p117-reindex-atomic-replace.md` — P117 atomic reindex replace + dry-run feasibility report（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p114-coarse-workspace-split.spec.md` | 完成 | P114 coarse workspace split：新增公开可发布的 `mempal-store-sqlite` / `mempal-runtime` / `mempal-mcp-server` 三个粗粒度 crate，把 SQLite storage、runtime workflows、MCP server wiring 从 root 拆出，同时保留 root CLI 和 legacy facade paths |
 | `specs/p115-codex-preamble-noise-strip.spec.md` | 完成 | P115 Codex runtime preamble strip：`strip_codex_rollout_noise` 剥离 `<INSTRUCTIONS>` / `<user_instructions>` / `<environment_context>` / `<recommended_plugins>` / `<turn_aborted>` wrapper 块（GitHub #10）；`CURRENT_NORMALIZE_VERSION` 2→3 让 `reindex --stale` 重拾 PR #7 前的旧 source；`is_codex_jsonl` 要求至少一条 `event_msg`/`response_item` |
 | `specs/p116-cowork-pair-delivery-receipts.spec.md` | 完成 | P116 cowork pair-push delivery receipts：pair 通道每条 push 基于确定性 base 生成唯一 `message_id`（`CoworkPushResponse` 返回），push/drain 写有界 receipts event log，`mempal cowork-receipts` / `cowork-status` 汇总 pending/drained/lost，`cowork-drain --hook-runtime` 记录注入 runtime（GitHub #81） |
+| `specs/p117-reindex-atomic-replace.spec.md` | 完成 | P117 atomic reindex replace：source 替换重排为 embed 先行 + 单事务 delete/insert（embed/insert 失败不再丢旧数据），`reindex --stale --dry-run` 补 missing-source 扫描成为真实可行性报告；file-less source（MCP 直录）保持不可重归一化 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -290,6 +291,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-07-09-p114-coarse-workspace-split.md` — P114 coarse workspace split（已完成）
 - `docs/plans/2026-07-26-p115-codex-preamble-noise-strip.md` — P115 Codex runtime preamble strip + normalize version bump（已完成）
 - `docs/plans/2026-07-26-p116-cowork-pair-delivery-receipts.md` — P116 cowork pair-push delivery receipts（已完成）
+- `docs/plans/2026-08-18-p117-reindex-atomic-replace.md` — P117 atomic reindex replace + dry-run feasibility report（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p114-coarse-workspace-split.spec.md` | 完成 | P114 coarse workspace split：新增公开可发布的 `mempal-store-sqlite` / `mempal-runtime` / `mempal-mcp-server` 三个粗粒度 crate，把 SQLite storage、runtime workflows、MCP server wiring 从 root 拆出，同时保留 root CLI 和 legacy facade paths |
 | `specs/p115-codex-preamble-noise-strip.spec.md` | 完成 | P115 Codex runtime preamble strip：`strip_codex_rollout_noise` 剥离 `<INSTRUCTIONS>` / `<user_instructions>` / `<environment_context>` / `<recommended_plugins>` / `<turn_aborted>` wrapper 块（GitHub #10）；`CURRENT_NORMALIZE_VERSION` 2→3 让 `reindex --stale` 重拾 PR #7 前的旧 source；`is_codex_jsonl` 要求至少一条 `event_msg`/`response_item` |
 | `specs/p116-cowork-pair-delivery-receipts.spec.md` | 完成 | P116 cowork pair-push delivery receipts：pair 通道每条 push 基于确定性 base 生成唯一 `message_id`（`CoworkPushResponse` 返回），push/drain 写有界 receipts event log，`mempal cowork-receipts` / `cowork-status` 汇总 pending/drained/lost，`cowork-drain --hook-runtime` 记录注入 runtime（GitHub #81） |
-| `specs/p117-reindex-atomic-replace.spec.md` | 完成 | P117 atomic reindex replace：source 替换重排为 embed 先行 + 单事务 delete/insert（embed/insert 失败不再丢旧数据），`reindex --stale --dry-run` 补 missing-source 扫描成为真实可行性报告；file-less source（MCP 直录）保持不可重归一化 |
+| `specs/p117-reindex-atomic-replace.spec.md` | 完成 | P117 atomic reindex replace：embed 先行并验证向量基数，delete/insert 单事务且 closure/COMMIT/ID 冲突失败均回滚；dry-run/real-run 报告并跳过 missing-source 与 Stage-1/Phase-2 knowledge 引用保护的 source，避免 evidence refs 悬空；file-less source 保持不可重归一化 |
 
 ### 当前 Spec（草稿，未实现）
 

--- a/crates/mempal-runtime/src/ingest/mod.rs
+++ b/crates/mempal-runtime/src/ingest/mod.rs
@@ -77,6 +77,9 @@ pub type Result<T> = std::result::Result<T, IngestError>;
 
 #[derive(Debug, Error)]
 pub enum IngestError {
+    /// Transaction bookkeeping error from the store layer (P117).
+    #[error(transparent)]
+    Db(#[from] crate::core::db::DbError),
     #[error("failed to read {path}")]
     ReadFile {
         path: PathBuf,
@@ -294,17 +297,11 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
     };
 
     let source_type = source_type_for(format);
-    if options.replace_existing_source && !options.dry_run {
-        let replace_result = if options.replace_across_rooms {
-            db.replace_active_source_drawers_across_rooms(&source_file, wing)
-        } else {
-            db.replace_active_source_drawers(&source_file, wing, Some(resolved_room.as_str()))
-        };
-        replace_result.map_err(|source| IngestError::ReplaceSource {
-            source_file: source_file.clone(),
-            source,
-        })?;
-    }
+    // P117: the destructive source replacement is deferred until AFTER
+    // embeddings exist, and then runs in the same transaction as the
+    // inserts — an embed or insert failure must never leave the source's
+    // old drawers deleted.
+    let replacing = options.replace_existing_source && !options.dry_run;
 
     let mut pending = Vec::new();
     let mut seen_drawer_ids = HashSet::new();
@@ -321,12 +318,16 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             stats.skipped += 1;
             continue;
         }
-        if db
-            .drawer_exists(&drawer_id)
-            .map_err(|source| IngestError::CheckDrawer {
-                drawer_id: drawer_id.clone(),
-                source,
-            })?
+        // Under replacement the existence check is skipped: drawer ids are
+        // source-aware (P110), so a colliding id can only belong to this
+        // same source, whose rows are deleted in the replace transaction.
+        if !replacing
+            && db
+                .drawer_exists(&drawer_id)
+                .map_err(|source| IngestError::CheckDrawer {
+                    drawer_id: drawer_id.clone(),
+                    source,
+                })?
         {
             stats.skipped += 1;
             continue;
@@ -356,39 +357,80 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             source,
         })?;
 
-    for ((chunk_index, chunk, drawer_id), vector) in pending.into_iter().zip(vectors) {
-        let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
-            id: drawer_id.clone(),
-            content: chunk.to_string(),
-            wing: wing.to_string(),
-            room: Some(resolved_room.clone()),
-            source_file: Some(source_file.clone()),
-            source_type: source_type.clone(),
-            added_at: current_timestamp(),
-            chunk_index: Some(chunk_index as i64),
-            importance: 0,
-        });
-        let drawer = Drawer {
-            normalize_version: CURRENT_NORMALIZE_VERSION,
-            ..drawer
+    let rows: Vec<(usize, &str, String, Vec<f32>)> = pending
+        .into_iter()
+        .zip(vectors)
+        .map(|((chunk_index, chunk, drawer_id), vector)| {
+            (chunk_index, chunk.as_ref(), drawer_id, vector)
+        })
+        .collect();
+
+    let insert_rows =
+        |db: &Database, stats: &mut IngestStats| -> std::result::Result<(), IngestError> {
+            for (chunk_index, chunk, drawer_id, vector) in &rows {
+                let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+                    id: drawer_id.clone(),
+                    content: (*chunk).to_string(),
+                    wing: wing.to_string(),
+                    room: Some(resolved_room.clone()),
+                    source_file: Some(source_file.clone()),
+                    source_type: source_type.clone(),
+                    added_at: current_timestamp(),
+                    chunk_index: Some(*chunk_index as i64),
+                    importance: 0,
+                });
+                let drawer = Drawer {
+                    normalize_version: CURRENT_NORMALIZE_VERSION,
+                    ..drawer
+                };
+
+                let inserted =
+                    db.insert_drawer(&drawer)
+                        .map_err(|source| IngestError::InsertDrawer {
+                            drawer_id: drawer.id.clone(),
+                            source,
+                        })?;
+                if inserted {
+                    db.insert_vector(drawer_id, vector).map_err(|source| {
+                        IngestError::InsertVector {
+                            drawer_id: drawer.id.clone(),
+                            source,
+                        }
+                    })?;
+                    stats.chunks += 1;
+                } else {
+                    stats.skipped += 1;
+                }
+            }
+            Ok(())
         };
 
-        let inserted = db
-            .insert_drawer(&drawer)
-            .map_err(|source| IngestError::InsertDrawer {
-                drawer_id: drawer.id.clone(),
+    if replacing {
+        // Delete-old + insert-new commit or roll back together.
+        let mut txn_stats = IngestStats::default();
+        db.with_immediate_transaction(|db| -> std::result::Result<(), IngestError> {
+            let replace_result = if options.replace_across_rooms {
+                db.replace_active_source_drawers_across_rooms_in_txn(&source_file, wing)
+            } else {
+                db.replace_active_source_drawers_in_txn(
+                    &source_file,
+                    wing,
+                    Some(resolved_room.as_str()),
+                )
+            };
+            replace_result.map_err(|source| IngestError::ReplaceSource {
+                source_file: source_file.clone(),
                 source,
             })?;
-        if inserted {
-            db.insert_vector(&drawer_id, &vector)
-                .map_err(|source| IngestError::InsertVector {
-                    drawer_id: drawer.id.clone(),
-                    source,
-                })?;
-            stats.chunks += 1;
-        } else {
-            stats.skipped += 1;
-        }
+            insert_rows(db, &mut txn_stats)
+        })?;
+        stats.chunks += txn_stats.chunks;
+        stats.skipped += txn_stats.skipped;
+    } else {
+        let mut direct_stats = IngestStats::default();
+        insert_rows(db, &mut direct_stats)?;
+        stats.chunks += direct_stats.chunks;
+        stats.skipped += direct_stats.skipped;
     }
 
     Ok(stats)

--- a/crates/mempal-runtime/src/ingest/mod.rs
+++ b/crates/mempal-runtime/src/ingest/mod.rs
@@ -104,6 +104,12 @@ pub enum IngestError {
         #[source]
         source: EmbedError,
     },
+    #[error("embedding count mismatch for {path}: expected {expected}, got {actual}")]
+    EmbeddingCountMismatch {
+        path: PathBuf,
+        expected: usize,
+        actual: usize,
+    },
     #[error("failed to check drawer {drawer_id}")]
     CheckDrawer {
         drawer_id: String,
@@ -116,6 +122,8 @@ pub enum IngestError {
         #[source]
         source: crate::core::db::DbError,
     },
+    #[error("replacement drawer id collision for {drawer_id}")]
+    ReplacementDrawerCollision { drawer_id: String },
     #[error("failed to replace source drawers for {source_file}")]
     ReplaceSource {
         source_file: String,
@@ -356,6 +364,13 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             path: path.to_path_buf(),
             source,
         })?;
+    if vectors.len() != pending.len() {
+        return Err(IngestError::EmbeddingCountMismatch {
+            path: path.to_path_buf(),
+            expected: pending.len(),
+            actual: vectors.len(),
+        });
+    }
 
     let rows: Vec<(usize, &str, String, Vec<f32>)> = pending
         .into_iter()
@@ -398,6 +413,10 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
                         }
                     })?;
                     stats.chunks += 1;
+                } else if replacing {
+                    return Err(IngestError::ReplacementDrawerCollision {
+                        drawer_id: drawer.id,
+                    });
                 } else {
                     stats.skipped += 1;
                 }

--- a/crates/mempal-runtime/src/ingest/reindex.rs
+++ b/crates/mempal-runtime/src/ingest/reindex.rs
@@ -61,24 +61,35 @@ pub async fn reindex_sources<E: Embedder + ?Sized>(
         ..ReindexReport::default()
     };
 
+    // P117: the source-file existence scan runs in dry-run too, so the
+    // report is a real feasibility statement (sources ingested without an
+    // on-disk file — e.g. MCP-ingested content — are not reindexable).
+    let mut reindexable = Vec::new();
+    for source in sources {
+        let has_file = source
+            .source_file
+            .as_deref()
+            .is_some_and(|source_file| PathBuf::from(source_file).is_file());
+        if has_file {
+            reindexable.push(source);
+        } else {
+            report.skipped_missing_sources += 1;
+            report.skipped_missing_drawers += source.drawer_count;
+        }
+    }
+
     if options.dry_run {
         return Ok(report);
     }
 
-    for source in sources {
-        let Some(source_file) = source.source_file.as_deref() else {
-            report.skipped_missing_sources += 1;
-            report.skipped_missing_drawers += source.drawer_count;
-            continue;
-        };
-        let source_path = PathBuf::from(source_file);
-        if !source_path.is_file() {
-            report.skipped_missing_sources += 1;
-            report.skipped_missing_drawers += source.drawer_count;
-            continue;
-        }
-
-        let stats = reindex_one_source(db, embedder, &source, source_file, source_path).await?;
+    for source in reindexable {
+        let source_file = source
+            .source_file
+            .as_deref()
+            .expect("checked Some above")
+            .to_string();
+        let source_path = PathBuf::from(&source_file);
+        let stats = reindex_one_source(db, embedder, &source, &source_file, source_path).await?;
         report.processed_sources += 1;
         report.reingested_files += stats.files;
         report.reingested_chunks += stats.chunks;

--- a/crates/mempal-runtime/src/ingest/reindex.rs
+++ b/crates/mempal-runtime/src/ingest/reindex.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 use thiserror::Error;
 
@@ -31,6 +34,9 @@ pub struct ReindexReport {
     pub skipped_existing_chunks: usize,
     pub skipped_missing_sources: u64,
     pub skipped_missing_drawers: u64,
+    pub skipped_protected_sources: u64,
+    pub skipped_protected_drawers: u64,
+    pub protecting_references: u64,
 }
 
 #[derive(Debug, Error)]
@@ -65,17 +71,38 @@ pub async fn reindex_sources<E: Embedder + ?Sized>(
     // report is a real feasibility statement (sources ingested without an
     // on-disk file — e.g. MCP-ingested content — are not reindexable).
     let mut reindexable = Vec::new();
+    let mut reference_summaries = HashMap::new();
+    let mut counted_protected_sources = HashSet::new();
     for source in sources {
-        let has_file = source
-            .source_file
-            .as_deref()
-            .is_some_and(|source_file| PathBuf::from(source_file).is_file());
-        if has_file {
-            reindexable.push(source);
-        } else {
+        let Some(source_file) = source.source_file.as_deref() else {
             report.skipped_missing_sources += 1;
             report.skipped_missing_drawers += source.drawer_count;
+            continue;
+        };
+        if !PathBuf::from(source_file).is_file() {
+            report.skipped_missing_sources += 1;
+            report.skipped_missing_drawers += source.drawer_count;
+            continue;
         }
+
+        let source_key = (source_file.to_string(), source.wing.clone());
+        let reference_summary = if let Some(summary) = reference_summaries.get(&source_key) {
+            *summary
+        } else {
+            let summary = db.source_knowledge_reference_summary(source_file, &source.wing)?;
+            reference_summaries.insert(source_key.clone(), summary);
+            summary
+        };
+        if reference_summary.referenced_drawers > 0 {
+            report.skipped_protected_sources += 1;
+            report.skipped_protected_drawers += source.drawer_count;
+            if counted_protected_sources.insert(source_key) {
+                report.protecting_references += reference_summary.references;
+            }
+            continue;
+        }
+
+        reindexable.push(source);
     }
 
     if options.dry_run {

--- a/crates/mempal-store-sqlite/src/lib.rs
+++ b/crates/mempal-store-sqlite/src/lib.rs
@@ -163,6 +163,15 @@ pub enum DbError {
     InvalidEnumValue { kind: &'static str, value: String },
     #[error("invalid drawer metadata: {0}")]
     InvalidDrawerMetadata(String),
+    #[error(
+        "source {source_file} in wing {wing} is protected by {references} knowledge references across {referenced_drawers} drawers"
+    )]
+    SourceProtectedByKnowledgeReferences {
+        source_file: String,
+        wing: String,
+        referenced_drawers: u64,
+        references: u64,
+    },
     #[error("invalid tunnel: {0}")]
     InvalidTunnel(String),
     #[error("failed to register sqlite-vec auto extension: {0}")]
@@ -174,6 +183,12 @@ pub enum DbError {
 pub struct Database {
     conn: Connection,
     path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct KnowledgeReferenceSummary {
+    pub referenced_drawers: u64,
+    pub references: u64,
 }
 
 impl Database {
@@ -604,6 +619,58 @@ impl Database {
         Ok(rows)
     }
 
+    /// Count active evidence drawers for one physical source that are protected
+    /// by Stage-1 knowledge reference arrays or Phase-2 evidence links.
+    ///
+    /// Source replacement must not hard-delete these drawers without an
+    /// explicit old-to-new reference mapping. P117 therefore uses this as a
+    /// conservative preflight and skips the whole source when the summary is
+    /// non-empty.
+    pub fn source_knowledge_reference_summary(
+        &self,
+        source_file: &str,
+        wing: &str,
+    ) -> Result<KnowledgeReferenceSummary, DbError> {
+        let (referenced_drawers, references) = self.conn.query_row(
+            r#"
+            WITH stage1_refs(evidence_id) AS (
+                SELECT ref.value
+                FROM drawers AS knowledge, json_each(knowledge.supporting_refs) AS ref
+                WHERE knowledge.deleted_at IS NULL AND knowledge.memory_kind = 'knowledge'
+                UNION ALL
+                SELECT ref.value
+                FROM drawers AS knowledge, json_each(knowledge.counterexample_refs) AS ref
+                WHERE knowledge.deleted_at IS NULL AND knowledge.memory_kind = 'knowledge'
+                UNION ALL
+                SELECT ref.value
+                FROM drawers AS knowledge, json_each(knowledge.teaching_refs) AS ref
+                WHERE knowledge.deleted_at IS NULL AND knowledge.memory_kind = 'knowledge'
+                UNION ALL
+                SELECT ref.value
+                FROM drawers AS knowledge, json_each(knowledge.verification_refs) AS ref
+                WHERE knowledge.deleted_at IS NULL AND knowledge.memory_kind = 'knowledge'
+            ),
+            all_refs(evidence_id) AS (
+                SELECT evidence_id FROM stage1_refs
+                UNION ALL
+                SELECT evidence_drawer_id FROM knowledge_evidence_links
+            )
+            SELECT COUNT(DISTINCT evidence.id), COUNT(*)
+            FROM all_refs
+            JOIN drawers AS evidence ON evidence.id = all_refs.evidence_id
+            WHERE evidence.deleted_at IS NULL
+              AND evidence.source_file = ?1
+              AND evidence.wing = ?2
+            "#,
+            (source_file, wing),
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )?;
+        Ok(KnowledgeReferenceSummary {
+            referenced_drawers: referenced_drawers as u64,
+            references: references as u64,
+        })
+    }
+
     /// Hard-delete the active drawers for a source scoped to a specific room
     /// (NULL room matches NULL room), removing their FTS and vector rows too.
     ///
@@ -628,10 +695,15 @@ impl Database {
             .map_err(E::from)?;
         match f(self) {
             Ok(value) => {
-                self.conn
+                if let Err(error) = self
+                    .conn
                     .execute_batch("COMMIT;")
                     .map_err(DbError::from)
-                    .map_err(E::from)?;
+                    .map_err(E::from)
+                {
+                    let _ = self.conn.execute_batch("ROLLBACK;");
+                    return Err(error);
+                }
                 Ok(value)
             }
             Err(error) => {
@@ -649,6 +721,7 @@ impl Database {
         wing: &str,
         room: Option<&str>,
     ) -> Result<u64, DbError> {
+        self.ensure_source_is_not_knowledge_referenced(source_file, wing)?;
         let rows = self.active_source_rows_in_room(source_file, wing, room)?;
         self.delete_source_drawer_rows_in_txn(&rows)
     }
@@ -661,6 +734,7 @@ impl Database {
         source_file: &str,
         wing: &str,
     ) -> Result<u64, DbError> {
+        self.ensure_source_is_not_knowledge_referenced(source_file, wing)?;
         let rows = self.active_source_rows_all_rooms(source_file, wing)?;
         self.delete_source_drawer_rows_in_txn(&rows)
     }
@@ -671,8 +745,9 @@ impl Database {
         wing: &str,
         room: Option<&str>,
     ) -> Result<u64, DbError> {
-        let rows = self.active_source_rows_in_room(source_file, wing, room)?;
-        self.delete_source_drawer_rows(&rows)
+        self.with_immediate_transaction(|db| {
+            db.replace_active_source_drawers_in_txn(source_file, wing, room)
+        })
     }
 
     fn active_source_rows_in_room(
@@ -716,8 +791,9 @@ impl Database {
         source_file: &str,
         wing: &str,
     ) -> Result<u64, DbError> {
-        let rows = self.active_source_rows_all_rooms(source_file, wing)?;
-        self.delete_source_drawer_rows(&rows)
+        self.with_immediate_transaction(|db| {
+            db.replace_active_source_drawers_across_rooms_in_txn(source_file, wing)
+        })
     }
 
     fn active_source_rows_all_rooms(
@@ -745,16 +821,6 @@ impl Database {
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
-    }
-
-    /// Transactionally hard-delete the given (rowid, id, content) drawer rows
-    /// along with their FTS and vector entries. Shared by the room-scoped and
-    /// across-rooms source replacement paths.
-    fn delete_source_drawer_rows(&self, rows: &[(i64, String, String)]) -> Result<u64, DbError> {
-        if rows.is_empty() {
-            return Ok(0);
-        }
-        self.with_immediate_transaction(|db| db.delete_source_drawer_rows_in_txn(rows))
     }
 
     /// Delete body without transaction control — the caller owns the
@@ -795,6 +861,23 @@ impl Database {
         }
 
         Ok(rows.len() as u64)
+    }
+
+    fn ensure_source_is_not_knowledge_referenced(
+        &self,
+        source_file: &str,
+        wing: &str,
+    ) -> Result<(), DbError> {
+        let summary = self.source_knowledge_reference_summary(source_file, wing)?;
+        if summary.referenced_drawers == 0 {
+            return Ok(());
+        }
+        Err(DbError::SourceProtectedByKnowledgeReferences {
+            source_file: source_file.to_string(),
+            wing: wing.to_string(),
+            referenced_drawers: summary.referenced_drawers,
+            references: summary.references,
+        })
     }
 
     fn table_exists(&self, table_name: &str) -> Result<bool, DbError> {

--- a/crates/mempal-store-sqlite/src/lib.rs
+++ b/crates/mempal-store-sqlite/src/lib.rs
@@ -612,12 +612,75 @@ impl Database {
     /// re-ingesting a physical source may re-route it to a different room, and
     /// a room-scoped delete would miss the stale drawers in the old room and
     /// leave duplicates behind.
+    /// Run `f` inside one IMMEDIATE transaction: commit on Ok, roll back on
+    /// Err (P117). Callables must use `_in_txn` method variants — nesting a
+    /// method that opens its own transaction will fail.
+    pub fn with_immediate_transaction<T, E>(
+        &self,
+        f: impl FnOnce(&Self) -> Result<T, E>,
+    ) -> Result<T, E>
+    where
+        E: From<DbError>,
+    {
+        self.conn
+            .execute_batch("BEGIN IMMEDIATE;")
+            .map_err(DbError::from)
+            .map_err(E::from)?;
+        match f(self) {
+            Ok(value) => {
+                self.conn
+                    .execute_batch("COMMIT;")
+                    .map_err(DbError::from)
+                    .map_err(E::from)?;
+                Ok(value)
+            }
+            Err(error) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(error)
+            }
+        }
+    }
+
+    /// Non-transactional variant of [`Self::replace_active_source_drawers`]
+    /// for use inside [`Self::with_immediate_transaction`] (P117).
+    pub fn replace_active_source_drawers_in_txn(
+        &self,
+        source_file: &str,
+        wing: &str,
+        room: Option<&str>,
+    ) -> Result<u64, DbError> {
+        let rows = self.active_source_rows_in_room(source_file, wing, room)?;
+        self.delete_source_drawer_rows_in_txn(&rows)
+    }
+
+    /// Non-transactional variant of
+    /// [`Self::replace_active_source_drawers_across_rooms`] for use inside
+    /// [`Self::with_immediate_transaction`] (P117).
+    pub fn replace_active_source_drawers_across_rooms_in_txn(
+        &self,
+        source_file: &str,
+        wing: &str,
+    ) -> Result<u64, DbError> {
+        let rows = self.active_source_rows_all_rooms(source_file, wing)?;
+        self.delete_source_drawer_rows_in_txn(&rows)
+    }
+
     pub fn replace_active_source_drawers(
         &self,
         source_file: &str,
         wing: &str,
         room: Option<&str>,
     ) -> Result<u64, DbError> {
+        let rows = self.active_source_rows_in_room(source_file, wing, room)?;
+        self.delete_source_drawer_rows(&rows)
+    }
+
+    fn active_source_rows_in_room(
+        &self,
+        source_file: &str,
+        wing: &str,
+        room: Option<&str>,
+    ) -> Result<Vec<(i64, String, String)>, DbError> {
         let mut statement = self.conn.prepare(
             r#"
             SELECT rowid, id, content
@@ -638,9 +701,7 @@ impl Database {
                 ))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
-        drop(statement);
-
-        self.delete_source_drawer_rows(rows)
+        Ok(rows)
     }
 
     /// Hard-delete the active drawers for a source across ALL rooms in a wing.
@@ -655,6 +716,15 @@ impl Database {
         source_file: &str,
         wing: &str,
     ) -> Result<u64, DbError> {
+        let rows = self.active_source_rows_all_rooms(source_file, wing)?;
+        self.delete_source_drawer_rows(&rows)
+    }
+
+    fn active_source_rows_all_rooms(
+        &self,
+        source_file: &str,
+        wing: &str,
+    ) -> Result<Vec<(i64, String, String)>, DbError> {
         let mut statement = self.conn.prepare(
             r#"
             SELECT rowid, id, content
@@ -674,61 +744,57 @@ impl Database {
                 ))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
-        drop(statement);
-
-        self.delete_source_drawer_rows(rows)
+        Ok(rows)
     }
 
     /// Transactionally hard-delete the given (rowid, id, content) drawer rows
     /// along with their FTS and vector entries. Shared by the room-scoped and
     /// across-rooms source replacement paths.
-    fn delete_source_drawer_rows(&self, rows: Vec<(i64, String, String)>) -> Result<u64, DbError> {
+    fn delete_source_drawer_rows(&self, rows: &[(i64, String, String)]) -> Result<u64, DbError> {
+        if rows.is_empty() {
+            return Ok(0);
+        }
+        self.with_immediate_transaction(|db| db.delete_source_drawer_rows_in_txn(rows))
+    }
+
+    /// Delete body without transaction control — the caller owns the
+    /// transaction (P117).
+    fn delete_source_drawer_rows_in_txn(
+        &self,
+        rows: &[(i64, String, String)],
+    ) -> Result<u64, DbError> {
         if rows.is_empty() {
             return Ok(0);
         }
 
-        self.conn.execute_batch("BEGIN IMMEDIATE;")?;
-        let result = (|| -> Result<u64, DbError> {
-            let fts_exists = self.table_exists("drawers_fts")?;
-            let vectors_exist = self.table_exists("drawer_vectors")?;
+        let fts_exists = self.table_exists("drawers_fts")?;
+        let vectors_exist = self.table_exists("drawer_vectors")?;
 
-            for (rowid, id, content) in &rows {
-                if fts_exists {
-                    self.conn.execute(
-                        "INSERT INTO drawers_fts(drawers_fts, rowid, content) VALUES ('delete', ?1, ?2)",
-                        params![rowid, content],
-                    )?;
-                }
-                if vectors_exist {
-                    self.conn
-                        .execute("DELETE FROM drawer_vectors WHERE id = ?1", [id])?;
-                }
-                // triples.source_drawer is a FK to drawers(id) (RESTRICT). Drop
-                // the dangling provenance link before the hard delete, otherwise
-                // deleting a drawer referenced by a KG triple fails with a
-                // FOREIGN KEY constraint error. The triple (a KG fact) is kept;
-                // only its stale source pointer is cleared.
+        for (rowid, id, content) in rows {
+            if fts_exists {
                 self.conn.execute(
-                    "UPDATE triples SET source_drawer = NULL WHERE source_drawer = ?1",
-                    [id],
+                    "INSERT INTO drawers_fts(drawers_fts, rowid, content) VALUES ('delete', ?1, ?2)",
+                    params![rowid, content],
                 )?;
+            }
+            if vectors_exist {
                 self.conn
-                    .execute("DELETE FROM drawers WHERE rowid = ?1", [rowid])?;
+                    .execute("DELETE FROM drawer_vectors WHERE id = ?1", [id])?;
             }
-
-            Ok(rows.len() as u64)
-        })();
-
-        match result {
-            Ok(count) => {
-                self.conn.execute_batch("COMMIT;")?;
-                Ok(count)
-            }
-            Err(error) => {
-                let _ = self.conn.execute_batch("ROLLBACK;");
-                Err(error)
-            }
+            // triples.source_drawer is a FK to drawers(id) (RESTRICT). Drop
+            // the dangling provenance link before the hard delete, otherwise
+            // deleting a drawer referenced by a KG triple fails with a
+            // FOREIGN KEY constraint error. The triple (a KG fact) is kept;
+            // only its stale source pointer is cleared.
+            self.conn.execute(
+                "UPDATE triples SET source_drawer = NULL WHERE source_drawer = ?1",
+                [id],
+            )?;
+            self.conn
+                .execute("DELETE FROM drawers WHERE rowid = ?1", [rowid])?;
         }
+
+        Ok(rows.len() as u64)
     }
 
     fn table_exists(&self, table_name: &str) -> Result<bool, DbError> {

--- a/docs/plans/2026-08-18-p117-reindex-atomic-replace.md
+++ b/docs/plans/2026-08-18-p117-reindex-atomic-replace.md
@@ -3,11 +3,14 @@
 日期：2026-08-18
 Spec：`specs/p117-reindex-atomic-replace.spec.md`
 背景：P115 把 `CURRENT_NORMALIZE_VERSION` 提到 3 后，运维上需要对生产
-palace.db 跑一次 `reindex --stale`。评审发现两个前置风险：
+palace.db 跑一次 `reindex --stale`。评审先后发现六个前置风险：
 `ingest_file_with_options` 在 embed 之前就硬删旧 drawers（embed/insert
 失败即永久丢数据）；`reindex --stale --dry-run` 在 missing-source 扫描前
 提前返回（实测 911 候选 drawers 中约 653 个的 source 文件已不存在，
-dry-run 却全部报告为可重处理）。
+dry-run 却全部报告为可重处理）；成功但向量数量不足的 embed 响应会被
+`zip` 静默截断；`COMMIT` 失败不会 rollback；被 Stage-1/Phase-2 knowledge
+引用的 evidence 可能悬空或触发 FK 中止；短哈希插入冲突会被当作 skip
+后提交不完整替换。
 
 ## 步骤
 
@@ -19,15 +22,28 @@ dry-run 却全部报告为可重处理）。
        一个不存在，dry-run 报告 skipped_missing 计数（当前恒为 0）；
      - `reindex_replaces_source_without_duplicates`：正常 reindex 无丢失
        无重复（守卫）。
-   - `crates/mempal-store-sqlite`：`with_immediate_transaction_rolls_back_on_error`。
+     - `reindex_embedding_count_mismatch_preserves_existing_drawers`：短/长
+       向量批次都必须报错且保留旧数据；
+     - `reindex_insert_collision_preserves_existing_drawers`：跨 source id
+       冲突必须回滚；
+     - `reindex_skips_sources_with_knowledge_references`：Stage-1 与 Phase-2
+       引用保护 source，dry-run/real-run 都报告并跳过；
+     - `replace_transaction_rechecks_knowledge_references`：直接 replace
+       绕过外层 report preflight 时，事务内复检仍阻止硬删除；
+     - `reindex_cli_reports_governance_protected_sources`：CLI 可见保护计数。
+   - store：`with_immediate_transaction_rolls_back_on_error` 与
+     `with_immediate_transaction_rolls_back_on_commit_failure`。
 2. **GREEN（最小实现）**
    - store：`with_immediate_transaction` helper + source-replace 删除的
-     `_in_txn` 变体（公开删除方法保留自带事务）。
+     `_in_txn` 变体（公开删除方法保留自带事务）；closure/COMMIT error
+     均 best-effort rollback；查询 source 的 Stage-1/Phase-2 引用汇总；
+     public replace 统一进入 `_in_txn` 路径并在事务内复检引用。
    - ingest：replace 路径重排为 chunk → dedup（replace 模式跳过
-     `drawer_exists`，源感知 id 只可能撞本 source）→ embed → 单事务内
-     delete + insert drawers/vectors。
-   - reindex：dry-run 也执行 source 文件存在性扫描，填充
-     `skipped_missing_*`（CLI 打印已就位）。
+     `drawer_exists`）→ embed → 精确验证向量基数 → 单事务内 delete +
+     insert drawers/vectors；replace insert=false 作为冲突错误回滚。
+   - reindex：dry-run 与 real-run 都执行 source 文件存在性及 knowledge
+     引用 preflight，填充 `skipped_missing_*` / `skipped_protected_*` /
+     `protecting_references`；CLI 输出对应计数。
 3. **验证**：workspace `cargo test`、`clippy -D warnings`、`fmt --check`、
    `agent-spec parse/lint/lifecycle`（Package/Filter 选择器）。
 4. **收尾**：AGENTS.md / CLAUDE.md inventory；PR；`mempal_ingest` 决策。
@@ -41,4 +57,6 @@ file-less source（MCP 直录内容）不可重归一化，属预期。
 
 ## 状态
 
-已完成。
+已完成。复审扩充后的 10 个 acceptance scenarios 与 boundary check 全部
+通过，agent-spec lint 零诊断；workspace test、clippy `-D warnings`、fmt
+全部通过。

--- a/docs/plans/2026-08-18-p117-reindex-atomic-replace.md
+++ b/docs/plans/2026-08-18-p117-reindex-atomic-replace.md
@@ -1,0 +1,44 @@
+# P117 实现计划 — atomic reindex replace + dry-run feasibility report
+
+日期：2026-08-18
+Spec：`specs/p117-reindex-atomic-replace.spec.md`
+背景：P115 把 `CURRENT_NORMALIZE_VERSION` 提到 3 后，运维上需要对生产
+palace.db 跑一次 `reindex --stale`。评审发现两个前置风险：
+`ingest_file_with_options` 在 embed 之前就硬删旧 drawers（embed/insert
+失败即永久丢数据）；`reindex --stale --dry-run` 在 missing-source 扫描前
+提前返回（实测 911 候选 drawers 中约 653 个的 source 文件已不存在，
+dry-run 却全部报告为可重处理）。
+
+## 步骤
+
+1. **RED（先写失败测试）**
+   - `tests/reindex_safety.rs`：
+     - `reindex_embed_failure_preserves_existing_drawers`：FailingEmbedder
+       下 reindex 报错且原 drawer 仍在（当前会被删掉）；
+     - `reindex_dry_run_reports_missing_sources`：一个 source 文件存在、
+       一个不存在，dry-run 报告 skipped_missing 计数（当前恒为 0）；
+     - `reindex_replaces_source_without_duplicates`：正常 reindex 无丢失
+       无重复（守卫）。
+   - `crates/mempal-store-sqlite`：`with_immediate_transaction_rolls_back_on_error`。
+2. **GREEN（最小实现）**
+   - store：`with_immediate_transaction` helper + source-replace 删除的
+     `_in_txn` 变体（公开删除方法保留自带事务）。
+   - ingest：replace 路径重排为 chunk → dedup（replace 模式跳过
+     `drawer_exists`，源感知 id 只可能撞本 source）→ embed → 单事务内
+     delete + insert drawers/vectors。
+   - reindex：dry-run 也执行 source 文件存在性扫描，填充
+     `skipped_missing_*`（CLI 打印已就位）。
+3. **验证**：workspace `cargo test`、`clippy -D warnings`、`fmt --check`、
+   `agent-spec parse/lint/lifecycle`（Package/Filter 选择器）。
+4. **收尾**：AGENTS.md / CLAUDE.md inventory；PR；`mempal_ingest` 决策。
+
+## 运维顺序（P117 合并后，另行执行）
+
+备份 palace.db → `cargo install --path . --force` → 重启全部 mempal MCP
+server（实测 39 个旧进程）与 Claude/Codex 会话 → 验证 normalize v3 与
+P116 schema → `reindex --stale --dry-run` 审阅报告 → 执行 reindex。
+file-less source（MCP 直录内容）不可重归一化，属预期。
+
+## 状态
+
+已完成。

--- a/specs/p117-reindex-atomic-replace.spec.md
+++ b/specs/p117-reindex-atomic-replace.spec.md
@@ -7,38 +7,52 @@ estimate: 0.5d
 
 ## Intent
 
-P117 removes the data-loss window in source replacement and makes
-`reindex --stale --dry-run` an honest feasibility report. Today
-`ingest_file_with_options` hard-deletes a source's drawers BEFORE
-embeddings are generated; an embedding or insert failure afterwards leaves
-the source permanently gone. And dry-run returns before the
-missing-source-file scan, so a run that would actually skip most candidate
-drawers (sources ingested without an on-disk file) reports them all as
-reprocessable. Both must be fixed before the operator runs the P115
-normalize-v3 `reindex --stale` on the production palace.db.
+P117 removes every known data-loss window in source replacement and makes
+`reindex --stale --dry-run` an honest feasibility report. Replacement must
+reject incomplete embedding batches and insert collisions before committing,
+and sources protected by Stage-1 or Phase-2 knowledge references must remain
+untouched. Dry-run must distinguish reindexable, missing, and governance-
+protected sources before the operator runs the P115 normalize-v3 reindex on
+the production palace.db.
 
 ## Decisions
 
 - Reorder the replace path: chunk, dedup, and embed BEFORE any destructive
   write. Embedding failure must leave the database untouched.
+- Require exactly one embedding vector per pending chunk before entering the
+  replacement transaction. Both short and overlong successful embedder
+  responses are errors and leave the database untouched.
 - The destructive window itself becomes one SQLite IMMEDIATE transaction:
   delete-old-source-drawers plus insert-new-drawers-and-vectors commit or
   roll back together, via a new `Database::with_immediate_transaction`
   helper and non-transactional `_in_txn` variants of the source-replace
   deletes (the existing public delete methods keep their own transaction
   for other callers).
+- `Database::with_immediate_transaction` performs a best-effort rollback when
+  either the closure or `COMMIT` fails, so the connection returns to autocommit
+  whenever SQLite permits rollback.
 - Under `replace_existing_source`, the per-chunk `drawer_exists` DB check
-  is skipped: drawer ids are source-aware (P110), so a colliding id can
-  only belong to this same source, whose rows are deleted in the same
-  transaction. In-run duplicate detection via the seen-id set stays.
+  is skipped because the source's old rows are deleted in the transaction.
+  In-run duplicate detection via the seen-id set stays, and an ignored insert
+  is a replacement collision error that rolls back instead of silently
+  counting the missing row as skipped.
+- Before classifying an on-disk source as reindexable, query Stage-1 drawer
+  reference arrays and Phase-2 `knowledge_evidence_links`. Any source with at
+  least one such reference is governance-protected: dry-run and real-run both
+  skip it, preserve every old drawer, and expose protected source/drawer/ref
+  counts in `ReindexReport` and CLI output. P117 does not guess an old-to-new
+  evidence mapping.
+- Repeat the knowledge-reference check inside the SQLite IMMEDIATE replacement
+  transaction, and route both public source-replace methods through their
+  `_in_txn` variants. This protects direct replace callers and closes the gap
+  between the reporting preflight and the destructive write.
 - Dry-run performs the same source-file existence scan as a real run and
-  fills `skipped_missing_sources` / `skipped_missing_drawers` before
-  returning; the CLI already prints these fields. Real-run behavior is
-  unchanged apart from the scan happening up front.
+  fills missing-source and governance-protected counters before returning.
 - Sources without an on-disk file (e.g. MCP-ingested content) remain
   non-reindexable by design; P117 only makes that visible, it does not try
   to re-normalize them.
-- No schema migration, no drawer-id change, no CLI flag changes.
+- No schema migration, no drawer-id change, no CLI flag or MCP contract changes;
+  the reindex report and existing CLI text output gain additive safety fields.
 
 ## Boundaries
 
@@ -46,6 +60,7 @@ normalize-v3 `reindex --stale` on the production palace.db.
 - crates/mempal-store-sqlite/src/lib.rs
 - crates/mempal-runtime/src/ingest/mod.rs
 - crates/mempal-runtime/src/ingest/reindex.rs
+- src/main.rs
 - tests/reindex_safety.rs
 - specs/p117-reindex-atomic-replace.spec.md
 - docs/plans/2026-08-18-p117-reindex-atomic-replace.md
@@ -66,23 +81,57 @@ Scenario: embedding failure leaves existing drawers intact
   Test:
     Package: mempal
     Filter: reindex_embed_failure_preserves_existing_drawers
+  Level: integration
   Given a stale drawer whose source file exists on disk
   When reindex runs with an embedder that always fails
   Then the reindex reports an error
+  And the original drawer and its content are still present and active
+
+Scenario: incomplete embedding batch leaves existing drawers intact
+  Test:
+    Package: mempal
+    Filter: reindex_embedding_count_mismatch_preserves_existing_drawers
+  Level: integration
+  Given a stale drawer whose source file exists on disk
+  When reindex receives successful embedding responses with fewer and more vectors than chunks
+  Then the reindex reports the expected and actual vector counts
   And the original drawer and its content are still present and active
 
 Scenario: transaction helper rolls back the whole batch on error
   Test:
     Package: mempal
     Filter: with_immediate_transaction_rolls_back_on_error
+  Level: integration
   Given an active drawer
   When a transaction deletes it and then returns an error
   Then the drawer is still present after the call
+
+Scenario: transaction helper rolls back after commit failure
+  Test:
+    Package: mempal
+    Filter: with_immediate_transaction_rolls_back_on_commit_failure
+  Level: integration
+  Given a deferred foreign-key violation created inside an IMMEDIATE transaction
+  When SQLite rejects COMMIT
+  Then `Database::with_immediate_transaction` returns an error
+  And the connection is in autocommit with no violating row
+
+Scenario: replacement insert collision rolls back old-source deletion
+  Test:
+    Package: mempal
+    Filter: reindex_insert_collision_preserves_existing_drawers
+  Level: integration
+  Given `replace_existing_source` skips `drawer_exists` for a stale source
+  And another source already owns the replacement id
+  When reindex attempts to insert the colliding replacement drawer
+  Then the reindex reports a collision error
+  And both pre-existing drawers remain active
 
 Scenario: reindex replaces a source without loss or duplicates
   Test:
     Package: mempal
     Filter: reindex_replaces_source_without_duplicates
+  Level: integration
   Given a stale drawer whose source file exists on disk
   When reindex runs with a working embedder
   Then the source's drawers are fresh, at the current normalize version
@@ -94,8 +143,39 @@ Scenario: dry-run reports missing sources without writing
   Test:
     Package: mempal
     Filter: reindex_dry_run_reports_missing_sources
+  Level: integration
   Given one stale drawer with an existing source file and one whose source path does not exist
   When reindex runs with dry_run
   Then the report counts both candidates
   And it counts the missing source and its drawers as skipped
+  And no drawer is modified
+
+Scenario: governance references protect source replacement
+  Test:
+    Package: mempal
+    Filter: reindex_skips_sources_with_knowledge_references
+  Level: integration
+  Given a stale on-disk source referenced by both a Stage-1 knowledge drawer and a Phase-2 card
+  When dry-run and real-run reindex inspect the source
+  Then both reports count the source, drawer, and two protecting references as skipped
+  And the original evidence drawer and both knowledge references remain intact
+
+Scenario: replacement transaction rechecks governance references
+  Test:
+    Package: mempal
+    Filter: replace_transaction_rechecks_knowledge_references
+  Level: integration
+  Given a stale on-disk source protected by a Stage-1 knowledge reference
+  When the direct replace ingest entry point bypasses the reindex reporting preflight
+  Then the SQLite replacement transaction reports the protected source
+  And the original evidence drawer and knowledge reference remain intact
+
+Scenario: CLI reports governance-protected sources
+  Test:
+    Package: mempal
+    Filter: reindex_cli_reports_governance_protected_sources
+  Level: integration
+  Given a stale on-disk source protected by a Stage-1 knowledge reference
+  When the CLI runs reindex stale in dry-run and real-run modes
+  Then both stdout summaries report the protected source, drawer, and reference counts
   And no drawer is modified

--- a/specs/p117-reindex-atomic-replace.spec.md
+++ b/specs/p117-reindex-atomic-replace.spec.md
@@ -1,0 +1,101 @@
+spec: task
+name: "P117: atomic reindex replace + dry-run feasibility report"
+inherits: project
+tags: [ingest, reindex, store, sqlite, data-safety]
+estimate: 0.5d
+---
+
+## Intent
+
+P117 removes the data-loss window in source replacement and makes
+`reindex --stale --dry-run` an honest feasibility report. Today
+`ingest_file_with_options` hard-deletes a source's drawers BEFORE
+embeddings are generated; an embedding or insert failure afterwards leaves
+the source permanently gone. And dry-run returns before the
+missing-source-file scan, so a run that would actually skip most candidate
+drawers (sources ingested without an on-disk file) reports them all as
+reprocessable. Both must be fixed before the operator runs the P115
+normalize-v3 `reindex --stale` on the production palace.db.
+
+## Decisions
+
+- Reorder the replace path: chunk, dedup, and embed BEFORE any destructive
+  write. Embedding failure must leave the database untouched.
+- The destructive window itself becomes one SQLite IMMEDIATE transaction:
+  delete-old-source-drawers plus insert-new-drawers-and-vectors commit or
+  roll back together, via a new `Database::with_immediate_transaction`
+  helper and non-transactional `_in_txn` variants of the source-replace
+  deletes (the existing public delete methods keep their own transaction
+  for other callers).
+- Under `replace_existing_source`, the per-chunk `drawer_exists` DB check
+  is skipped: drawer ids are source-aware (P110), so a colliding id can
+  only belong to this same source, whose rows are deleted in the same
+  transaction. In-run duplicate detection via the seen-id set stays.
+- Dry-run performs the same source-file existence scan as a real run and
+  fills `skipped_missing_sources` / `skipped_missing_drawers` before
+  returning; the CLI already prints these fields. Real-run behavior is
+  unchanged apart from the scan happening up front.
+- Sources without an on-disk file (e.g. MCP-ingested content) remain
+  non-reindexable by design; P117 only makes that visible, it does not try
+  to re-normalize them.
+- No schema migration, no drawer-id change, no CLI flag changes.
+
+## Boundaries
+
+### Allowed Changes
+- crates/mempal-store-sqlite/src/lib.rs
+- crates/mempal-runtime/src/ingest/mod.rs
+- crates/mempal-runtime/src/ingest/reindex.rs
+- tests/reindex_safety.rs
+- specs/p117-reindex-atomic-replace.spec.md
+- docs/plans/2026-08-18-p117-reindex-atomic-replace.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not add a schema migration, table, or column.
+- Do not change drawer identity hashing or chunking.
+- Do not change CLI flags or MCP tool contracts.
+- Do not auto-delete or rewrite drawers whose source file is missing.
+
+## Acceptance Criteria
+
+Rule: no-loss-replace  Replacement never destroys data it cannot rebuild
+
+Scenario: embedding failure leaves existing drawers intact
+  Test:
+    Package: mempal
+    Filter: reindex_embed_failure_preserves_existing_drawers
+  Given a stale drawer whose source file exists on disk
+  When reindex runs with an embedder that always fails
+  Then the reindex reports an error
+  And the original drawer and its content are still present and active
+
+Scenario: transaction helper rolls back the whole batch on error
+  Test:
+    Package: mempal
+    Filter: with_immediate_transaction_rolls_back_on_error
+  Given an active drawer
+  When a transaction deletes it and then returns an error
+  Then the drawer is still present after the call
+
+Scenario: reindex replaces a source without loss or duplicates
+  Test:
+    Package: mempal
+    Filter: reindex_replaces_source_without_duplicates
+  Given a stale drawer whose source file exists on disk
+  When reindex runs with a working embedder
+  Then the source's drawers are fresh, at the current normalize version
+  And no duplicate or leftover drawer remains for that source
+
+Rule: honest-dry-run  Dry-run is a feasibility report, not a candidate count
+
+Scenario: dry-run reports missing sources without writing
+  Test:
+    Package: mempal
+    Filter: reindex_dry_run_reports_missing_sources
+  Given one stale drawer with an existing source file and one whose source path does not exist
+  When reindex runs with dry_run
+  Then the report counts both candidates
+  And it counts the missing source and its drawers as skipped
+  And no drawer is modified

--- a/src/main.rs
+++ b/src/main.rs
@@ -3149,16 +3149,27 @@ fn print_reindex_report(report: ReindexReport, dry_run: bool) {
                 report.skipped_missing_drawers, report.skipped_missing_sources
             );
         }
+        if report.skipped_protected_drawers > 0 {
+            println!(
+                "would skip {} drawers from {} governance-protected sources ({} knowledge references)",
+                report.skipped_protected_drawers,
+                report.skipped_protected_sources,
+                report.protecting_references
+            );
+        }
         return;
     }
 
     println!(
-        "reindex complete: processed {} sources, {} drawers selected, {} chunks written, skipped {} existing chunks, skipped {} missing-source drawers",
+        "reindex complete: processed {} sources, {} drawers selected, {} chunks written, skipped {} existing chunks, skipped {} missing-source drawers, skipped {} governance-protected drawers from {} sources ({} knowledge references)",
         report.processed_sources,
         report.candidate_drawers,
         report.reingested_chunks,
         report.skipped_existing_chunks,
-        report.skipped_missing_drawers
+        report.skipped_missing_drawers,
+        report.skipped_protected_drawers,
+        report.skipped_protected_sources,
+        report.protecting_references
     );
 }
 

--- a/tests/reindex_safety.rs
+++ b/tests/reindex_safety.rs
@@ -1,0 +1,226 @@
+//! P117: reindex must never destroy data it cannot rebuild, and dry-run
+//! must be an honest feasibility report.
+
+use mempal::core::db::Database;
+use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
+use mempal::embed::Embedder;
+use mempal::ingest::reindex::{ReindexMode, ReindexOptions, reindex_sources};
+use tempfile::TempDir;
+
+struct StubEmbedder;
+
+#[async_trait::async_trait]
+impl Embedder for StubEmbedder {
+    async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| vec![0.1, 0.2, 0.3]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        3
+    }
+
+    fn name(&self) -> &str {
+        "stub"
+    }
+}
+
+/// Fails every embed call — models the embedding backend being down.
+struct FailingEmbedder;
+
+#[async_trait::async_trait]
+impl Embedder for FailingEmbedder {
+    async fn embed(&self, _texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        Err(mempal::embed::EmbedError::Runtime(
+            "embedding backend unavailable".into(),
+        ))
+    }
+
+    fn dimensions(&self) -> usize {
+        3
+    }
+
+    fn name(&self) -> &str {
+        "failing"
+    }
+}
+
+fn insert_stale_drawer(db: &Database, id: &str, source_file: &str, content: &str) {
+    let mut drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("reindex".to_string()),
+        source_file: Some(source_file.to_string()),
+        source_type: SourceType::Conversation,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    });
+    drawer.normalize_version = 1;
+    db.insert_drawer(&drawer).expect("insert stale drawer");
+}
+
+fn active_contents(db: &Database) -> Vec<String> {
+    let mut statement = db
+        .conn()
+        .prepare("SELECT content FROM drawers WHERE deleted_at IS NULL ORDER BY id")
+        .expect("prepare");
+    statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect")
+}
+
+#[test]
+fn with_immediate_transaction_rolls_back_on_error() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    insert_stale_drawer(&db, "drawer_txn_keep", "/tmp/p117-txn.md", "keep me");
+
+    let result: Result<(), _> = db.with_immediate_transaction(|db| {
+        db.replace_active_source_drawers_across_rooms_in_txn("/tmp/p117-txn.md", "mempal")?;
+        Err(mempal::core::db::DbError::InvalidDrawerMetadata(
+            "boom".into(),
+        ))
+    });
+
+    assert!(result.is_err());
+    assert_eq!(
+        active_contents(&db),
+        vec!["keep me".to_string()],
+        "an error inside the transaction must roll back the delete"
+    );
+}
+
+#[tokio::test]
+async fn reindex_embed_failure_preserves_existing_drawers() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let source = tmp.path().join("claude.jsonl");
+    std::fs::write(
+        &source,
+        serde_json::json!({"type":"assistant","message":"precious content"}).to_string(),
+    )
+    .expect("write source");
+    insert_stale_drawer(
+        &db,
+        "drawer_stale_precious",
+        &source.to_string_lossy(),
+        "precious content",
+    );
+
+    let result = reindex_sources(
+        &db,
+        &FailingEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: false,
+        },
+    )
+    .await;
+
+    assert!(result.is_err(), "reindex must surface the embed failure");
+    let contents = active_contents(&db);
+    assert_eq!(
+        contents,
+        vec!["precious content".to_string()],
+        "an embed failure must not destroy the existing drawers"
+    );
+}
+
+#[tokio::test]
+async fn reindex_replaces_source_without_duplicates() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let source = tmp.path().join("claude.jsonl");
+    std::fs::write(
+        &source,
+        serde_json::json!({"type":"assistant","message":"fresh content"}).to_string(),
+    )
+    .expect("write source");
+    insert_stale_drawer(
+        &db,
+        "drawer_stale_old",
+        &source.to_string_lossy(),
+        "outdated normalized content",
+    );
+
+    let report = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: false,
+        },
+    )
+    .await
+    .expect("reindex");
+
+    assert_eq!(report.processed_sources, 1);
+    let contents = active_contents(&db);
+    assert_eq!(
+        contents,
+        vec!["fresh content".to_string()],
+        "old drawers replaced by freshly normalized ones, no leftovers"
+    );
+    let version: u32 = db
+        .conn()
+        .query_row(
+            "SELECT normalize_version FROM drawers WHERE deleted_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read normalize_version");
+    assert_eq!(
+        version,
+        mempal::ingest::normalize::CURRENT_NORMALIZE_VERSION
+    );
+}
+
+#[tokio::test]
+async fn reindex_dry_run_reports_missing_sources() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let existing = tmp.path().join("exists.jsonl");
+    std::fs::write(
+        &existing,
+        serde_json::json!({"type":"assistant","message":"still here"}).to_string(),
+    )
+    .expect("write source");
+    insert_stale_drawer(
+        &db,
+        "drawer_stale_exists",
+        &existing.to_string_lossy(),
+        "still here",
+    );
+    insert_stale_drawer(
+        &db,
+        "drawer_stale_gone",
+        &tmp.path().join("gone.jsonl").to_string_lossy(),
+        "source vanished",
+    );
+
+    let report = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: true,
+        },
+    )
+    .await
+    .expect("dry-run reindex");
+
+    assert_eq!(report.candidate_sources, 2);
+    assert_eq!(report.candidate_drawers, 2);
+    assert_eq!(
+        report.skipped_missing_sources, 1,
+        "dry-run must surface sources whose file no longer exists: {report:?}"
+    );
+    assert_eq!(report.skipped_missing_drawers, 1);
+
+    // dry-run must not have touched anything
+    let contents = active_contents(&db);
+    assert_eq!(contents.len(), 2);
+}

--- a/tests/reindex_safety.rs
+++ b/tests/reindex_safety.rs
@@ -2,9 +2,16 @@
 //! must be an honest feasibility report.
 
 use mempal::core::db::Database;
-use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
+use mempal::core::types::{
+    AnchorKind, BootstrapEvidenceArgs, Drawer, KnowledgeCard, KnowledgeEvidenceLink,
+    KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, SourceType,
+};
+use mempal::core::utils::build_bootstrap_evidence_drawer_id;
 use mempal::embed::Embedder;
-use mempal::ingest::reindex::{ReindexMode, ReindexOptions, reindex_sources};
+use mempal::ingest::normalize::CURRENT_NORMALIZE_VERSION;
+use mempal::ingest::reindex::{ReindexError, ReindexMode, ReindexOptions, reindex_sources};
+use mempal::ingest::{IngestError, IngestOptions, ingest_file_with_options};
+use std::process::Command;
 use tempfile::TempDir;
 
 struct StubEmbedder;
@@ -44,6 +51,26 @@ impl Embedder for FailingEmbedder {
     }
 }
 
+/// Violates the embedder batch contract without returning an error.
+struct MismatchedEmbedder {
+    vector_count: usize,
+}
+
+#[async_trait::async_trait]
+impl Embedder for MismatchedEmbedder {
+    async fn embed(&self, _texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        Ok(vec![vec![0.1, 0.2, 0.3]; self.vector_count])
+    }
+
+    fn dimensions(&self) -> usize {
+        3
+    }
+
+    fn name(&self) -> &str {
+        "mismatched"
+    }
+}
+
 fn insert_stale_drawer(db: &Database, id: &str, source_file: &str, content: &str) {
     let mut drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
         id: id.to_string(),
@@ -72,6 +99,75 @@ fn active_contents(db: &Database) -> Vec<String> {
         .expect("collect")
 }
 
+fn insert_stage1_knowledge_reference(db: &Database, knowledge_id: &str, evidence_id: &str) {
+    let mut drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: knowledge_id.to_string(),
+        content: "governed knowledge content".to_string(),
+        wing: "mempal".to_string(),
+        room: Some("knowledge".to_string()),
+        source_file: Some(format!("knowledge://project/p117/{knowledge_id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000002".to_string(),
+        chunk_index: Some(0),
+        importance: 4,
+    });
+    drawer.normalize_version = CURRENT_NORMALIZE_VERSION;
+    drawer.memory_kind = MemoryKind::Knowledge;
+    drawer.provenance = None;
+    drawer.statement = Some("Protected evidence must remain citable.".to_string());
+    drawer.tier = Some(KnowledgeTier::Qi);
+    drawer.status = Some(KnowledgeStatus::Candidate);
+    drawer.supporting_refs = vec![evidence_id.to_string()];
+    db.insert_drawer(&drawer)
+        .expect("insert Stage-1 knowledge reference");
+}
+
+fn insert_phase2_knowledge_reference(db: &Database, evidence_id: &str) {
+    db.insert_knowledge_card(&KnowledgeCard {
+        id: "card_p117_protected".to_string(),
+        statement: "Protected evidence must remain citable.".to_string(),
+        content: "P117 reference-safety regression card.".to_string(),
+        tier: KnowledgeTier::Qi,
+        status: KnowledgeStatus::Candidate,
+        domain: MemoryDomain::Project,
+        field: "software-engineering".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        scope_constraints: None,
+        trigger_hints: None,
+        created_at: "1710000002".to_string(),
+        updated_at: "1710000002".to_string(),
+    })
+    .expect("insert Phase-2 card");
+    db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+        id: "link_p117_protected".to_string(),
+        card_id: "card_p117_protected".to_string(),
+        evidence_drawer_id: evidence_id.to_string(),
+        role: KnowledgeEvidenceRole::Supporting,
+        note: Some("protect this evidence during reindex".to_string()),
+        created_at: "1710000002".to_string(),
+    })
+    .expect("insert Phase-2 evidence link");
+}
+
+fn write_cli_config(home: &std::path::Path, db_path: &std::path::Path) {
+    let mempal_dir = home.join(".mempal");
+    std::fs::create_dir_all(&mempal_dir).expect("create .mempal");
+    std::fs::write(
+        mempal_dir.join("config.toml"),
+        format!(
+            "db_path = \"{}\"\n\n[embed]\nbackend = \"api\"\ndimensions = 3\n",
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+}
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
 #[test]
 fn with_immediate_transaction_rolls_back_on_error() {
     let tmp = TempDir::new().expect("tempdir");
@@ -91,6 +187,41 @@ fn with_immediate_transaction_rolls_back_on_error() {
         vec!["keep me".to_string()],
         "an error inside the transaction must roll back the delete"
     );
+}
+
+#[test]
+fn with_immediate_transaction_rolls_back_on_commit_failure() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    db.conn()
+        .execute_batch(
+            r#"
+            CREATE TABLE deferred_parent (id INTEGER PRIMARY KEY);
+            CREATE TABLE deferred_child (
+                parent_id INTEGER,
+                FOREIGN KEY(parent_id) REFERENCES deferred_parent(id)
+                    DEFERRABLE INITIALLY DEFERRED
+            );
+            "#,
+        )
+        .expect("create deferred foreign key tables");
+
+    let result: Result<(), mempal::core::db::DbError> = db.with_immediate_transaction(|db| {
+        db.conn()
+            .execute("INSERT INTO deferred_child(parent_id) VALUES (42)", [])?;
+        Ok(())
+    });
+
+    assert!(result.is_err(), "deferred foreign key must reject COMMIT");
+    assert!(
+        db.conn().is_autocommit(),
+        "a failed COMMIT must not leave the connection inside a transaction"
+    );
+    let count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM deferred_child", [], |row| row.get(0))
+        .expect("count deferred children");
+    assert_eq!(count, 0, "rollback must remove the violating row");
 }
 
 #[tokio::test]
@@ -126,6 +257,123 @@ async fn reindex_embed_failure_preserves_existing_drawers() {
         contents,
         vec!["precious content".to_string()],
         "an embed failure must not destroy the existing drawers"
+    );
+}
+
+#[tokio::test]
+async fn reindex_embedding_count_mismatch_preserves_existing_drawers() {
+    for actual in [0, 2] {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        let source = tmp.path().join("mismatch.md");
+        std::fs::write(&source, "fresh content").expect("write source");
+        insert_stale_drawer(
+            &db,
+            "drawer_stale_mismatch",
+            &source.to_string_lossy(),
+            "precious old content",
+        );
+
+        let error = reindex_sources(
+            &db,
+            &MismatchedEmbedder {
+                vector_count: actual,
+            },
+            ReindexOptions {
+                mode: ReindexMode::Stale,
+                dry_run: false,
+            },
+        )
+        .await
+        .expect_err("a mismatched embedding batch must fail reindex");
+
+        match error {
+            ReindexError::Ingest {
+                source:
+                    IngestError::EmbeddingCountMismatch {
+                        expected,
+                        actual: reported,
+                        ..
+                    },
+                ..
+            } => {
+                assert_eq!(expected, 1);
+                assert_eq!(reported, actual);
+            }
+            other => panic!("unexpected reindex error: {other:?}"),
+        }
+        assert_eq!(
+            active_contents(&db),
+            vec!["precious old content".to_string()],
+            "a mismatched embedding batch must not destroy the existing drawer"
+        );
+    }
+}
+
+#[tokio::test]
+async fn reindex_insert_collision_preserves_existing_drawers() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let source = tmp.path().join("collision.md");
+    std::fs::write(&source, "fresh content").expect("write source");
+    let source_file = source.to_string_lossy().to_string();
+    insert_stale_drawer(
+        &db,
+        "drawer_stale_collision",
+        &source_file,
+        "precious old content",
+    );
+
+    let replacement_id = build_bootstrap_evidence_drawer_id(
+        "mempal",
+        Some("reindex"),
+        "fresh content",
+        &SourceType::Project,
+        Some(&source_file),
+    );
+    let mut colliding = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: replacement_id,
+        content: "unrelated source content".to_string(),
+        wing: "mempal".to_string(),
+        room: Some("other".to_string()),
+        source_file: Some("other-source.md".to_string()),
+        source_type: SourceType::Project,
+        added_at: "1710000001".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    });
+    colliding.normalize_version = CURRENT_NORMALIZE_VERSION;
+    db.insert_drawer(&colliding)
+        .expect("insert colliding drawer from another source");
+
+    let error = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: false,
+        },
+    )
+    .await
+    .expect_err("a replacement id collision must fail reindex");
+
+    assert!(
+        matches!(
+            error,
+            ReindexError::Ingest {
+                source: IngestError::ReplacementDrawerCollision { .. },
+                ..
+            }
+        ),
+        "error must identify the replacement collision: {error:?}"
+    );
+    let contents = active_contents(&db);
+    assert_eq!(contents.len(), 2, "both pre-existing drawers must remain");
+    assert!(contents.iter().any(|value| value == "precious old content"));
+    assert!(
+        contents
+            .iter()
+            .any(|value| value == "unrelated source content")
     );
 }
 
@@ -223,4 +471,186 @@ async fn reindex_dry_run_reports_missing_sources() {
     // dry-run must not have touched anything
     let contents = active_contents(&db);
     assert_eq!(contents.len(), 2);
+}
+
+#[tokio::test]
+async fn reindex_skips_sources_with_knowledge_references() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let source = tmp.path().join("protected.md");
+    std::fs::write(&source, "fresh content").expect("write source");
+    insert_stale_drawer(
+        &db,
+        "drawer_stale_protected",
+        &source.to_string_lossy(),
+        "precious governed evidence",
+    );
+    insert_stage1_knowledge_reference(&db, "drawer_knowledge_protected", "drawer_stale_protected");
+    insert_phase2_knowledge_reference(&db, "drawer_stale_protected");
+
+    let dry_run = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: true,
+        },
+    )
+    .await
+    .expect("dry-run must report protected sources");
+    assert_eq!(dry_run.skipped_protected_sources, 1);
+    assert_eq!(dry_run.skipped_protected_drawers, 1);
+    assert_eq!(dry_run.protecting_references, 2);
+
+    let real_run = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: false,
+        },
+    )
+    .await
+    .expect("real reindex must safely skip protected sources");
+    assert_eq!(real_run.processed_sources, 0);
+    assert_eq!(real_run.skipped_protected_sources, 1);
+    assert_eq!(real_run.skipped_protected_drawers, 1);
+    assert_eq!(real_run.protecting_references, 2);
+
+    let evidence = db
+        .get_drawer("drawer_stale_protected")
+        .expect("load evidence")
+        .expect("evidence remains");
+    assert_eq!(evidence.content, "precious governed evidence");
+    let knowledge = db
+        .get_drawer("drawer_knowledge_protected")
+        .expect("load knowledge")
+        .expect("knowledge remains");
+    assert_eq!(knowledge.supporting_refs, vec!["drawer_stale_protected"]);
+    assert_eq!(
+        db.knowledge_evidence_links_for_drawer("drawer_stale_protected")
+            .expect("load Phase-2 links")
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn replace_transaction_rechecks_knowledge_references() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let source = tmp.path().join("protected-direct.md");
+    std::fs::write(&source, "fresh content").expect("write source");
+    let source_file = source.to_string_lossy().to_string();
+    insert_stale_drawer(
+        &db,
+        "drawer_stale_direct_protected",
+        &source_file,
+        "precious direct evidence",
+    );
+    insert_stage1_knowledge_reference(
+        &db,
+        "drawer_knowledge_direct_protected",
+        "drawer_stale_direct_protected",
+    );
+
+    let error = ingest_file_with_options(
+        &db,
+        &StubEmbedder,
+        &source,
+        "mempal",
+        IngestOptions {
+            room: Some("reindex"),
+            source_root: source.parent(),
+            source_file_override: Some(&source_file),
+            replace_existing_source: true,
+            replace_across_rooms: true,
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect_err("the replacement transaction must reject a protected source");
+
+    assert!(
+        format!("{error:?}").contains("SourceProtectedByKnowledgeReferences"),
+        "error must identify the transactional reference guard: {error:?}"
+    );
+    assert_eq!(
+        db.get_drawer("drawer_stale_direct_protected")
+            .expect("load evidence")
+            .expect("evidence remains")
+            .content,
+        "precious direct evidence"
+    );
+    assert_eq!(
+        db.get_drawer("drawer_knowledge_direct_protected")
+            .expect("load knowledge")
+            .expect("knowledge remains")
+            .supporting_refs,
+        vec!["drawer_stale_direct_protected"]
+    );
+}
+
+#[test]
+fn reindex_cli_reports_governance_protected_sources() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    write_cli_config(tmp.path(), &db_path);
+    let db = Database::open(&db_path).expect("open db");
+    let source = tmp.path().join("protected-cli.md");
+    std::fs::write(&source, "fresh content").expect("write source");
+    insert_stale_drawer(
+        &db,
+        "drawer_stale_cli_protected",
+        &source.to_string_lossy(),
+        "precious CLI evidence",
+    );
+    insert_stage1_knowledge_reference(
+        &db,
+        "drawer_knowledge_cli_protected",
+        "drawer_stale_cli_protected",
+    );
+
+    let output = Command::new(mempal_bin())
+        .args(["reindex", "--stale", "--dry-run"])
+        .env("HOME", tmp.path())
+        .output()
+        .expect("run reindex dry-run");
+    assert!(
+        output.status.success(),
+        "reindex dry-run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(
+            "would skip 1 drawers from 1 governance-protected sources (1 knowledge references)"
+        ),
+        "protected-source summary missing from stdout: {stdout}"
+    );
+
+    let output = Command::new(mempal_bin())
+        .args(["reindex", "--stale"])
+        .env("HOME", tmp.path())
+        .output()
+        .expect("run reindex");
+    assert!(
+        output.status.success(),
+        "reindex failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(
+            "skipped 1 governance-protected drawers from 1 sources (1 knowledge references)"
+        ),
+        "real-run protected-source summary missing from stdout: {stdout}"
+    );
+    assert_eq!(
+        db.get_drawer("drawer_stale_cli_protected")
+            .expect("load evidence")
+            .expect("evidence remains")
+            .content,
+        "precious CLI evidence"
+    );
 }


### PR DESCRIPTION
P115 normalize-v3 reindex 的前置加固：source 替换重排为 embed 先行 + 单事务 delete/insert（embed/insert 失败不再丢旧数据）；dry-run 补 missing-source 扫描成为真实可行性报告（实测生产库 911 候选中约 653 个 source 文件已不存在）。TDD 4 新测试（3 先 RED）；workspace tests / clippy -D warnings / fmt / agent-spec lifecycle 100% 全过。合并后运维顺序：备份 palace.db → cargo install --path . --force → 重启全部 39 个旧 MCP server → dry-run 审阅 → reindex。详见 specs/p117-reindex-atomic-replace.spec.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)